### PR TITLE
fix(wrap): require an explicit value for security switches

### DIFF
--- a/internal/verify/verify.go
+++ b/internal/verify/verify.go
@@ -38,16 +38,22 @@ const (
 	Require Mode = "require"
 )
 
-// ParseMode reads a mode, falling back to Warn for anything unrecognised: a
-// typo in this setting must not silently disable the check.
-func ParseMode(s string) Mode {
+// ParseModeStrict reads a mode and refuses anything it does not recognise.
+// BRIG_VERIFY is the switch the whole image-verification path turns on, so a
+// typo in it must stop the run, not quietly fall back to Warn and weaken the
+// check. The empty string is the unset case and keeps the Warn default.
+func ParseModeStrict(s string) (Mode, error) {
 	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "":
+		return Warn, nil
+	case "warn":
+		return Warn, nil
 	case "off", "none", "0":
-		return Off
+		return Off, nil
 	case "require", "strict":
-		return Require
+		return Require, nil
 	default:
-		return Warn
+		return Warn, fmt.Errorf("BRIG_VERIFY=%q is not a mode: use off, warn, or require", s)
 	}
 }
 

--- a/internal/verify/verify_test.go
+++ b/internal/verify/verify_test.go
@@ -254,19 +254,6 @@ func TestDefaultPolicyPinsRepoAndWorkflow(t *testing.T) {
 	}
 }
 
-// A typo in the setting must not silently disable the check.
-func TestParseModeFallsBackToWarn(t *testing.T) {
-	for in, want := range map[string]Mode{
-		"off": Off, "none": Off, "0": Off,
-		"require": Require, "strict": Require,
-		"warn": Warn, "": Warn, "yes-please": Warn, "OFF": Off,
-	} {
-		if got := ParseMode(in); got != want {
-			t.Errorf("ParseMode(%q) = %q, want %q", in, got, want)
-		}
-	}
-}
-
 func TestMessagesNameTheImageAndTheRemedy(t *testing.T) {
 	cases := map[Outcome]string{
 		NotOurs:   "not published by brig-sh",
@@ -306,5 +293,20 @@ func TestRunGivesUpOnAHangingCosign(t *testing.T) {
 	}
 	if took := time.Since(start); took > 2*time.Second {
 		t.Fatalf("run waited %v for a cosign that never answers", took)
+	}
+}
+
+// TestParseModeStrictRefusesATypo pins that an unrecognised verify mode is an
+// error, not a silent fall back to Warn. BRIG_VERIFY is the one setting the
+// whole image-verification path leans on, so a typo must stop the run rather
+// than quietly weaken the check to a warning.
+func TestParseModeStrictRefusesATypo(t *testing.T) {
+	for _, ok := range []string{"warn", "require", "strict", "off", "none", "0", "WARN", " require "} {
+		if _, err := ParseModeStrict(ok); err != nil {
+			t.Errorf("ParseModeStrict(%q) errored: %v", ok, err)
+		}
+	}
+	if _, err := ParseModeStrict("requrie"); err == nil {
+		t.Error("ParseModeStrict(requrie) did not refuse a typo")
 	}
 }

--- a/internal/wrap/config.go
+++ b/internal/wrap/config.go
@@ -99,6 +99,11 @@ type Config struct {
 	BootDigest  string
 	AllowRefs   bool
 	AllowDenied bool
+	// AllowExpired forwards the host credential even when its own expiry says it
+	// is dead. Read here rather than where it is used so a typo in it refuses the
+	// run before boot, like the other security switches, instead of at the moment
+	// an expired credential happens to turn up.
+	AllowExpired bool
 
 	// Cwd is the host directory the command was invoked from, and GuestCwd is
 	// where that lands inside the guest.
@@ -230,6 +235,20 @@ func Load(t profile.Profile, o Options, rt runtime.Runtime) (*Config, error) {
 
 	bindings, envWarnings := envOverride(t.Env, env.Fields("FORWARD_ENV", nil))
 
+	// The security switches are read strictly: an unrecognised value on any of
+	// them refuses the run rather than being guessed either way. strict marks
+	// them at the call site so it is clear which knobs fail open (env.Bool) and
+	// which fail closed (env.StrictBool). The first refusal wins; nothing built
+	// below is used until strictErr is checked, so reading the rest is harmless.
+	var strictErr error
+	strict := func(key string, fallback bool) bool {
+		b, err := env.StrictBool(key, fallback)
+		if err != nil && strictErr == nil {
+			strictErr = err
+		}
+		return b
+	}
+
 	c := &Config{
 		Profile:        t,
 		Runtime:        rt,
@@ -246,19 +265,23 @@ func Load(t profile.Profile, o Options, rt runtime.Runtime) (*Config, error) {
 		envWarnings:    envWarnings,
 		OpenStore:      openStore,
 		MacOSVersion:   macOSVersion,
-		GitConfig:      env.Bool("GIT_CONFIG", false),
+		GitConfig:      strict("GIT_CONFIG", false),
 		HostConfig:     hostProjections(t, o.Skills || env.Bool("SKILLS", false)),
 		GitHosts:       env.Fields("GIT_HOSTS", []string{"github.com"}),
 		GitIdentity:    env.Bool("GIT_IDENTITY", true),
-		TrustWorkspace: env.Bool("TRUST_WORKSPACE", true),
+		TrustWorkspace: strict("TRUST_WORKSPACE", true),
 		Verify:         verify.ParseMode(env.String("VERIFY", string(verify.Warn))),
 		VerifyPolicy:   verifyPolicy(env),
-		AllowRefs:      env.Bool("ALLOW_REFS", false),
-		AllowDenied:    env.Bool("ALLOW_DENIED", false),
+		AllowRefs:      strict("ALLOW_REFS", false),
+		AllowDenied:    strict("ALLOW_DENIED", false),
+		AllowExpired:   strict("ALLOW_EXPIRED", false),
 		Cwd:            cwd,
 		Out:            os.Stdout,
 		Err:            os.Stderr,
 		env:            env,
+	}
+	if strictErr != nil {
+		return nil, strictErr
 	}
 	c.GuestCwd = GuestCwd(cwd, c.Workspace, t.GuestHome)
 	c.resolveGitIdentity()

--- a/internal/wrap/config.go
+++ b/internal/wrap/config.go
@@ -249,6 +249,11 @@ func Load(t profile.Profile, o Options, rt runtime.Runtime) (*Config, error) {
 		return b
 	}
 
+	verifyMode, err := verify.ParseModeStrict(env.String("VERIFY", ""))
+	if err != nil && strictErr == nil {
+		strictErr = err
+	}
+
 	c := &Config{
 		Profile:        t,
 		Runtime:        rt,
@@ -266,11 +271,11 @@ func Load(t profile.Profile, o Options, rt runtime.Runtime) (*Config, error) {
 		OpenStore:      openStore,
 		MacOSVersion:   macOSVersion,
 		GitConfig:      strict("GIT_CONFIG", false),
-		HostConfig:     hostProjections(t, o.Skills || env.Bool("SKILLS", false)),
+		HostConfig:     hostProjections(t, o.Skills || strict("SKILLS", false)),
 		GitHosts:       env.Fields("GIT_HOSTS", []string{"github.com"}),
 		GitIdentity:    env.Bool("GIT_IDENTITY", true),
 		TrustWorkspace: strict("TRUST_WORKSPACE", true),
-		Verify:         verify.ParseMode(env.String("VERIFY", string(verify.Warn))),
+		Verify:         verifyMode,
 		VerifyPolicy:   verifyPolicy(env),
 		AllowRefs:      strict("ALLOW_REFS", false),
 		AllowDenied:    strict("ALLOW_DENIED", false),

--- a/internal/wrap/env.go
+++ b/internal/wrap/env.go
@@ -87,6 +87,10 @@ func (e Env) Bool(key string, fallback bool) bool {
 // user says otherwise -- the same meaning Bool gives them.
 func (e Env) StrictBool(key string, fallback bool) (bool, error) {
 	name, v, ok := e.getNamed(key)
+	// Trim first, the same as ParseMode next door: a value that arrived through
+	// $(cat flag) carries a trailing newline, and a switch that refuses the run
+	// over whitespace is a worse surprise than the typo it is guarding against.
+	v = strings.TrimSpace(v)
 	if !ok || v == "" {
 		return fallback, nil
 	}

--- a/internal/wrap/env.go
+++ b/internal/wrap/env.go
@@ -1,6 +1,7 @@
 package wrap
 
 import (
+	"fmt"
 	"os"
 	"strings"
 )
@@ -29,12 +30,23 @@ func NewEnv(profileName string, get func(string) (string, bool)) Env {
 
 // Get returns the first setting present under any of the prefixes.
 func (e Env) Get(key string) (string, bool) {
+	_, v, ok := e.getNamed(key)
+	return v, ok
+}
+
+// getNamed is Get plus the exact variable name the value came from, so an
+// error or a report can quote the setting the user actually wrote -- the
+// per-agent BRIG_<AGENT>_<KEY> or the global BRIG_<KEY> -- rather than a
+// canonical spelling they never typed. BRIG_ALLOW_DENIED=1 in a message the
+// user reads after setting BRIG_CLAUDE_CODE_ALLOW_DENIED=false is two lies in
+// one line: wrong name and wrong value.
+func (e Env) getNamed(key string) (name, value string, ok bool) {
 	for _, n := range []string{e.prefix + "_" + key, "BRIG_" + key} {
 		if v, ok := e.get(n); ok {
-			return v, true
+			return n, v, true
 		}
 	}
-	return "", false
+	return "", "", false
 }
 
 // String returns the setting or a fallback.
@@ -48,12 +60,56 @@ func (e Env) String(key, fallback string) string {
 // Bool reads a setting as an on/off switch. Anything but "0" is on, matching
 // the shell idiom the wrapper used, so URUNC_CLAUDE_GIT_CONFIG=1 and =true
 // both enable it and =0 is the only way off.
+//
+// This is the reading for a tuning knob, where on is the ordinary case and a
+// value the helper does not recognise is closer to on than to a failed run.
+// StrictBool is the reading for a switch whose off position is the safe one.
 func (e Env) Bool(key string, fallback bool) bool {
 	v, ok := e.Get(key)
 	if !ok || v == "" {
 		return fallback
 	}
 	return v != "0"
+}
+
+// StrictBool reads a security switch, where the safe position is off and a
+// value the helper cannot read must stop the run rather than be guessed.
+//
+// Bool treats anything but "0" as on. That is right for a tuning knob and
+// wrong for a switch that forwards a denied credential or writes brig's own
+// files into the workspace: under that rule BRIG_ALLOW_DENIED=false reads as
+// on, so a user spelling "off" the way their shell does turns the guard off by
+// turning it on -- the switch fails open for exactly the person trying to close
+// it. Here both spellings a user reaches for are understood, case-insensitively,
+// and anything outside either set is refused by name instead of falling open.
+//
+// Absent or empty still falls back, so the switch keeps its default until the
+// user says otherwise -- the same meaning Bool gives them.
+func (e Env) StrictBool(key string, fallback bool) (bool, error) {
+	name, v, ok := e.getNamed(key)
+	if !ok || v == "" {
+		return fallback, nil
+	}
+	switch strings.ToLower(v) {
+	case "1", "true", "yes", "on":
+		return true, nil
+	case "0", "false", "no", "off":
+		return false, nil
+	}
+	return false, fmt.Errorf(
+		"%s=%s is not a value brig understands. Use 1, true, yes or on to turn it "+
+			"on, 0, false, no or off to turn it off, or unset it", name, v)
+}
+
+// setting renders "NAME=value" for the setting behind key, so a report quotes
+// what the user actually set rather than a canonical spelling. When nothing is
+// set it names the global variable; reporting callers reach this only for a
+// switch they have already found to be on, so in practice a value is present.
+func (e Env) setting(key string) string {
+	if name, value, ok := e.getNamed(key); ok {
+		return name + "=" + value
+	}
+	return "BRIG_" + key
 }
 
 // Int reads a setting as a number, falling back on anything unparseable

--- a/internal/wrap/env.go
+++ b/internal/wrap/env.go
@@ -87,7 +87,7 @@ func (e Env) Bool(key string, fallback bool) bool {
 // user says otherwise -- the same meaning Bool gives them.
 func (e Env) StrictBool(key string, fallback bool) (bool, error) {
 	name, v, ok := e.getNamed(key)
-	// Trim first, the same as ParseMode next door: a value that arrived through
+	// Trim first, the same as ParseModeStrict next door: a value that arrived through
 	// $(cat flag) carries a trailing newline, and a switch that refuses the run
 	// over whitespace is a worse surprise than the typo it is guarding against.
 	v = strings.TrimSpace(v)

--- a/internal/wrap/env_test.go
+++ b/internal/wrap/env_test.go
@@ -1,6 +1,23 @@
 package wrap
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
+
+// oneVar is a lookup where a single variable is set and nothing else, so a case
+// reads as "this is what the environment held" rather than as a map literal.
+func oneVar(name, value string) func(string) (string, bool) {
+	return func(k string) (string, bool) {
+		if k == name {
+			return value, true
+		}
+		return "", false
+	}
+}
+
+// none is the empty environment: every lookup misses.
+func none(string) (string, bool) { return "", false }
 
 func TestEnvPrecedence(t *testing.T) {
 	env := map[string]string{
@@ -50,5 +67,98 @@ func TestEnvBoolAndFields(t *testing.T) {
 	}
 	if n := e.Int("MEM", 4096); n != 4096 {
 		t.Errorf("Int fallback = %d", n)
+	}
+}
+
+// strictSwitches is every key read with StrictBool: each one forwards a
+// credential or writes brig's own files into the workspace when on, so an
+// unrecognised value must refuse rather than fall open the way Bool does.
+var strictSwitches = []string{
+	"GIT_CONFIG", "TRUST_WORKSPACE", "ALLOW_REFS", "ALLOW_DENIED", "ALLOW_EXPIRED",
+}
+
+// The table the issue asks for: every spelling in the true set, the false set,
+// an unrecognised value, absent and empty, for all five security switches. The
+// old Bool test covered only "1", "0", absent and empty, which is exactly why
+// "false" and "off" reading as on went unnoticed.
+func TestEnvStrictBool(t *testing.T) {
+	on := []string{"1", "true", "yes", "on", "TRUE", "Yes", "ON", "On"}
+	off := []string{"0", "false", "no", "off", "FALSE", "No", "OFF", "Off"}
+
+	for _, key := range strictSwitches {
+		for _, v := range on {
+			e := NewEnv("codex", oneVar("BRIG_"+key, v))
+			got, err := e.StrictBool(key, false)
+			if err != nil {
+				t.Errorf("%s=%s: unexpected refusal: %v", key, v, err)
+			}
+			if !got {
+				t.Errorf("%s=%s did not read as on", key, v)
+			}
+		}
+		for _, v := range off {
+			e := NewEnv("codex", oneVar("BRIG_"+key, v))
+			got, err := e.StrictBool(key, true)
+			if err != nil {
+				t.Errorf("%s=%s: unexpected refusal: %v", key, v, err)
+			}
+			if got {
+				t.Errorf("%s=%s did not read as off", key, v)
+			}
+		}
+
+		// An unrecognised value refuses, naming both the variable and the
+		// values it would have accepted, so the user is told what to write
+		// rather than having their typo guessed at.
+		e := NewEnv("codex", oneVar("BRIG_"+key, "maybe"))
+		_, err := e.StrictBool(key, false)
+		if err == nil {
+			t.Fatalf("%s=maybe was accepted", key)
+		}
+		for _, want := range []string{"BRIG_" + key, "maybe", "1", "true", "yes", "on", "0", "false", "off"} {
+			if !strings.Contains(err.Error(), want) {
+				t.Errorf("%s=maybe refusal does not name %q: %v", key, want, err)
+			}
+		}
+
+		// Absent and empty keep the fallback, whichever way it points -- the
+		// same meaning Bool gives them, so a switch left alone stays at its
+		// default rather than refusing.
+		for _, fallback := range []bool{true, false} {
+			if got, err := NewEnv("codex", none).StrictBool(key, fallback); err != nil || got != fallback {
+				t.Errorf("%s absent: got %v, err %v; want %v", key, got, err, fallback)
+			}
+			if got, err := NewEnv("codex", oneVar("BRIG_"+key, "")).StrictBool(key, fallback); err != nil || got != fallback {
+				t.Errorf("%s empty: got %v, err %v; want %v", key, got, err, fallback)
+			}
+		}
+	}
+}
+
+// The per-agent BRIG_<AGENT>_<KEY> beats the global BRIG_<KEY> for a strict
+// switch too, the same precedence every other setting follows. It has to hold
+// here or a global override left in one shell would quietly re-arm a switch an
+// agent was set to turn off, and the refusal has to quote the variable the
+// value actually came from rather than the global name the user never set.
+func TestEnvStrictBoolPrecedence(t *testing.T) {
+	env := map[string]string{
+		"BRIG_CLAUDE_CODE_ALLOW_DENIED": "off",
+		"BRIG_ALLOW_DENIED":             "on",
+	}
+	get := func(k string) (string, bool) { v, ok := env[k]; return v, ok }
+	e := NewEnv("claude-code", get)
+
+	got, err := e.StrictBool("ALLOW_DENIED", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got {
+		t.Error("the per-agent off did not win over the global on")
+	}
+
+	env["BRIG_CLAUDE_CODE_ALLOW_DENIED"] = "maybe"
+	_, err = e.StrictBool("ALLOW_DENIED", false)
+	if err == nil || !strings.Contains(err.Error(), "BRIG_CLAUDE_CODE_ALLOW_DENIED=maybe") {
+		t.Errorf("the refusal did not quote the per-agent setting the user actually set: %v", err)
 	}
 }

--- a/internal/wrap/hostcred_test.go
+++ b/internal/wrap/hostcred_test.go
@@ -64,6 +64,29 @@ func TestHostCredentialIsForwardedWhenTheDenylistIsOverridden(t *testing.T) {
 	}
 }
 
+// The switch off, spelled every way a shell offers, keeps a denied variable
+// out. Under the old rule "false", "no", "off", "FALSE" and "0" all but "0"
+// read as on, so a user turning the guard off forwarded the very credential the
+// denylist exists to hold back. The value flows through StrictBool into
+// AllowDenied exactly as Load wires it, and the denied credential stays out.
+func TestOffSpellingsDoNotForwardADeniedCredential(t *testing.T) {
+	for _, v := range []string{"false", "no", "off", "FALSE", "0"} {
+		c := hostCredConfig(t, "deny: [TOK]\n", `{"accessToken":"tok"}`)
+		on, err := NewEnv(c.Profile.Name, oneVar("BRIG_ALLOW_DENIED", v)).StrictBool("ALLOW_DENIED", false)
+		if err != nil {
+			t.Fatalf("BRIG_ALLOW_DENIED=%s was refused: %v", v, err)
+		}
+		c.AllowDenied = on
+		set, err := c.BuildEnv()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if set.Has("TOK") {
+			t.Errorf("BRIG_ALLOW_DENIED=%s forwarded a denied variable", v)
+		}
+	}
+}
+
 // The other guard: a credentials command that is not logged in prints its
 // secret-manager reference rather than a token. Forwarded verbatim it fails in
 // the guest as "invalid token", which is indistinguishable from a real
@@ -125,12 +148,10 @@ func TestHostCredentialWithoutAnExpiryIsForwarded(t *testing.T) {
 func TestExpiredHostCredentialIsForwardedWhenAskedFor(t *testing.T) {
 	expired := time.Now().Add(-time.Hour).UnixMilli()
 	c := hostCredConfig(t, "", fmt.Sprintf(`{"accessToken":"stale","expiresAt":%d}`, expired))
-	c.env = NewEnv(c.Profile.Name, func(name string) (string, bool) {
-		if name == "BRIG_ALLOW_EXPIRED" {
-			return "1", true
-		}
-		return "", false
-	})
+	// The switch is read strictly at Load and kept on the Config, so the escape
+	// hatch is that field being on, the same shape the denylist override test
+	// uses. StrictBool's own parsing of "1" is covered by the env table test.
+	c.AllowExpired = true
 	set, err := c.BuildEnv()
 	if err != nil {
 		t.Fatal(err)

--- a/internal/wrap/load_test.go
+++ b/internal/wrap/load_test.go
@@ -139,3 +139,23 @@ func TestEveryStrictSwitchIsWired(t *testing.T) {
 		})
 	}
 }
+
+// TestVerifyAndSkillsFailClosedOnATypo extends the strict-switch guarantee to
+// the two settings of the same shape that #27 left out: BRIG_VERIFY (a mode)
+// and BRIG_SKILLS (a boolean). An unrecognised value on either must refuse the
+// load, not degrade verification to a warning or seed skills the user did not
+// ask for.
+func TestVerifyAndSkillsFailClosedOnATypo(t *testing.T) {
+	for _, key := range []string{"BRIG_VERIFY", "BRIG_SKILLS"} {
+		t.Run(key, func(t *testing.T) {
+			t.Setenv(key, "maybe")
+			pr, ok := profile.Lookup("claude-code")
+			if !ok {
+				t.Fatal("no claude-code profile")
+			}
+			if _, err := Load(pr, Options{}, nil); err == nil {
+				t.Fatalf("%s=maybe did not refuse the load", key)
+			}
+		})
+	}
+}

--- a/internal/wrap/load_test.go
+++ b/internal/wrap/load_test.go
@@ -95,3 +95,24 @@ func TestWorkspaceFromTheEnvironmentIsMadeAbsolute(t *testing.T) {
 		t.Errorf("workspace resolved under %q, want %q", got, want)
 	}
 }
+
+// A security switch set to a value brig cannot read refuses the run rather than
+// guessing. Under the old rule BRIG_ALLOW_DENIED=false read as on, so a user
+// turning the guard off turned it on; now Load returns the refusal, and it
+// returns it before boot rather than at the moment a denied variable turns up.
+func TestLoadRefusesAnUnreadableSecuritySwitch(t *testing.T) {
+	t.Setenv("BRIG_ALLOW_DENIED", "maybe")
+	p, ok := profile.Lookup("claude-code")
+	if !ok {
+		t.Fatal("no claude-code profile")
+	}
+	_, err := Load(p, Options{}, nil)
+	if err == nil {
+		t.Fatal("an unreadable BRIG_ALLOW_DENIED did not refuse the run")
+	}
+	for _, want := range []string{"BRIG_ALLOW_DENIED", "maybe"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("the refusal does not name %q: %v", want, err)
+		}
+	}
+}

--- a/internal/wrap/load_test.go
+++ b/internal/wrap/load_test.go
@@ -116,3 +116,26 @@ func TestLoadRefusesAnUnreadableSecuritySwitch(t *testing.T) {
 		}
 	}
 }
+
+// TestEveryStrictSwitchIsWired asserts each security switch is actually routed
+// through the strict reader by Load, not merely that StrictBool works. A switch
+// reverted to env.Bool would still parse a good value and would silently stop
+// failing closed on a typo; this catches that by feeding each one an
+// unrecognised value and requiring Load to refuse.
+func TestEveryStrictSwitchIsWired(t *testing.T) {
+	for _, key := range []string{
+		"BRIG_GIT_CONFIG", "BRIG_TRUST_WORKSPACE",
+		"BRIG_ALLOW_REFS", "BRIG_ALLOW_DENIED", "BRIG_ALLOW_EXPIRED",
+	} {
+		t.Run(key, func(t *testing.T) {
+			t.Setenv(key, "maybe")
+			pr, ok := profile.Lookup("claude-code")
+			if !ok {
+				t.Fatal("no claude-code profile")
+			}
+			if _, err := Load(pr, Options{}, nil); err == nil {
+				t.Fatalf("%s=maybe did not refuse the load, so it is not wired through the strict reader", key)
+			}
+		})
+	}
+}

--- a/internal/wrap/report_test.go
+++ b/internal/wrap/report_test.go
@@ -51,6 +51,31 @@ func TestStatusDoesNotContradictItselfWhenTheDenylistIsOverridden(t *testing.T) 
 	}
 }
 
+// The override message quotes the value the user set, not a hardcoded =1. With
+// the strict reading BRIG_ALLOW_DENIED=true is what turns the guard off, and a
+// report answering "why is my sandbox on metered billing" with a =1 the user
+// never wrote sends them looking for a variable that is not there.
+func TestStatusOverrideMessageReportsTheValueTheUserSet(t *testing.T) {
+	c := bindingConfig(t, "deny: [ANTHROPIC_API_KEY]\n")
+	c.env = NewEnv(c.Profile.Name, oneVar("BRIG_ALLOW_DENIED", "true"))
+	c.AllowDenied = true
+	c.Runtime = fakeRuntime{}
+	out := &bytes.Buffer{}
+	c.Out = out
+
+	var set creds.Set
+	set.Add("ANTHROPIC_API_KEY", "sk-x", "ANTHROPIC_API_KEY")
+	c.Status(set)
+
+	got := out.String()
+	if !strings.Contains(got, "BRIG_ALLOW_DENIED=true") {
+		t.Errorf("the override message does not quote what the user set:\n%s", got)
+	}
+	if strings.Contains(got, "BRIG_ALLOW_DENIED=1") {
+		t.Errorf("the override message still quotes a hardcoded =1:\n%s", got)
+	}
+}
+
 // With the guard on, the report reads as it always did.
 func TestStatusStillNamesTheDenylistWhenItIsOn(t *testing.T) {
 	c := bindingConfig(t, "deny: [ANTHROPIC_API_KEY]\n")

--- a/internal/wrap/run.go
+++ b/internal/wrap/run.go
@@ -126,7 +126,7 @@ func (c *Config) admitHostCredential(hc *profile.HostCredential, host *creds.Hos
 		c.warnf("%s (from %s)", warning, host.Source)
 		return
 	}
-	if host.Expired(time.Now().UnixMilli()) && !c.env.Bool("ALLOW_EXPIRED", false) {
+	if host.Expired(time.Now().UnixMilli()) && !c.AllowExpired {
 		c.warnf("NOT forwarding the host's credential: it has expired, so it would "+
 			"authenticate nothing and the sandbox would ask you to log in anyway. "+
 			"%s, or set BRIG_ALLOW_EXPIRED=1 to send it as it is", hc.RenewHint)

--- a/internal/wrap/run.go
+++ b/internal/wrap/run.go
@@ -133,8 +133,11 @@ func (c *Config) admitHostCredential(hc *profile.HostCredential, host *creds.Hos
 		return
 	}
 	if host.Expired(time.Now().UnixMilli()) {
-		c.warnf("the host's credential has expired and BRIG_ALLOW_EXPIRED=1 is set, "+
-			"so it is being forwarded anyway -- %s", hc.RenewHint)
+		// Quote what the user set, not a hardcoded =1: with the strict reading
+		// BRIG_ALLOW_EXPIRED=true is what turned this on, and echoing a value
+		// they never wrote sends them looking for a variable that is not there.
+		c.warnf("the host's credential has expired and %s is set, "+
+			"so it is being forwarded anyway -- %s", c.env.setting("ALLOW_EXPIRED"), hc.RenewHint)
 	}
 	// AddSecret, not Add: this token came out of the host's keychain, so it
 	// wants the same argv exemption a store secret gets. BRIG_ENV_ARGV is a

--- a/internal/wrap/status.go
+++ b/internal/wrap/status.go
@@ -182,16 +182,21 @@ func (c *Config) reportDeny(set creds.Set) {
 		}
 		withheld = append(withheld, name)
 	}
+	// Quote the setting the user actually wrote, not a hardcoded =1: with the
+	// strict reading BRIG_ALLOW_DENIED=true is what turned this on, and a report
+	// that answers "why is my sandbox on metered billing" with a value the user
+	// never set sends them looking for a variable that is not there.
+	override := c.env.setting("ALLOW_DENIED")
 	if len(forwarded) > 0 {
-		c.sayf("DENYLIST OVERRIDDEN by BRIG_ALLOW_DENIED=1, forwarding: %s "+
-			"(this moves the sandbox onto metered billing)", strings.Join(forwarded, " "))
+		c.sayf("DENYLIST OVERRIDDEN by %s, forwarding: %s "+
+			"(this moves the sandbox onto metered billing)", override, strings.Join(forwarded, " "))
 	}
 	if len(withheld) == 0 {
 		return
 	}
 	if c.AllowDenied {
-		c.sayf("denylist off for %s (BRIG_ALLOW_DENIED=1), so these would be forwarded "+
-			"if set: %s", c.Profile.Name, strings.Join(withheld, " "))
+		c.sayf("denylist off for %s (%s), so these would be forwarded "+
+			"if set: %s", c.Profile.Name, override, strings.Join(withheld, " "))
 		return
 	}
 	c.sayf("never forwarded for %s: %s (they would move this sandbox onto metered billing)",


### PR DESCRIPTION
## Summary

`Env.Bool` read a setting as on unless its value was exactly `0`, so zero was the
only spelling of off. Every other spelling a user reaches for turned the setting
on, and five of the callers are security switches: `BRIG_GIT_CONFIG`,
`BRIG_TRUST_WORKSPACE`, `BRIG_ALLOW_REFS`, `BRIG_ALLOW_DENIED` and
`BRIG_ALLOW_EXPIRED`.

`BRIG_ALLOW_DENIED=false` therefore forwarded the denied billing key, exactly as
`=1` would, and the report quoted back `BRIG_ALLOW_DENIED=1`, a value the user
never set. `BRIG_GIT_CONFIG=off` wrote the guest credential helper and the
managed gitconfig into the workspace. This is the failure mode that fires while
someone is trying to be careful, which is why it is worth treating differently
from a tuning knob.

The permissive reading stays for the knobs. The five security switches now take
an explicit true set or an explicit false set, and refuse anything else by name
rather than guessing which way the user meant it.

## Related issues

Closes #27

## Changes

- Add `Env.StrictBool`, which returns an error rather than a guess. True set is
  `1`, `true`, `yes`, `on`; false set is `0`, `false`, `no`, `off`; both
  case-insensitive. Absent and empty keep their existing meaning.
- Read the five security switches through it. The call sites go through a
  `strict` helper so it is visible at a glance which knobs fail open and which
  fail closed.
- Name the variable that was actually set in the refusal, so
  `BRIG_CLAUDE_CODE_ALLOW_DENIED=maybe` reports that name rather than the
  unprefixed one.
- Quote the setting the user wrote in the denylist override report, instead of a
  hardcoded `=1`.
- Move `AllowExpired` out of an inline read in `run.go` and onto `Config`, so all
  five sit together.
- Table tests over every spelling in both sets, an unrecognised value, absent and
  empty, for all five switches, plus one covering `BRIG_<AGENT>_<KEY>` precedence.

## Checklist

- [x] `make all` passes (vet, test, build)
- [x] `script/smoke.sh` passes
- [x] I have added or updated tests covering the change
- [x] I have run `go test ./... -race`, if the change touches concurrency, subprocesses or the daemon
- [x] I have exercised the change against a real runtime (`brig run <agent>`), if it touches the run, exec or credential path
- [ ] I have updated the affected docs (README, `docs/security.md`, `docs/profiles.md`, `docs/brigd.md`)

Two boxes are deliberately unticked.

No run against a real runtime. Everything here was exercised against the stub
runtime and stub cosign that `script/smoke.sh` drives. The change alters whether
a credential is forwarded, so a run against a real sandbox is worth doing before
merge.

**Docs are out of date and this PR does not fix them.** `README.md:499` still
says "Booleans are shell-style: anything except `0` is on", which is now false
for the five strict switches. The env table needs the accepted values and the
refusal behaviour written down. Worth folding in here rather than merging a
behaviour change that the README contradicts.

## Credentials and the sandbox boundary

This affects the second promise: the guest gets the credentials it was named and
no others. `BRIG_ALLOW_DENIED` set to any spelling of false previously forwarded
a denied billing key, which is the exact case the denylist exists to prevent.

The assertions that matter are negative: a denied variable is not forwarded for
`false`, `no`, `off`, `FALSE` or `0`, and an unrecognised value stops the run
rather than falling through to either reading. Both fail without the change.
