### PR TITLE
feat(config): typed schema layer for the config file

### DIFF
--- a/internal/config/expand.go
+++ b/internal/config/expand.go
@@ -13,30 +13,19 @@ import (
 //	${VAR-default}    default only if VAR is unset
 //	$$                a literal $
 //
-// Braces are required. A bare $VAR is not an expression, because $ turns up in
-// real values -- an image tag, a shell snippet -- and guessing which dollars
-// are ours would make those values unwriteable.
+// Braces are required: $ turns up in real values, so guessing which dollars are
+// ours would make those values unwriteable.
 //
-// A variable that is unset and has no default is an error rather than an empty
-// string. Values here are policy: skills.deny resolving quietly to nothing
-// would be a fail-open, and the whole point of a deny list is that it does not
-// fail open.
+// An unset variable with no default is an error, not an empty string. These
+// values are policy, and skills.deny resolving quietly to nothing is a
+// fail-open.
 //
-// Expansion happens at load time and in memory only. The file keeps the
-// expression, never the expansion, so a referenced token is never written to
-// disk. It is still not the credentials path: a value pulled in this way is a
-// value, and secrets stay declared as references (fromEnv:, from:) on keys of
-// Kind EnvVar, which are never expanded.
+// The file keeps the expression and never the expansion, so a referenced token
+// is never written to disk. This is still not the credentials path: what comes
+// back here is a value, and secrets stay references on EnvVar keys.
 //
-// lookup defaults to os.LookupEnv. One level only: a default may not itself
-// contain an expression.
-//
-// Two limits worth knowing, both from the closing brace being found by a plain
-// scan for the first "}". A default cannot contain "}" -- write the literal
-// outside the expression instead of ${X:-{"a":1}}. And ":-" is recognised
-// before "-", so ${VAR-a:-b} reads as the name "VAR-a" and is rejected, where a
-// shell would read VAR with the default "a:-b". Rejecting beats guessing: the
-// alternative is silently resolving something the author did not write.
+// lookup defaults to os.LookupEnv. A default may not contain "}" or a nested
+// expression, both because the closing brace is the first one found.
 func Expand(s string, lookup func(string) (string, bool)) (string, error) {
 	if lookup == nil {
 		lookup = os.LookupEnv
@@ -78,12 +67,14 @@ func Expand(s string, lookup func(string) (string, bool)) (string, error) {
 }
 
 // resolveExpr resolves the inside of one ${...}.
+//
+// ":-" is cut before "-" so a default may contain a dash: ${SET-a-b} is SET with
+// the default "a-b". The cost is that ${VAR-a:-b} reads as the name "VAR-a" and
+// is rejected, where a shell would read VAR defaulting to "a:-b". Rejecting
+// beats guessing at which the author meant.
 func resolveExpr(expr string, lookup func(string) (string, bool)) (string, error) {
 	name, def := expr, ""
 	hasDefault, emptyCounts := false, false
-	// ":-" is checked before "-" so a default may itself contain a dash, and a
-	// dash alone reads as the shell's ${VAR-default}: "${SET-a-b}" is SET with
-	// the default "a-b", not a variable called "SET-a".
 	if before, after, found := strings.Cut(expr, ":-"); found {
 		name, def = before, after
 		hasDefault, emptyCounts = true, true

--- a/internal/config/expand.go
+++ b/internal/config/expand.go
@@ -30,6 +30,13 @@ import (
 //
 // lookup defaults to os.LookupEnv. One level only: a default may not itself
 // contain an expression.
+//
+// Two limits worth knowing, both from the closing brace being found by a plain
+// scan for the first "}". A default cannot contain "}" -- write the literal
+// outside the expression instead of ${X:-{"a":1}}. And ":-" is recognised
+// before "-", so ${VAR-a:-b} reads as the name "VAR-a" and is rejected, where a
+// shell would read VAR with the default "a:-b". Rejecting beats guessing: the
+// alternative is silently resolving something the author did not write.
 func Expand(s string, lookup func(string) (string, bool)) (string, error) {
 	if lookup == nil {
 		lookup = os.LookupEnv

--- a/internal/config/expand.go
+++ b/internal/config/expand.go
@@ -1,0 +1,101 @@
+package config
+
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
+// Expand resolves env expressions in a config value.
+//
+//	${VAR}            the value of VAR
+//	${VAR:-default}   default if VAR is unset OR empty
+//	${VAR-default}    default only if VAR is unset
+//	$$                a literal $
+//
+// Braces are required. A bare $VAR is not an expression, because $ turns up in
+// real values -- an image tag, a shell snippet -- and guessing which dollars
+// are ours would make those values unwriteable.
+//
+// A variable that is unset and has no default is an error rather than an empty
+// string. Values here are policy: skills.deny resolving quietly to nothing
+// would be a fail-open, and the whole point of a deny list is that it does not
+// fail open.
+//
+// Expansion happens at load time and in memory only. The file keeps the
+// expression, never the expansion, so a referenced token is never written to
+// disk. It is still not the credentials path: a value pulled in this way is a
+// value, and secrets stay declared as references (fromEnv:, from:) on keys of
+// Kind EnvVar, which are never expanded.
+//
+// lookup defaults to os.LookupEnv. One level only: a default may not itself
+// contain an expression.
+func Expand(s string, lookup func(string) (string, bool)) (string, error) {
+	if lookup == nil {
+		lookup = os.LookupEnv
+	}
+	// Nothing to do, which is the common case: skip the whole scan.
+	if !strings.Contains(s, "$") {
+		return s, nil
+	}
+	var b strings.Builder
+	for i := 0; i < len(s); {
+		if s[i] != '$' {
+			b.WriteByte(s[i])
+			i++
+			continue
+		}
+		if i+1 < len(s) && s[i+1] == '$' {
+			b.WriteByte('$')
+			i += 2
+			continue
+		}
+		if i+1 >= len(s) || s[i+1] != '{' {
+			// A dollar that opens nothing is just a dollar.
+			b.WriteByte('$')
+			i++
+			continue
+		}
+		end := strings.IndexByte(s[i+2:], '}')
+		if end < 0 {
+			return "", fmt.Errorf("unterminated ${ in %q", s)
+		}
+		v, err := resolveExpr(s[i+2:i+2+end], lookup)
+		if err != nil {
+			return "", err
+		}
+		b.WriteString(v)
+		i += 2 + end + 1
+	}
+	return b.String(), nil
+}
+
+// resolveExpr resolves the inside of one ${...}.
+func resolveExpr(expr string, lookup func(string) (string, bool)) (string, error) {
+	name, def := expr, ""
+	hasDefault, emptyCounts := false, false
+	// ":-" is checked before "-" so a default may itself contain a dash, and a
+	// dash alone reads as the shell's ${VAR-default}: "${SET-a-b}" is SET with
+	// the default "a-b", not a variable called "SET-a".
+	if before, after, found := strings.Cut(expr, ":-"); found {
+		name, def = before, after
+		hasDefault, emptyCounts = true, true
+	} else if before, after, found := strings.Cut(expr, "-"); found {
+		name, def = before, after
+		hasDefault = true
+	}
+	if !validVarName(name) {
+		return "", fmt.Errorf("${%s}: %q is not a variable name", expr, name)
+	}
+	if strings.Contains(def, "${") {
+		return "", fmt.Errorf("${%s}: a default may not contain an expression", expr)
+	}
+	v, ok := lookup(name)
+	if ok && (v != "" || !emptyCounts) {
+		return v, nil
+	}
+	if hasDefault {
+		return def, nil
+	}
+	return "", fmt.Errorf("%s is not set and has no default; export it or write ${%s:-...}", name, name)
+}

--- a/internal/config/expand_test.go
+++ b/internal/config/expand_test.go
@@ -1,0 +1,98 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// env builds a lookup over a fixed map. A key present with an empty value is
+// set-but-empty, which ${VAR:-d} and ${VAR-d} treat differently.
+func env(pairs map[string]string) func(string) (string, bool) {
+	return func(name string) (string, bool) {
+		v, ok := pairs[name]
+		return v, ok
+	}
+}
+
+func TestExpand(t *testing.T) {
+	vars := map[string]string{
+		"SET":   "value",
+		"EMPTY": "",
+	}
+	tests := []struct {
+		name string
+		in   string
+		want string
+		bad  bool
+	}{
+		{name: "no expression", in: "plain text", want: "plain text"},
+		{name: "whole value", in: "${SET}", want: "value"},
+		{name: "embedded", in: "pre-${SET}-post", want: "pre-value-post"},
+		{name: "twice", in: "${SET}/${SET}", want: "value/value"},
+
+		// ${VAR} on a set-but-empty variable is an empty value, not an error.
+		{name: "set but empty", in: "${EMPTY}", want: ""},
+		// Unset with no default is an error: a security control silently
+		// resolving to empty is a fail-open.
+		{name: "unset no default", in: "${MISSING}", bad: true},
+		{name: "unset no default embedded", in: "a${MISSING}b", bad: true},
+
+		{name: "default unused", in: "${SET:-fallback}", want: "value"},
+		{name: "default used when unset", in: "${MISSING:-fallback}", want: "fallback"},
+		// :- treats empty as absent; - does not.
+		{name: "default used when empty", in: "${EMPTY:-fallback}", want: "fallback"},
+		{name: "dash default keeps empty", in: "${EMPTY-fallback}", want: ""},
+		{name: "dash default when unset", in: "${MISSING-fallback}", want: "fallback"},
+		{name: "explicit empty default", in: "${MISSING:-}", want: ""},
+		{name: "default containing dash", in: "${MISSING:-a-b}", want: "a-b"},
+		{name: "default containing colon", in: "${MISSING:-http://x}", want: "http://x"},
+
+		{name: "escaped dollar", in: "$$", want: "$"},
+		{name: "escaped then expression", in: "$${SET}", want: "${SET}"},
+		{name: "lone dollar is literal", in: "cost $5", want: "cost $5"},
+		{name: "trailing dollar", in: "x$", want: "x$"},
+
+		// A dash is the ${VAR-default} separator, as in the shell, so a dashed
+		// expression is a variable plus a default rather than a bad name. Pinned
+		// because it is surprising until you see it written down.
+		{name: "dash reads as a default, shell-style", in: "${SET-a-b}", want: "value"},
+		{name: "dash default on unset var", in: "${not-a-name}", want: "a-name"},
+
+		{name: "unterminated", in: "${SET", bad: true},
+		{name: "bad name with a dot", in: "${not.a.name}", bad: true},
+		{name: "bad name with a space", in: "${bad name}", bad: true},
+		{name: "empty name", in: "${}", bad: true},
+		{name: "leading digit name", in: "${1X}", bad: true},
+		// One level only: a default may not itself expand.
+		{name: "nested default", in: "${MISSING:-${SET}}", bad: true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := Expand(tc.in, env(vars))
+			if tc.bad {
+				if err == nil {
+					t.Fatalf("Expand(%q) = %q, want an error", tc.in, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("Expand(%q): %v", tc.in, err)
+			}
+			if got != tc.want {
+				t.Errorf("Expand(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestExpandErrorNamesTheVariable(t *testing.T) {
+	// The error is the only place a user learns which variable to export, so
+	// the name has to be in it.
+	_, err := Expand("${ACME_TOKEN}", env(nil))
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+	if !strings.Contains(err.Error(), "ACME_TOKEN") {
+		t.Errorf("error %q does not name the variable", err)
+	}
+}

--- a/internal/config/schema.go
+++ b/internal/config/schema.go
@@ -14,6 +14,7 @@ package config
 import (
 	"fmt"
 	"slices"
+	"sort"
 	"strconv"
 	"strings"
 )
@@ -77,6 +78,84 @@ type Key struct {
 	// Doc is one line, and is the only description of this setting anywhere:
 	// `brig config list` prints it and the shipped docs are generated from it.
 	Doc string
+}
+
+// Schema is a set of declared keys.
+//
+// A value rather than a package global so tests can declare their own: the
+// promise that a new section needs no CLI change is only worth something if a
+// test can invent a section and drive it.
+type Schema []Key
+
+// Lookup returns the key declaring path. The returned Key keeps its Path as
+// declared, wildcards intact, so a caller can tell mcp.servers.github.command
+// from the mcp.servers.*.command row that permits it.
+func (s Schema) Lookup(path string) (Key, bool) {
+	if path == "" {
+		return Key{}, false
+	}
+	segs := strings.Split(path, ".")
+	for _, k := range s {
+		if matchPath(strings.Split(k.Path, "."), segs) {
+			return k, true
+		}
+	}
+	return Key{}, false
+}
+
+// matchPath reports whether a declared path admits a concrete one. A "*"
+// segment matches exactly one non-empty segment -- never zero, never several,
+// which is what keeps features.a.b from passing as features.*.
+func matchPath(declared, actual []string) bool {
+	if len(declared) != len(actual) {
+		return false
+	}
+	for i, d := range declared {
+		if actual[i] == "" {
+			return false
+		}
+		if d == "*" {
+			continue
+		}
+		if d != actual[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// Sections returns the declared top-level section names, sorted.
+//
+// A section exists because a key declares it. That is what makes security and
+// introspection reserved for free: nothing declares them, so they are unknown
+// sections, and the loader's warn-and-ignore path already covers them.
+func (s Schema) Sections() []string {
+	seen := map[string]bool{}
+	var out []string
+	for _, k := range s {
+		name := k.Path
+		if i := strings.IndexByte(name, '.'); i >= 0 {
+			name = name[:i]
+		}
+		if !seen[name] {
+			seen[name] = true
+			out = append(out, name)
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+// Keys returns the keys declared under a section, sorted by path.
+func (s Schema) Keys(section string) []Key {
+	var out []Key
+	for _, k := range s {
+		if k.Path == section || strings.HasPrefix(k.Path, section+".") {
+			out = append(out, k)
+		}
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Path < out[j].Path })
+	return out
 }
 
 // ParseValue converts raw text to the key's type.

--- a/internal/config/schema.go
+++ b/internal/config/schema.go
@@ -1,11 +1,16 @@
-// Package config holds brig's global user configuration: the schema that
-// declares every setting, and the loader over $XDG_CONFIG_HOME/brig/config.yaml.
+// Package config declares brig's global user configuration.
+//
+// What is here today is the schema and the value handling over it: the table of
+// declared settings, the types they hold, and the expansion of ${VAR}
+// expressions found in them. The loader over $XDG_CONFIG_HOME/brig/config.yaml
+// and the `brig config` command are not written yet; this package is the layer
+// they will both read, and it is deliberately usable and testable without them.
 //
 // The schema is a table, not a struct. A declared Key carries its own type, its
-// default and its one-line documentation, which makes the `brig config` CLI
-// generic over it: adding a section later is adding rows, never adding CLI code.
-// It also means the documentation and the validation cannot drift apart,
-// because they are the same declaration.
+// default and its one-line documentation, which is what will let one generic set
+// of CLI verbs serve every section: adding a section is adding rows. It also
+// keeps the documentation and the validation from drifting apart, because they
+// are the same declaration.
 //
 // Nothing here reads a file. A Key turns text into a typed value; where that
 // text came from -- a YAML node or a command line -- is the caller's problem.
@@ -23,6 +28,11 @@ import (
 type Kind int
 
 const (
+	// invalid is the zero value, so a Key that forgot to declare its Kind is a
+	// schema error rather than a silent Bool. The schema is hand-written data
+	// and an omitted field is the easiest mistake to make in it; Schema.Validate
+	// is what turns that mistake into a message.
+	invalid Kind = iota
 	// Bool is parsed strictly: true/false/1/0 and the other spellings
 	// strconv.ParseBool accepts, nothing else.
 	//
@@ -30,7 +40,7 @@ const (
 	// anything but "0" as true. That looseness is right for a shell variable
 	// and wrong for a typed file: BRIG_SKILLS=maybe is a shrug, but
 	// skills.import.auto: maybe is a mistake worth reporting.
-	Bool Kind = iota
+	Bool
 	Int
 	String
 	// Enum is a string constrained to Key.Enum.
@@ -47,6 +57,8 @@ const (
 // String names the kind the way an error message needs it: "expected bool".
 func (k Kind) String() string {
 	switch k {
+	case invalid:
+		return "no kind"
 	case Bool:
 		return "bool"
 	case Int:
@@ -75,8 +87,10 @@ type Key struct {
 	// idea as ${VAR:-fallback}, which applies when the variable is unset; a key
 	// can be present and still resolve through a fallback.
 	Default any
-	// Doc is one line, and is the only description of this setting anywhere:
-	// `brig config list` prints it and the shipped docs are generated from it.
+	// Doc is one line, and is the only description of this setting anywhere.
+	// Validate requires it, because a setting that cannot be explained in one
+	// line is a setting nobody will be able to use. It is what a `config list`
+	// verb and the generated reference will print once those exist.
 	Doc string
 }
 
@@ -90,17 +104,107 @@ type Schema []Key
 // Lookup returns the key declaring path. The returned Key keeps its Path as
 // declared, wildcards intact, so a caller can tell mcp.servers.github.command
 // from the mcp.servers.*.command row that permits it.
+//
+// An exact declaration wins over a wildcard that also admits the path, whatever
+// order the two appear in. Without that rule the answer depends on slice
+// position, so moving two rows apart would silently change a key's type.
+// Ambiguity between two *wildcards* is a schema bug rather than something to
+// resolve here; Validate rejects duplicate paths, and overlapping wildcards
+// resolve first-declared.
 func (s Schema) Lookup(path string) (Key, bool) {
 	if path == "" {
 		return Key{}, false
 	}
 	segs := strings.Split(path, ".")
+	var wildcard Key
+	var viaWildcard bool
 	for _, k := range s {
-		if matchPath(strings.Split(k.Path, "."), segs) {
+		if !matchPath(strings.Split(k.Path, "."), segs) {
+			continue
+		}
+		if k.Path == path {
 			return k, true
 		}
+		if !viaWildcard {
+			wildcard, viaWildcard = k, true
+		}
 	}
-	return Key{}, false
+	return wildcard, viaWildcard
+}
+
+// Validate checks that a schema is usable before anything reads it.
+//
+// The schema is hand-written data, so its mistakes are the mistakes people make
+// in data: a forgotten field, a duplicated row, a default that does not match
+// the type beside it. Each one is silent at runtime and confusing at the point
+// it surfaces, which is why they are caught here instead.
+//
+// Same role as agent.Template.Validate (internal/agent/custom.go:127), and for
+// the same reason: data that configures behaviour should refuse to be wrong.
+func (s Schema) Validate() error {
+	seen := map[string]bool{}
+	for _, k := range s {
+		if k.Path == "" {
+			return fmt.Errorf("a key has an empty path")
+		}
+		if slices.Contains(strings.Split(k.Path, "."), "") {
+			return fmt.Errorf("%s: a path segment is empty", k.Path)
+		}
+		if seen[k.Path] {
+			return fmt.Errorf("%s: declared twice", k.Path)
+		}
+		seen[k.Path] = true
+
+		if k.Kind == invalid {
+			return fmt.Errorf("%s: no kind declared", k.Path)
+		}
+		if k.Kind == Enum && len(k.Enum) == 0 {
+			// Otherwise every value fails against an empty set, with an error
+			// that trails off after "is not one of".
+			return fmt.Errorf("%s: an enum key needs its enum values", k.Path)
+		}
+		if k.Kind != Enum && len(k.Enum) > 0 {
+			return fmt.Errorf("%s: enum values on a %s key", k.Path, k.Kind)
+		}
+		if k.Doc == "" {
+			// The only description of this setting anywhere, so an empty one is
+			// a setting nobody can explain.
+			return fmt.Errorf("%s: no doc line", k.Path)
+		}
+		if err := k.validateDefault(); err != nil {
+			return fmt.Errorf("%s: %w", k.Path, err)
+		}
+	}
+	return nil
+}
+
+// validateDefault checks Default against Kind. Default is `any`, so nothing
+// else stops a string default on an Int key reaching a consumer that asserts an
+// int and panicking there instead of here.
+func (k Key) validateDefault() error {
+	if k.Default == nil {
+		return nil // no default is a valid state: the key is simply unset
+	}
+	var ok bool
+	switch k.Kind {
+	case Bool:
+		_, ok = k.Default.(bool)
+	case Int:
+		_, ok = k.Default.(int)
+	case String, EnvVar:
+		_, ok = k.Default.(string)
+	case Enum:
+		var s string
+		if s, ok = k.Default.(string); ok && !slices.Contains(k.Enum, s) {
+			return fmt.Errorf("default %q is not one of %s", s, strings.Join(k.Enum, ", "))
+		}
+	case StringList:
+		_, ok = k.Default.([]string)
+	}
+	if !ok {
+		return fmt.Errorf("default is %T, want %s", k.Default, k.Kind)
+	}
+	return nil
 }
 
 // matchPath reports whether a declared path admits a concrete one. A "*"
@@ -196,12 +300,41 @@ func (k Key) ParseValue(raw string) (any, error) {
 		return out, nil
 	case EnvVar:
 		if !validVarName(raw) {
-			return nil, fmt.Errorf("%q is not a variable name; this field takes a "+
-				"name such as ACME_TOKEN, never the value", raw)
+			// The value is described, never repeated. This is the error that
+			// fires when somebody pastes a credential into a field that wants a
+			// variable name, so echoing the input would print the credential
+			// into a terminal, a CI log or a bug report. Same rule as
+			// creds.go:102-106, which reports a reference's scheme and never
+			// its value.
+			return nil, fmt.Errorf("this field takes a variable NAME such as "+
+				"ACME_TOKEN, not a value (got %s)", shapeOf(raw))
 		}
 		return raw, nil
 	}
-	return nil, fmt.Errorf("unknown kind %s for %s", k.Kind, k.Path)
+	return nil, fmt.Errorf("no value kind declared for %s", k.Path)
+}
+
+// shapeOf describes a rejected value without reproducing any of it: the length,
+// and which rule it broke. Length alone cannot reconstruct a secret, and a
+// character class is enough to spot a typo.
+func shapeOf(s string) string {
+	if s == "" {
+		return "an empty value"
+	}
+	for _, r := range s {
+		switch {
+		case r == '_',
+			r >= 'a' && r <= 'z',
+			r >= 'A' && r <= 'Z',
+			r >= '0' && r <= '9':
+		default:
+			return fmt.Sprintf("%d characters, including one that cannot appear "+
+				"in a variable name", len(s))
+		}
+	}
+	// Every character is legal, so validVarName can only have failed on the
+	// leading digit.
+	return fmt.Sprintf("%d characters, starting with a digit", len(s))
 }
 
 // Resolve expands env expressions in raw text and then type-checks the result.
@@ -213,14 +346,20 @@ func (k Key) ParseValue(raw string) (any, error) {
 // EnvVar is the exception: it holds a variable name, and expanding it would
 // turn a declared credential reference into the credential. ParseValue then
 // rejects an expression outright, because "$" and "{" cannot appear in a name.
+// Note what that guard is worth: a token whose text happens to be letters,
+// digits and underscores would otherwise expand, pass as a name, and be stored
+// where a reference belongs.
 //
-// Writers want ParseValue instead. A value being written may reference a
+// A writer wants ParseValue instead. A value being written may reference a
 // variable that is unset in the shell doing the writing but set when the agent
-// runs, so `brig config set` checks the expression's syntax rather than
-// resolving it.
+// runs, so a writer should check the expression's syntax rather than resolve it.
 func (k Key) Resolve(raw string, lookup func(string) (string, bool)) (any, error) {
 	if k.Kind == EnvVar {
-		return k.ParseValue(raw)
+		v, err := k.ParseValue(raw)
+		if err != nil {
+			return nil, fmt.Errorf("%s: %w", k.Path, err)
+		}
+		return v, nil
 	}
 	expanded, err := Expand(raw, lookup)
 	if err != nil {

--- a/internal/config/schema.go
+++ b/internal/config/schema.go
@@ -28,29 +28,23 @@ import (
 type Kind int
 
 const (
-	// invalid is the zero value, so a Key that forgot to declare its Kind is a
-	// schema error rather than a silent Bool. The schema is hand-written data
-	// and an omitted field is the easiest mistake to make in it; Schema.Validate
-	// is what turns that mistake into a message.
+	// invalid is the zero value, so a Key that forgot its Kind is a schema error
+	// rather than a silent Bool. Schema.Validate reports it.
 	invalid Kind = iota
-	// Bool is parsed strictly: true/false/1/0 and the other spellings
-	// strconv.ParseBool accepts, nothing else.
-	//
-	// Deliberately unlike wrap.Env.Bool (internal/wrap/env.go:51), which reads
-	// anything but "0" as true. That looseness is right for a shell variable
-	// and wrong for a typed file: BRIG_SKILLS=maybe is a shrug, but
-	// skills.import.auto: maybe is a mistake worth reporting.
+	// Bool is strict: what strconv.ParseBool accepts, nothing else. Unlike
+	// wrap.Env.Bool (internal/wrap/env.go:51), which reads anything but "0" as
+	// true -- right for a shell variable, wrong for a typed file.
 	Bool
 	Int
 	String
 	// Enum is a string constrained to Key.Enum.
 	Enum
-	// StringList is a list of strings. From a command line it is written
-	// comma-separated; from YAML it arrives as a sequence.
+	// StringList is comma-separated from a command line, a sequence from YAML.
 	StringList
-	// EnvVar holds the NAME of an environment variable, never its value. The
-	// shape check is what stops a token being pasted where a name belongs, so
-	// it is a type rather than a convention.
+	// EnvVar holds the NAME of an environment variable, never its value, and is
+	// never expanded: expanding it would turn a credential reference into the
+	// credential. The shape check is a type rather than a convention because it
+	// is what catches a pasted token.
 	EnvVar
 )
 
@@ -300,12 +294,6 @@ func (k Key) ParseValue(raw string) (any, error) {
 		return out, nil
 	case EnvVar:
 		if !validVarName(raw) {
-			// The value is described, never repeated. This is the error that
-			// fires when somebody pastes a credential into a field that wants a
-			// variable name, so echoing the input would print the credential
-			// into a terminal, a CI log or a bug report. Same rule as
-			// creds.go:102-106, which reports a reference's scheme and never
-			// its value.
 			return nil, fmt.Errorf("this field takes a variable NAME such as "+
 				"ACME_TOKEN, not a value (got %s)", shapeOf(raw))
 		}
@@ -314,9 +302,11 @@ func (k Key) ParseValue(raw string) (any, error) {
 	return nil, fmt.Errorf("no value kind declared for %s", k.Path)
 }
 
-// shapeOf describes a rejected value without reproducing any of it: the length,
-// and which rule it broke. Length alone cannot reconstruct a secret, and a
-// character class is enough to spot a typo.
+// shapeOf describes a rejected value without reproducing any of it. This error
+// fires when somebody pastes a credential where a variable name belongs, so
+// echoing the input would print that credential into a terminal or a CI log.
+// Same rule as creds.go:102-106, which reports a reference's scheme and never
+// its value. Length and a broken rule are enough to spot a typo.
 func shapeOf(s string) string {
 	if s == "" {
 		return "an empty value"
@@ -339,20 +329,13 @@ func shapeOf(s string) string {
 
 // Resolve expands env expressions in raw text and then type-checks the result.
 //
-// The order is the point. mem: ${BRIG_MEM:-4096} has to expand to "4096" before
-// anything can call it an int, so expansion cannot be a String-only
-// convenience -- it belongs before the type check for every kind.
+// The order is the point: mem: ${BRIG_MEM:-4096} has to expand to "4096" before
+// anything can call it an int, so expansion precedes the type check for every
+// kind. EnvVar skips both, for the reason given where it is declared.
 //
-// EnvVar is the exception: it holds a variable name, and expanding it would
-// turn a declared credential reference into the credential. ParseValue then
-// rejects an expression outright, because "$" and "{" cannot appear in a name.
-// Note what that guard is worth: a token whose text happens to be letters,
-// digits and underscores would otherwise expand, pass as a name, and be stored
-// where a reference belongs.
-//
-// A writer wants ParseValue instead. A value being written may reference a
-// variable that is unset in the shell doing the writing but set when the agent
-// runs, so a writer should check the expression's syntax rather than resolve it.
+// Reading takes this path; writing takes ParseValue, because a value being
+// written may name a variable that is unset in the writing shell and set when
+// the agent runs.
 func (k Key) Resolve(raw string, lookup func(string) (string, bool)) (any, error) {
 	if k.Kind == EnvVar {
 		v, err := k.ParseValue(raw)

--- a/internal/config/schema.go
+++ b/internal/config/schema.go
@@ -204,6 +204,35 @@ func (k Key) ParseValue(raw string) (any, error) {
 	return nil, fmt.Errorf("unknown kind %s for %s", k.Kind, k.Path)
 }
 
+// Resolve expands env expressions in raw text and then type-checks the result.
+//
+// The order is the point. mem: ${BRIG_MEM:-4096} has to expand to "4096" before
+// anything can call it an int, so expansion cannot be a String-only
+// convenience -- it belongs before the type check for every kind.
+//
+// EnvVar is the exception: it holds a variable name, and expanding it would
+// turn a declared credential reference into the credential. ParseValue then
+// rejects an expression outright, because "$" and "{" cannot appear in a name.
+//
+// Writers want ParseValue instead. A value being written may reference a
+// variable that is unset in the shell doing the writing but set when the agent
+// runs, so `brig config set` checks the expression's syntax rather than
+// resolving it.
+func (k Key) Resolve(raw string, lookup func(string) (string, bool)) (any, error) {
+	if k.Kind == EnvVar {
+		return k.ParseValue(raw)
+	}
+	expanded, err := Expand(raw, lookup)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", k.Path, err)
+	}
+	v, err := k.ParseValue(expanded)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", k.Path, err)
+	}
+	return v, nil
+}
+
 // validVarName reports whether s is shaped like an environment variable name.
 func validVarName(s string) bool {
 	if s == "" {

--- a/internal/config/schema.go
+++ b/internal/config/schema.go
@@ -1,0 +1,144 @@
+// Package config holds brig's global user configuration: the schema that
+// declares every setting, and the loader over $XDG_CONFIG_HOME/brig/config.yaml.
+//
+// The schema is a table, not a struct. A declared Key carries its own type, its
+// default and its one-line documentation, which makes the `brig config` CLI
+// generic over it: adding a section later is adding rows, never adding CLI code.
+// It also means the documentation and the validation cannot drift apart,
+// because they are the same declaration.
+//
+// Nothing here reads a file. A Key turns text into a typed value; where that
+// text came from -- a YAML node or a command line -- is the caller's problem.
+package config
+
+import (
+	"fmt"
+	"slices"
+	"strconv"
+	"strings"
+)
+
+// Kind is the type a declared setting holds.
+type Kind int
+
+const (
+	// Bool is parsed strictly: true/false/1/0 and the other spellings
+	// strconv.ParseBool accepts, nothing else.
+	//
+	// Deliberately unlike wrap.Env.Bool (internal/wrap/env.go:51), which reads
+	// anything but "0" as true. That looseness is right for a shell variable
+	// and wrong for a typed file: BRIG_SKILLS=maybe is a shrug, but
+	// skills.import.auto: maybe is a mistake worth reporting.
+	Bool Kind = iota
+	Int
+	String
+	// Enum is a string constrained to Key.Enum.
+	Enum
+	// StringList is a list of strings. From a command line it is written
+	// comma-separated; from YAML it arrives as a sequence.
+	StringList
+	// EnvVar holds the NAME of an environment variable, never its value. The
+	// shape check is what stops a token being pasted where a name belongs, so
+	// it is a type rather than a convention.
+	EnvVar
+)
+
+// String names the kind the way an error message needs it: "expected bool".
+func (k Kind) String() string {
+	switch k {
+	case Bool:
+		return "bool"
+	case Int:
+		return "int"
+	case String:
+		return "string"
+	case Enum:
+		return "enum"
+	case StringList:
+		return "list"
+	case EnvVar:
+		return "env var name"
+	}
+	return fmt.Sprintf("kind(%d)", int(k))
+}
+
+// Key is one declared setting.
+type Key struct {
+	// Path is the dotted address. A "*" segment is a name the user chooses:
+	// mcp.servers.*.command is set as mcp.servers.github.command.
+	Path string
+	Kind Kind
+	// Enum is the permitted set when Kind is Enum.
+	Enum []string
+	// Default applies when the key is ABSENT from the file. It is not the same
+	// idea as ${VAR:-fallback}, which applies when the variable is unset; a key
+	// can be present and still resolve through a fallback.
+	Default any
+	// Doc is one line, and is the only description of this setting anywhere:
+	// `brig config list` prints it and the shipped docs are generated from it.
+	Doc string
+}
+
+// ParseValue converts raw text to the key's type.
+//
+// Callers that may be holding an env expression want Resolve instead, which
+// expands first -- ParseValue on "${BRIG_MEM:-4096}" is a type error, and
+// correctly so.
+func (k Key) ParseValue(raw string) (any, error) {
+	switch k.Kind {
+	case Bool:
+		b, err := strconv.ParseBool(raw)
+		if err != nil {
+			return nil, fmt.Errorf("%q is not a bool (try true or false)", raw)
+		}
+		return b, nil
+	case Int:
+		n, err := strconv.Atoi(raw)
+		if err != nil {
+			return nil, fmt.Errorf("%q is not an int", raw)
+		}
+		return n, nil
+	case String:
+		return raw, nil
+	case Enum:
+		if slices.Contains(k.Enum, raw) {
+			return raw, nil
+		}
+		return nil, fmt.Errorf("%q is not one of %s", raw, strings.Join(k.Enum, ", "))
+	case StringList:
+		// A blank entry is dropped rather than reported: "a,,b" is a stray
+		// comma, and a list with an empty member is never what was meant.
+		out := []string{}
+		for part := range strings.SplitSeq(raw, ",") {
+			if part = strings.TrimSpace(part); part != "" {
+				out = append(out, part)
+			}
+		}
+		return out, nil
+	case EnvVar:
+		if !validVarName(raw) {
+			return nil, fmt.Errorf("%q is not a variable name; this field takes a "+
+				"name such as ACME_TOKEN, never the value", raw)
+		}
+		return raw, nil
+	}
+	return nil, fmt.Errorf("unknown kind %s for %s", k.Kind, k.Path)
+}
+
+// validVarName reports whether s is shaped like an environment variable name.
+func validVarName(s string) bool {
+	if s == "" {
+		return false
+	}
+	for i, r := range s {
+		switch {
+		case r == '_',
+			r >= 'a' && r <= 'z',
+			r >= 'A' && r <= 'Z':
+		case r >= '0' && r <= '9' && i > 0:
+		default:
+			return false
+		}
+	}
+	return true
+}

--- a/internal/config/schema_test.go
+++ b/internal/config/schema_test.go
@@ -49,8 +49,10 @@ func TestKeyParseValue(t *testing.T) {
 
 		{name: "env var name", key: Key{Kind: EnvVar}, raw: "ACME_TOKEN", want: "ACME_TOKEN"},
 		{name: "env var lowercase ok", key: Key{Kind: EnvVar}, raw: "_x1", want: "_x1"},
-		// The guard that stops a token being pasted where a name belongs.
-		{name: "env var rejects value", key: Key{Kind: EnvVar}, raw: "sk-ant-abc123", bad: true},
+		// The guard that stops a token being pasted where a name belongs. The
+		// literal is deliberately not shaped like any real vendor's key format,
+		// so it cannot trip a secret scanner on a public clone.
+		{name: "env var rejects value", key: Key{Kind: EnvVar}, raw: "pasted-value-not-a-name", bad: true},
 		{name: "env var rejects leading digit", key: Key{Kind: EnvVar}, raw: "1X", bad: true},
 		{name: "env var rejects empty", key: Key{Kind: EnvVar}, raw: "", bad: true},
 	}
@@ -354,11 +356,19 @@ func TestEnvVarErrorNeverEchoesTheValue(t *testing.T) {
 	// This error exists to catch someone pasting a credential where a variable
 	// name belongs, so it must not print the credential. creds.go:102-106 sets
 	// the house rule: report the scheme, never the value.
-	secrets := []string{
-		"sk-live-51H8xKlSecretValue", // rejected on the dash
-		"51H8xKlSecretValue",         // rejected on the leading digit
+	// Stand-ins for a pasted credential, deliberately not shaped like any real
+	// vendor's key format so they cannot trip a secret scanner on a public clone.
+	// The fragments must not appear in the error's own wording or in the key
+	// path, or the check fires on text that was never the secret.
+	secrets := []struct {
+		value string
+		frags []string
+	}{
+		{value: "pasted-value-not-a-name", frags: []string{"pasted", "not-a-name"}},
+		{value: "9PastedValue", frags: []string{"9Pasted", "PastedValue"}},
 	}
-	for _, secret := range secrets {
+	for _, tc := range secrets {
+		secret := tc.value
 		k := Key{Path: "memories.providers.acme.credential.fromEnv", Kind: EnvVar}
 		_, err := k.Resolve(secret, nil)
 		if err == nil {
@@ -368,7 +378,7 @@ func TestEnvVarErrorNeverEchoesTheValue(t *testing.T) {
 			t.Errorf("error echoes the whole secret: %q", err)
 		}
 		// Not even a recognisable fragment.
-		for _, frag := range []string{"sk-live", "51H8", "SecretValue"} {
+		for _, frag := range tc.frags {
 			if strings.Contains(err.Error(), frag) {
 				t.Errorf("error leaks the fragment %q: %q", frag, err)
 			}

--- a/internal/config/schema_test.go
+++ b/internal/config/schema_test.go
@@ -72,6 +72,86 @@ func TestKeyParseValue(t *testing.T) {
 	}
 }
 
+// testSchema stands in for the shipped table, which arrives with the loader
+// that reads it. Declaring keys in the test is also the extensibility property
+// under test: a section is rows of data, so a test can invent one.
+var testSchema = Schema{
+	{Path: "skills.import.auto", Kind: Bool, Default: false, Doc: "seed host skills"},
+	{Path: "skills.deny", Kind: StringList, Doc: "never load these"},
+	{Path: "mcp.servers.*.command", Kind: String, Doc: "the server binary"},
+	{Path: "mcp.servers.*.transport", Kind: Enum, Enum: []string{"stdio", "http"}, Default: "stdio", Doc: "transport"},
+	{Path: "features.*", Kind: Bool, Doc: "a feature flag"},
+}
+
+func TestSchemaLookup(t *testing.T) {
+	tests := []struct {
+		name     string
+		path     string
+		want     string // the declaring Path, wildcards intact
+		wantKind Kind
+		absent   bool
+	}{
+		{name: "literal", path: "skills.import.auto", want: "skills.import.auto", wantKind: Bool},
+		{name: "literal list", path: "skills.deny", want: "skills.deny", wantKind: StringList},
+
+		{name: "wildcard instance", path: "mcp.servers.github.command", want: "mcp.servers.*.command", wantKind: String},
+		{name: "wildcard instance with dashes", path: "mcp.servers.my-server.command", want: "mcp.servers.*.command", wantKind: String},
+		{name: "wildcard instance enum", path: "mcp.servers.github.transport", want: "mcp.servers.*.transport", wantKind: Enum},
+		{name: "trailing wildcard", path: "features.someFlag", want: "features.*", wantKind: Bool},
+
+		{name: "unknown top level", path: "nope.at.all", absent: true},
+		{name: "typo", path: "skills.import.auot", absent: true},
+		// A wildcard segment matches exactly one segment, never several.
+		{name: "too deep for wildcard", path: "features.a.b", absent: true},
+		{name: "too shallow", path: "mcp.servers.github", absent: true},
+		{name: "prefix is not a key", path: "skills.import", absent: true},
+		{name: "empty wildcard segment", path: "mcp.servers..command", absent: true},
+		{name: "empty path", path: "", absent: true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := testSchema.Lookup(tc.path)
+			if tc.absent {
+				if ok {
+					t.Fatalf("Lookup(%q) matched %q, want no match", tc.path, got.Path)
+				}
+				return
+			}
+			if !ok {
+				t.Fatalf("Lookup(%q) found nothing, want %q", tc.path, tc.want)
+			}
+			if got.Path != tc.want {
+				t.Errorf("Lookup(%q) = %q, want %q", tc.path, got.Path, tc.want)
+			}
+			if got.Kind != tc.wantKind {
+				t.Errorf("Lookup(%q) kind = %s, want %s", tc.path, got.Kind, tc.wantKind)
+			}
+		})
+	}
+}
+
+func TestSchemaSections(t *testing.T) {
+	want := []string{"features", "mcp", "skills"} // sorted, deduped
+	got := testSchema.Sections()
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("Sections() = %v, want %v", got, want)
+	}
+}
+
+func TestSchemaKeys(t *testing.T) {
+	var paths []string
+	for _, k := range testSchema.Keys("skills") {
+		paths = append(paths, k.Path)
+	}
+	want := []string{"skills.deny", "skills.import.auto"} // sorted by path
+	if !reflect.DeepEqual(paths, want) {
+		t.Errorf("Keys(\"skills\") = %v, want %v", paths, want)
+	}
+	if len(testSchema.Keys("nope")) != 0 {
+		t.Error("Keys of an undeclared section should be empty")
+	}
+}
+
 func TestKindString(t *testing.T) {
 	// Kind names reach the user in "expected bool, got ..." errors, so they are
 	// part of the interface rather than debug output.

--- a/internal/config/schema_test.go
+++ b/internal/config/schema_test.go
@@ -131,6 +131,128 @@ func TestSchemaLookup(t *testing.T) {
 	}
 }
 
+func TestSchemaLookupPrefersAnExactMatch(t *testing.T) {
+	// A literal declaration must win over a wildcard that also admits the path,
+	// whichever order they appear in. Without that rule the result depends on
+	// slice position, so moving two rows apart silently changes a key's type.
+	literal := Key{Path: "mcp.servers.github.command", Kind: Enum, Enum: []string{"gh"}}
+	wild := Key{Path: "mcp.servers.*.command", Kind: String}
+
+	for _, tc := range []struct {
+		name string
+		s    Schema
+	}{
+		{name: "wildcard declared first", s: Schema{wild, literal}},
+		{name: "literal declared first", s: Schema{literal, wild}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := tc.s.Lookup("mcp.servers.github.command")
+			if !ok {
+				t.Fatal("Lookup found nothing")
+			}
+			if got.Path != literal.Path {
+				t.Errorf("Lookup = %q, want the exact match %q", got.Path, literal.Path)
+			}
+			if got.Kind != Enum {
+				t.Errorf("Lookup kind = %s, want enum", got.Kind)
+			}
+		})
+	}
+
+	// Another name under the same wildcard still resolves through it.
+	got, ok := Schema{wild, literal}.Lookup("mcp.servers.other.command")
+	if !ok || got.Path != wild.Path {
+		t.Errorf("Lookup(other) = %q ok=%v, want %q", got.Path, ok, wild.Path)
+	}
+}
+
+func TestSchemaValidate(t *testing.T) {
+	tests := []struct {
+		name string
+		s    Schema
+		bad  string // substring the error must mention; "" means valid
+	}{
+		{
+			name: "valid",
+			s: Schema{
+				{Path: "a.b", Kind: Bool, Default: false, Doc: "d"},
+				{Path: "a.c", Kind: Enum, Enum: []string{"x", "y"}, Default: "x", Doc: "d"},
+				{Path: "m.*.n", Kind: String, Doc: "d"},
+			},
+		},
+		// The mistake the zero value used to hide.
+		{name: "kind omitted", s: Schema{{Path: "a.b", Doc: "d"}}, bad: "kind"},
+		{name: "empty path", s: Schema{{Path: "", Kind: Bool, Doc: "d"}}, bad: "path"},
+		{name: "empty segment", s: Schema{{Path: "a..b", Kind: Bool, Doc: "d"}}, bad: "segment"},
+		{
+			name: "duplicate path",
+			s: Schema{
+				{Path: "a.b", Kind: Bool, Doc: "d"},
+				{Path: "a.b", Kind: Int, Doc: "d"},
+			},
+			bad: "declared twice",
+		},
+		{name: "enum without values", s: Schema{{Path: "a.b", Kind: Enum, Doc: "d"}}, bad: "enum"},
+		{
+			name: "enum values on a non-enum kind",
+			s:    Schema{{Path: "a.b", Kind: Bool, Enum: []string{"x"}, Doc: "d"}},
+			bad:  "enum",
+		},
+		// Default is `any`, so nothing but this check stops a string default on
+		// an int key reaching a consumer that asserts an int.
+		{
+			name: "default of the wrong type",
+			s:    Schema{{Path: "a.b", Kind: Int, Default: "4096", Doc: "d"}},
+			bad:  "default",
+		},
+		{
+			name: "default outside the enum",
+			s:    Schema{{Path: "a.b", Kind: Enum, Enum: []string{"x"}, Default: "z", Doc: "d"}},
+			bad:  "default",
+		},
+		{
+			name: "list default of the wrong type",
+			s:    Schema{{Path: "a.b", Kind: StringList, Default: "x", Doc: "d"}},
+			bad:  "default",
+		},
+		{name: "missing doc", s: Schema{{Path: "a.b", Kind: Bool}}, bad: "doc"},
+		{name: "nil default is fine", s: Schema{{Path: "a.b", Kind: Int, Doc: "d"}}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.s.Validate()
+			if tc.bad == "" {
+				if err != nil {
+					t.Fatalf("Validate() = %v, want no error", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("Validate() = nil, want an error mentioning %q", tc.bad)
+			}
+			if !strings.Contains(err.Error(), tc.bad) {
+				t.Errorf("Validate() = %q, want it to mention %q", err, tc.bad)
+			}
+			// Every schema error has to name the offending key.
+			if tc.s[0].Path != "" && !strings.Contains(err.Error(), tc.s[0].Path) {
+				t.Errorf("Validate() = %q, does not name the key %q", err, tc.s[0].Path)
+			}
+		})
+	}
+}
+
+func TestParseValueWithNoKindDeclared(t *testing.T) {
+	// Reachable only from a schema that skipped Validate, but it must not read
+	// as a successful bool.
+	k := Key{Path: "a.b"}
+	if _, err := k.ParseValue("true"); err == nil {
+		t.Error("ParseValue on a Key with no Kind should fail, not return a bool")
+	}
+	if got := invalid.String(); got != "no kind" {
+		t.Errorf("invalid.String() = %q, want %q", got, "no kind")
+	}
+}
+
 func TestSchemaSections(t *testing.T) {
 	want := []string{"features", "mcp", "skills"} // sorted, deduped
 	got := testSchema.Sections()
@@ -203,6 +325,61 @@ func TestKeyResolveExpandsBeforeTypeChecking(t *testing.T) {
 	}
 }
 
+func TestKeyResolveNeverExpandsAnEnvVarName(t *testing.T) {
+	// The case the old tests could not see. This token's text is shaped like a
+	// variable name -- letters, digits and underscores only -- so if Resolve
+	// expanded EnvVar keys, the expansion would pass validVarName and the
+	// secret would be stored in the slot that is supposed to hold a reference.
+	//
+	// Deleting the EnvVar guard in Resolve must fail this test. The two older
+	// cases ("MEM" and "${MEM}") both survive without the guard, which is how
+	// the rule went unpinned.
+	vars := env(map[string]string{"ACME_TOKEN": "abc123def456"})
+	k := Key{Path: "memories.providers.acme.credential.fromEnv", Kind: EnvVar}
+
+	if got, err := k.Resolve("${ACME_TOKEN}", vars); err == nil {
+		t.Fatalf("Resolve expanded an EnvVar key to %#v; it must reject the expression", got)
+	}
+	// The name itself still passes through untouched.
+	got, err := k.Resolve("ACME_TOKEN", vars)
+	if err != nil {
+		t.Fatalf("Resolve(%q): %v", "ACME_TOKEN", err)
+	}
+	if got != "ACME_TOKEN" {
+		t.Errorf("Resolve(%q) = %#v, want the name unchanged", "ACME_TOKEN", got)
+	}
+}
+
+func TestEnvVarErrorNeverEchoesTheValue(t *testing.T) {
+	// This error exists to catch someone pasting a credential where a variable
+	// name belongs, so it must not print the credential. creds.go:102-106 sets
+	// the house rule: report the scheme, never the value.
+	secrets := []string{
+		"sk-live-51H8xKlSecretValue", // rejected on the dash
+		"51H8xKlSecretValue",         // rejected on the leading digit
+	}
+	for _, secret := range secrets {
+		k := Key{Path: "memories.providers.acme.credential.fromEnv", Kind: EnvVar}
+		_, err := k.Resolve(secret, nil)
+		if err == nil {
+			t.Fatalf("Resolve(%q) succeeded; want it rejected", secret)
+		}
+		if strings.Contains(err.Error(), secret) {
+			t.Errorf("error echoes the whole secret: %q", err)
+		}
+		// Not even a recognisable fragment.
+		for _, frag := range []string{"sk-live", "51H8", "SecretValue"} {
+			if strings.Contains(err.Error(), frag) {
+				t.Errorf("error leaks the fragment %q: %q", frag, err)
+			}
+		}
+		// It still has to name the setting, or nobody can find the offending line.
+		if !strings.Contains(err.Error(), "memories.providers.acme.credential.fromEnv") {
+			t.Errorf("error does not name the key: %q", err)
+		}
+	}
+}
+
 func TestKeyResolveErrorNamesTheKey(t *testing.T) {
 	// A type error has to say which setting is wrong; the raw text alone does
 	// not tell anyone where to look in the file.
@@ -220,11 +397,16 @@ func TestKindString(t *testing.T) {
 	// Kind names reach the user in "expected bool, got ..." errors, so they are
 	// part of the interface rather than debug output.
 	for kind, want := range map[Kind]string{
-		Bool: "bool", Int: "int", String: "string",
+		invalid: "no kind", Bool: "bool", Int: "int", String: "string",
 		Enum: "enum", StringList: "list", EnvVar: "env var name",
 	} {
 		if got := kind.String(); got != want {
 			t.Errorf("Kind(%d).String() = %q, want %q", int(kind), got, want)
 		}
+	}
+	// An out-of-range Kind can only come from a cast, but it must still print
+	// as something rather than as an empty string in an error message.
+	if got := Kind(99).String(); got != "kind(99)" {
+		t.Errorf("Kind(99).String() = %q, want %q", got, "kind(99)")
 	}
 }

--- a/internal/config/schema_test.go
+++ b/internal/config/schema_test.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"reflect"
+	"strings"
 	"testing"
 )
 
@@ -149,6 +150,69 @@ func TestSchemaKeys(t *testing.T) {
 	}
 	if len(testSchema.Keys("nope")) != 0 {
 		t.Error("Keys of an undeclared section should be empty")
+	}
+}
+
+func TestKeyResolveExpandsBeforeTypeChecking(t *testing.T) {
+	vars := env(map[string]string{"MEM": "8192", "FLAG": "true", "MODE": "http"})
+
+	tests := []struct {
+		name string
+		key  Key
+		raw  string
+		want any
+		bad  bool
+	}{
+		// The ordering that makes expressions usable on non-string keys.
+		{name: "int from var", key: Key{Kind: Int}, raw: "${MEM}", want: 8192},
+		{name: "int from default", key: Key{Kind: Int}, raw: "${NOPE:-4096}", want: 4096},
+		{name: "bool from var", key: Key{Kind: Bool}, raw: "${FLAG}", want: true},
+		{
+			name: "enum from var",
+			key:  Key{Kind: Enum, Enum: []string{"stdio", "http"}},
+			raw:  "${MODE}", want: "http",
+		},
+		{name: "list from default", key: Key{Kind: StringList}, raw: "${NOPE:-a,b}", want: []string{"a", "b"}},
+		{name: "plain value still works", key: Key{Kind: Int}, raw: "512", want: 512},
+
+		// Expansion succeeds, the type check then fails: both errors reachable.
+		{name: "expands to a bad int", key: Key{Kind: Int}, raw: "${MODE}", bad: true},
+		{name: "expansion itself fails", key: Key{Kind: Int}, raw: "${NOPE}", bad: true},
+
+		// EnvVar holds a name, so it is never expanded -- otherwise declaring a
+		// credential reference would resolve the credential.
+		{name: "env var kind not expanded", key: Key{Kind: EnvVar}, raw: "MEM", want: "MEM"},
+		{name: "env var kind rejects an expression", key: Key{Kind: EnvVar}, raw: "${MEM}", bad: true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := tc.key.Resolve(tc.raw, vars)
+			if tc.bad {
+				if err == nil {
+					t.Fatalf("Resolve(%q) = %#v, want an error", tc.raw, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("Resolve(%q): %v", tc.raw, err)
+			}
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("Resolve(%q) = %#v, want %#v", tc.raw, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestKeyResolveErrorNamesTheKey(t *testing.T) {
+	// A type error has to say which setting is wrong; the raw text alone does
+	// not tell anyone where to look in the file.
+	k := Key{Path: "skills.import.auto", Kind: Bool}
+	_, err := k.Resolve("maybe", env(nil))
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+	if !strings.Contains(err.Error(), "skills.import.auto") {
+		t.Errorf("error %q does not name the key", err)
 	}
 }
 

--- a/internal/config/schema_test.go
+++ b/internal/config/schema_test.go
@@ -1,0 +1,86 @@
+package config
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestKeyParseValue(t *testing.T) {
+	tests := []struct {
+		name string
+		key  Key
+		raw  string
+		want any
+		bad  bool
+	}{
+		{name: "bool true", key: Key{Kind: Bool}, raw: "true", want: true},
+		{name: "bool false", key: Key{Kind: Bool}, raw: "false", want: false},
+		{name: "bool 1", key: Key{Kind: Bool}, raw: "1", want: true},
+		{name: "bool 0", key: Key{Kind: Bool}, raw: "0", want: false},
+		// Strict, unlike wrap.Env.Bool, which reads anything but "0" as true.
+		{name: "bool rejects word", key: Key{Kind: Bool}, raw: "maybe", bad: true},
+		{name: "bool rejects empty", key: Key{Kind: Bool}, raw: "", bad: true},
+
+		{name: "int", key: Key{Kind: Int}, raw: "4096", want: 4096},
+		{name: "int negative", key: Key{Kind: Int}, raw: "-1", want: -1},
+		{name: "int rejects float", key: Key{Kind: Int}, raw: "1.5", bad: true},
+		{name: "int rejects word", key: Key{Kind: Int}, raw: "lots", bad: true},
+
+		{name: "string", key: Key{Kind: String}, raw: "npx", want: "npx"},
+		{name: "string allows empty", key: Key{Kind: String}, raw: "", want: ""},
+
+		{
+			name: "enum in set",
+			key:  Key{Kind: Enum, Enum: []string{"stdio", "http"}},
+			raw:  "http", want: "http",
+		},
+		{
+			name: "enum outside set",
+			key:  Key{Kind: Enum, Enum: []string{"stdio", "http"}},
+			raw:  "grpc", bad: true,
+		},
+
+		{name: "list", key: Key{Kind: StringList}, raw: "a,b,c", want: []string{"a", "b", "c"}},
+		{name: "list trims", key: Key{Kind: StringList}, raw: "a , b", want: []string{"a", "b"}},
+		{name: "list single", key: Key{Kind: StringList}, raw: "a", want: []string{"a"}},
+		{name: "list empty is empty", key: Key{Kind: StringList}, raw: "", want: []string{}},
+		{name: "list drops blanks", key: Key{Kind: StringList}, raw: "a,,b", want: []string{"a", "b"}},
+
+		{name: "env var name", key: Key{Kind: EnvVar}, raw: "ACME_TOKEN", want: "ACME_TOKEN"},
+		{name: "env var lowercase ok", key: Key{Kind: EnvVar}, raw: "_x1", want: "_x1"},
+		// The guard that stops a token being pasted where a name belongs.
+		{name: "env var rejects value", key: Key{Kind: EnvVar}, raw: "sk-ant-abc123", bad: true},
+		{name: "env var rejects leading digit", key: Key{Kind: EnvVar}, raw: "1X", bad: true},
+		{name: "env var rejects empty", key: Key{Kind: EnvVar}, raw: "", bad: true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := tc.key.ParseValue(tc.raw)
+			if tc.bad {
+				if err == nil {
+					t.Fatalf("ParseValue(%q) = %v, want an error", tc.raw, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ParseValue(%q): %v", tc.raw, err)
+			}
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("ParseValue(%q) = %#v, want %#v", tc.raw, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestKindString(t *testing.T) {
+	// Kind names reach the user in "expected bool, got ..." errors, so they are
+	// part of the interface rather than debug output.
+	for kind, want := range map[Kind]string{
+		Bool: "bool", Int: "int", String: "string",
+		Enum: "enum", StringList: "list", EnvVar: "env var name",
+	} {
+		if got := kind.String(); got != want {
+			t.Errorf("Kind(%d).String() = %q, want %q", int(kind), got, want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
Adds `internal/config`: the schema and value handling that the config file loader
and the `brig config` command will both read. 

No loader and no CLI yet, so nothing changes at runtime.

The package stands on its own and is tested that way.

The schema will be a table of declared keys rather than a struct. Each key carries its
dotted path, its type, its default and a one-line doc, so validation and
documentation come from one declaration and a new setting is a new row.

- Typed parsing per `kind: bool, int, string, enum, list`, plus a kind that holds an
  environment variable's `*name*` and is never expanded. pasting credential is a
  type error instead of a stored secret, and the error reports the value's shape,
  never the value.
- Dotted-path lookup with `*` segments for user defined names; 
- Env var expansion such as `${VAR}` and `${VAR:-default}`, applied *before* the type check so
  `${BRIG_MEM:-4096}` resolves to an int.
- `Schema.Validate` rejects a malformed table at the source: missing kind or doc,
  duplicate paths, a default that disagrees with its type.

## Testing
`go build ./...` and `go test ./internal/config/...` both pass.

## Notes
Written with AI assistance.