### PR TITLE
feat(cli): print the execution envelope and add `brig info`

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -19,12 +19,13 @@ duplicates.
 ## To reproduce
 
 <!--
-The exact steps, including the command line. `brig env <agent>` prints what
-would be forwarded, by name and never by value, and is usually the quickest way
-to show a credential problem without pasting a secret.
+The exact steps, including the command line. `brig info <agent>` prints the
+execution envelope and everything that would be forwarded, by name and never by
+value, and is usually the quickest way to show a credential problem without
+pasting a secret.
 
 If the sandbox boots but misbehaves, say which runtime is underneath: `brig
-status` reports the backend, and `hull ps` / `nerdctl ps` shows the instance.
+info` reports the backend, and `hull ps` / `nerdctl ps` shows the instance.
 -->
 
 1.
@@ -56,6 +57,6 @@ status` reports the backend, and `hull ps` / `nerdctl ps` shows the instance.
 Relevant output, fenced. Link related issues inline with #NN.
 
 Please do not paste credential values. brig is careful never to print one --
-`brig env` shows names only -- so if you find a value in output anywhere, that
+`brig info` shows names only -- so if you find a value in output anywhere, that
 is itself the bug, and worth saying so rather than pasting it.
 -->

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ separate Linux re-implementation of it.
 | `brig rm <agent>` | stop and remove the sandbox. The workspace is untouched |
 | `brig ls` | every brig sandbox, running or merely holding its name, with its workspace |
 | `brig reset` | stop and remove every brig sandbox. Workspaces are untouched |
-| `brig env <agent>` | what would be forwarded, **by name only**, and whether the guest will be authenticated |
+| `brig info <agent>` | the boundary a run would trust -- sandbox, workspace, image, credentials **by name only** -- and whether the guest will be authenticated (`brig env` is the old spelling) |
 | `brig profiles` | the profiles, their images, and what each one refuses to forward |
 | `brig profile ls\|export\|import\|edit\|rm` | manage profiles (`brig export` is the short form of `brig profile export`). `export --json` for JSON instead of YAML |
 | `brig secret create\|read\|update\|delete\|ls` | keep secrets in your keyring. macOS only for now |
@@ -169,7 +169,7 @@ underscore, ten characters -- so `my_project` and `my-project` stay separate,
 while `Foo` and `foo` do not (macOS filesystems ignore case, and two names
 sharing one directory but not one VM is a bug waiting to happen). If the slug
 differs from what you typed, brig says which directory it used.
-`brig env claude --name refactor` prints the one in use.
+`brig info claude --name refactor` prints the one in use.
 
 **Every other verb needs the same `--name`.** A named session is addressed by
 its agent *plus* its name, not by the name alone:
@@ -185,7 +185,7 @@ the sandbox's own name and is not what the verbs take -- `brig rm refactor`
 and `brig rm brig-claude-code-refactor` both fail with "unknown agent". Pass
 the agent and `--name`, as above.
 
-To drop the workspace too, remove the directory `brig env` prints. And
+To drop the workspace too, remove the directory `brig info` prints. And
 `brig reset` stops and removes every brig sandbox at once, named ones
 included, leaving all workspaces alone.
 
@@ -277,7 +277,7 @@ by their own tools' design. Three rules apply to every one of them:
 - **A denylisted variable is refused**, with the reason. `BRIG_ALLOW_DENIED=1`
   if metered billing is genuinely what you want.
 
-`brig env <agent>` reports what would be forwarded, by name, and whether the
+`brig info <agent>` reports what would be forwarded, by name, and whether the
 guest will actually be authenticated -- an expired stored credential is exactly
 what sends a sandbox back to its login screen.
 
@@ -325,10 +325,20 @@ names are optional, and the run says what it could not find and carries on.
 your own.
 
 ```console
-$ brig env claude
+$ brig info claude
+PROFILE      claude-code
+SANDBOX      brig-claude-code (hull)
+WORKSPACE    /Users/you/brig/claude-code (read-write)
+IMAGE        ghcr.io/brig-sh/claude-code-stock:latest (pull missing)
+CREDENTIALS  GH_TOKEN
 brig: forwarding to guest:
 brig:   GH_TOKEN(secret)
 ```
+
+The block at the top is the execution envelope: the boundary the run would
+trust, printed before the sandbox boots. `brig run` and `brig create` print the
+same block before they start one, so what you preview is what you get. Names
+only, never values. `--quiet` drops it.
 
 A secret a profile declares but the store does not have fails the run before
 any sandbox is created, naming every one that is missing and the command that

--- a/cmd/brig/main.go
+++ b/cmd/brig/main.go
@@ -260,9 +260,10 @@ func run(args []string) error {
 
 	// The execution envelope: the boundary this run is about to trust, printed
 	// before the sandbox boots so the user sees it before it matters. Only run
-	// and create print it -- exec and shell attach to a sandbox whose envelope
-	// the user already saw, so repeating it would be noise. --quiet drops it for
-	// a script or a returning session.
+	// and create print it. exec and shell continue an existing session and stay
+	// quiet; when there is no sandbox yet they let EnsureRunning start one
+	// without printing the block, so a scripted brig exec is not interrupted.
+	// --quiet drops it for a script or a returning session.
 	if (verb == "run" || verb == "create") && !opts.quiet {
 		cfg.PrintPreRunEnvelope(set)
 	}

--- a/cmd/brig/main.go
+++ b/cmd/brig/main.go
@@ -46,7 +46,8 @@ usage:
   brig rm     <profile>                          stop and remove the sandbox
   brig ls                                        list sandboxes
   brig reset                                     stop and remove every brig sandbox
-  brig env    <profile>                          report the environment, by name -- fails
+  brig info   <profile>                          print the execution envelope and the
+                                                 full environment, by name -- fails
                                                  if a declared secret is missing
   brig profiles                                  list the profiles
   brig profile ls|export|import|edit|rm          manage profiles
@@ -66,6 +67,8 @@ flags (before the agent's own arguments; -- ends brig's parsing):
   -m, --memory MB        guest memory
       --cpus N           guest vCPUs
   -d, --detach           with run: start the sandbox and exit
+  -q, --quiet            with run or create: do not print the execution
+                         envelope before the agent starts
       --skills           project your own ~/.claude skills and plugins into
                          the guest, read-only (or BRIG_SKILLS=1)
 
@@ -176,7 +179,7 @@ func run(args []string) error {
 		return listSandboxes(rest)
 	case "reset":
 		return reset(rest)
-	case "run", "create", "exec", "shell", "stop", "rm", "env":
+	case "run", "create", "exec", "shell", "stop", "rm", "info", "env":
 	default:
 		return fmt.Errorf("unknown command %q (try `brig help`)", verb)
 	}
@@ -207,19 +210,23 @@ func run(args []string) error {
 
 	rt, err := runtime.DetectFor(runtime.Preference{Bin: t.RuntimeBin})
 	if err != nil {
-		// brig env is the report worth giving when the runtime is the thing
+		// brig info is the report worth giving when the runtime is the thing
 		// that is broken: only one of its lines comes from the runtime, and the
 		// person most likely to run it is the one whose runtime is not on PATH.
-		// So env carries on without one, and Status marks that single line
-		// unavailable. Every other verb needs the runtime to do its work, so
-		// they still fail here, naming what is missing.
+		// So it carries on without one, and the report marks that single line
+		// unavailable. env is the old spelling of the same command and gets the
+		// same treatment, or the spelling brig recommends would be the one that
+		// fails. Every other verb needs the runtime to do its work, so they
+		// still fail here, naming what is missing.
 		//
-		// But only "no runtime on PATH" is a state env should paper over. An
-		// unknown BRIG_RUNTIME or a runtimeBin that is not there is a mistake to
-		// fix, and env is the verb people run to find it -- so those surface
-		// here as they do for run, naming the real cause. Match the sentinel,
-		// not any error, or a future error type silently rejoins the swallow.
-		if verb != "env" || !errors.Is(err, runtime.ErrNoRuntime) {
+		// But only "no runtime on PATH" is a state the report should paper
+		// over. An unknown BRIG_RUNTIME or a runtimeBin that is not there is a
+		// mistake to fix, and this is the verb people run to find it -- so those
+		// surface here as they do for run, naming the real cause. Match the
+		// sentinel, not any error, or a future error type silently rejoins the
+		// swallow.
+		reports := verb == "info" || verb == "env"
+		if !reports || !errors.Is(err, runtime.ErrNoRuntime) {
 			return err
 		}
 		rt = nil
@@ -251,9 +258,26 @@ func run(args []string) error {
 		return err
 	}
 
+	// The execution envelope: the boundary this run is about to trust, printed
+	// before the sandbox boots so the user sees it before it matters. Only run
+	// and create print it -- exec and shell attach to a sandbox whose envelope
+	// the user already saw, so repeating it would be noise. --quiet drops it for
+	// a script or a returning session.
+	if (verb == "run" || verb == "create") && !opts.quiet {
+		cfg.PrintPreRunEnvelope(set)
+	}
+
 	switch verb {
+	case "info":
+		cfg.Info(set)
+		return nil
 	case "env":
-		cfg.Status(set)
+		// Kept for one release as a spelling of `brig info`, with the single
+		// line the other deprecated verbs print. The bug report template used
+		// to send reporters to `brig status`, which was never a command; info
+		// is the name that work settled on.
+		deprecated("brig env", "brig info")
+		cfg.Info(set)
 		return nil
 	case "create":
 		if err := cfg.EnsureRunning(set); err != nil {
@@ -321,6 +345,7 @@ type options struct {
 	load      wrap.Options
 	nameGiven bool
 	detach    bool
+	quiet     bool
 }
 
 // brigFlags is what brig owns on a run line. Everything else on that line
@@ -340,6 +365,7 @@ var brigFlags = []struct {
 	{long: "cpus", value: true},
 	{long: "detach", short: "d"},
 	{long: "skills"},
+	{long: "quiet", short: "q"},
 }
 
 // ours reports whether a token is one of brig's flags, and whether that flag
@@ -462,6 +488,9 @@ func parse(args []string) (o options, profileName string, tail []string, err err
 		// Opt-in, and only ever opt-in: this hands the guest the user's real
 		// skills and plugins, read-only.
 		{"skills", "", func(n string) { fs.BoolVar(&o.load.Skills, n, false, "") }},
+		// Suppresses the execution envelope on run and create, for a script or
+		// a returning session that has already seen it.
+		{"quiet", "q", func(n string) { fs.BoolVar(&o.quiet, n, false, "") }},
 	} {
 		// Both spellings write the same variable, so whichever the user typed
 		// lands in one place and the last one on the line wins.

--- a/cmd/brig/main_test.go
+++ b/cmd/brig/main_test.go
@@ -94,6 +94,28 @@ func TestParseSandboxFlags(t *testing.T) {
 	}
 }
 
+// --quiet is brig's own flag, read off the run line like the other bare flags
+// and never handed to the agent. It suppresses the execution envelope.
+func TestParseReadsQuiet(t *testing.T) {
+	for _, args := range [][]string{{"claude", "--quiet"}, {"claude", "-q"}} {
+		o, name, tail, err := parse(args)
+		if err != nil {
+			t.Fatalf("parse(%q): %v", args, err)
+		}
+		if !o.quiet || name != "claude" || len(tail) != 0 {
+			t.Errorf("parse(%q) = quiet %v, name %q, tail %q", args, o.quiet, name, tail)
+		}
+	}
+	// Absent by default, and after the agent's arguments begin it is the
+	// agent's word rather than brig's.
+	if o, _, _, _ := parse([]string{"claude"}); o.quiet {
+		t.Error("quiet defaulted to on")
+	}
+	if o, _, _, _ := parse([]string{"claude", "-p", "hi", "--quiet"}); o.quiet {
+		t.Error("--quiet was read out of the agent's own arguments")
+	}
+}
+
 func TestParseRejectsBadValues(t *testing.T) {
 	cases := [][]string{
 		{"claude", "--name"},     // nothing after it

--- a/cmd/brig/runtime_guard_test.go
+++ b/cmd/brig/runtime_guard_test.go
@@ -97,3 +97,31 @@ func TestLsWithoutARuntimeSaysNothingToList(t *testing.T) {
 		t.Errorf("ls with no runtime on PATH failed instead of listing nothing: %v", err)
 	}
 }
+
+// info is the new spelling of env, so it answers without a runtime for the same
+// reason: the runtime is one line of the report, and the person reading it is
+// often the one whose runtime is what broke. A new verb that fails where the
+// one it deprecates succeeds would make the recommended spelling the worse one.
+func TestInfoReportsWithoutARuntime(t *testing.T) {
+	t.Setenv("BRIG_PROFILE_DIR", t.TempDir())
+	emptyPath(t)
+
+	if err := run([]string{"info", "claude-code"}); err != nil {
+		t.Errorf("brig info with no runtime on PATH failed instead of reporting: %v", err)
+	}
+}
+
+// And the exemption stays narrow for info too: an unknown BRIG_RUNTIME is a
+// mistake to fix, not a missing install.
+func TestInfoSurfacesUnknownRuntime(t *testing.T) {
+	t.Setenv("BRIG_PROFILE_DIR", t.TempDir())
+	t.Setenv("BRIG_RUNTIME", "podman")
+
+	err := run([]string{"info", "claude-code"})
+	if err == nil {
+		t.Fatal("brig info with an unknown BRIG_RUNTIME was accepted")
+	}
+	if want := `unknown BRIG_RUNTIME "podman" (want hull or nerdctl)`; !strings.Contains(err.Error(), want) {
+		t.Errorf("info error = %v, want it to name the bad value: %q", err, want)
+	}
+}

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -34,6 +34,19 @@ name for the `claude-code` profile.
 
 The first run is the slow one. In order:
 
+- **The envelope is printed.** Before anything boots, brig names the boundary
+  the run is about to trust:
+
+  ```
+  PROFILE      claude-code
+  SANDBOX      brig-claude-code (hull)
+  WORKSPACE    /Users/you/brig/claude-code (read-write)
+  IMAGE        ghcr.io/brig-sh/claude-code-stock:latest (pull missing)
+  CREDENTIALS  GH_TOKEN
+  ```
+
+  Credentials are named, never printed. `brig info claude` shows the same block
+  without starting anything, and `--quiet` drops it.
 - **The image is pulled.** The guest image comes down from the registry once.
   Later runs use the copy already on disk.
 - **The image is verified.** brig checks that the image was built by the

--- a/internal/wrap/envelope.go
+++ b/internal/wrap/envelope.go
@@ -1,0 +1,150 @@
+package wrap
+
+import (
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/brig-sh/brig/internal/creds"
+	"github.com/brig-sh/brig/internal/profile"
+)
+
+// envelopeRow is one line of the execution envelope: a label and the value
+// that sits under it. The value carries its own parenthetical detail, so the
+// renderer only has to line the labels up.
+type envelopeRow struct {
+	label string
+	value string
+}
+
+// envelope is the boundary a run is about to trust, in the order a reader
+// meets it: whose session, which profile, the sandbox and the runtime under
+// it, the directory that becomes the guest's home, the image, and the
+// credentials handed in.
+//
+// It is read from the same Config the full report reads, and the credential
+// row from the same creds.Set and resolved secrets the run itself forwards, so
+// the block and `brig info` cannot come to disagree about what a sandbox
+// received. That single source is the whole reason to route both through here
+// rather than to gather the facts a second time.
+//
+// The rows are a slice rather than a fixed set of fields because more of them
+// are coming: the isolation mechanism, the verify mode and the network posture
+// each add a row, and a slice takes one without a caller learning a new field
+// or the renderer changing. A new row appends here and nothing downstream
+// moves.
+func (c *Config) envelope(set creds.Set) []envelopeRow {
+	var rows []envelopeRow
+	// Only when named. An unnamed run has no session of its own to report, and
+	// the profile and the sandbox rows below already carry everything a bare
+	// run has to say.
+	if c.RawName != "" {
+		rows = append(rows, envelopeRow{"SESSION", c.RawName})
+	}
+	// The runtime is the one thing in the envelope that needs a runtime. brig
+	// info and brig env answer without one, marking the line unavailable the
+	// way the full report does, rather than failing the whole envelope: the
+	// person reading it is often the one whose runtime is what broke.
+	kind := "runtime unavailable"
+	if c.Runtime != nil {
+		kind = c.Runtime.Kind()
+	}
+	rows = append(rows,
+		envelopeRow{"PROFILE", c.Profile.Name},
+		envelopeRow{"SANDBOX", fmt.Sprintf("%s (%s)", c.VMName, kind)},
+		// The workspace is mounted as the guest's home, read-write. The
+		// annotation is here rather than implied so a later read-only mount has
+		// a place to say so in the row it already has, instead of needing a new
+		// one.
+		envelopeRow{"WORKSPACE", fmt.Sprintf("%s (read-write)", c.Workspace)},
+		// The pull policy, the same detail the full report prints beside the
+		// image. Whether the signature verified is a separate fact that the
+		// verify-mode row will carry, so it is deliberately not folded in here.
+		envelopeRow{"IMAGE", fmt.Sprintf("%s (pull %s)", c.Image, c.Pull)},
+		envelopeRow{"CREDENTIALS", c.credentialLine(set)},
+	)
+	return rows
+}
+
+// credentialLine is the CREDENTIALS row: every credential this run hands the
+// guest, by name, and never a value.
+//
+// A credential reaches the guest one of two ways, and the row names both so the
+// login surface is visible in one place:
+//   - as an environment variable, which creds.Set already tracks by name; and
+//   - as a file written into a tmpfs, which the profile's files: bindings
+//     declare and the resolved store fills.
+//
+// The file half is read from the same structures deliverSecretFiles writes
+// from -- the files: bindings and the resolved secret values -- so the row
+// names exactly what will be delivered rather than a separate guess at it. Only
+// the presence of a value is read, never the value itself.
+func (c *Config) credentialLine(set creds.Set) string {
+	var names []string
+	for _, n := range credentialNames(set) {
+		names = append(names, bareName(n))
+	}
+	for _, b := range c.Profile.Files {
+		// A ref this cannot read names no credential, so the row leaves it out
+		// rather than printing something the reader cannot act on. Skipping is
+		// safe in both directions: Validate refuses a malformed ref at load, for
+		// a file profile and a built-in alike, so one does not reach here; and
+		// if one ever did, writeSecretFiles fails the run on the same ref. The
+		// block under-reports and the run then stops, which is the right way
+		// round -- the opposite, naming a file as delivered when the binding
+		// naming it is unreadable, is the claim that would be false.
+		r, err := profile.ParseRef(b.Ref)
+		if err != nil {
+			continue
+		}
+		if _, ok := c.secrets.Values[r.Name]; ok {
+			names = append(names, r.Name)
+		}
+	}
+	if len(names) == 0 {
+		return "(none)"
+	}
+	return strings.Join(names, ", ")
+}
+
+// bareName drops the source annotation the full report carries -- "TOK(secret)"
+// becomes "TOK" -- because the block names credentials plainly and the detailed
+// report is where the source belongs.
+func bareName(s string) string {
+	if i := strings.LastIndex(s, "("); i > 0 && strings.HasSuffix(s, ")") {
+		return strings.TrimRight(s[:i], " ")
+	}
+	return s
+}
+
+// renderEnvelope writes the block to w, labels left-aligned to a common width
+// so the values form a column. The width is measured rather than fixed so a
+// longer label a future row introduces widens the column instead of breaking
+// the alignment.
+func (c *Config) renderEnvelope(w io.Writer, set creds.Set) {
+	rows := c.envelope(set)
+	width := 0
+	for _, r := range rows {
+		if len(r.label) > width {
+			width = len(r.label)
+		}
+	}
+	for _, r := range rows {
+		fmt.Fprintf(w, "%-*s  %s\n", width, r.label, r.value)
+	}
+}
+
+// PrintPreRunEnvelope writes the envelope before a run or create boots the
+// sandbox, to stderr. Stderr rather than stdout so it never lands in the
+// agent's own output or in the sandbox name a scripted create captures; the
+// block is a notice, not the command's result. --quiet suppresses it entirely.
+func (c *Config) PrintPreRunEnvelope(set creds.Set) { c.renderEnvelope(c.Err, set) }
+
+// Info is `brig info`: the envelope, then everything `brig env` has always
+// printed, both to stdout because here the report is the point. `brig env` is
+// kept as a deprecated spelling that calls this and prints one line naming the
+// new one.
+func (c *Config) Info(set creds.Set) {
+	c.renderEnvelope(c.Out, set)
+	c.Status(set)
+}

--- a/internal/wrap/envelope_test.go
+++ b/internal/wrap/envelope_test.go
@@ -1,0 +1,169 @@
+package wrap
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/brig-sh/brig/internal/creds"
+	"github.com/brig-sh/brig/internal/profile"
+)
+
+// envelopeConfig is a run resolved far enough to print its envelope: a named
+// session on a profile that delivers one credential as a file, with a runtime
+// that answers the one question the block asks of it.
+func envelopeConfig() *Config {
+	return &Config{
+		RawName:   "review",
+		VMName:    "brig-claude-code-review",
+		Workspace: "/Users/me/src/brig",
+		Image:     "ghcr.io/brig-sh/claude-code:latest",
+		Pull:      "missing",
+		Runtime:   fakeRuntime{},
+		Profile: profile.Profile{
+			Name: "claude-code",
+			Files: []profile.FileBinding{{
+				Ref:  "secrets.claude-credentials",
+				Path: ".claude/.credentials.json",
+				Mode: "0600",
+			}},
+		},
+		Out: &bytes.Buffer{},
+		Err: &bytes.Buffer{},
+	}
+}
+
+// The block names the boundary a run is about to trust: the session, the
+// profile, the sandbox and its runtime, the workspace, the image, and every
+// credential handed in -- the file-delivered one and the environment one alike.
+func TestEnvelopeNamesTheBoundary(t *testing.T) {
+	c := envelopeConfig()
+	c.secrets = creds.Resolution{Values: map[string]string{"claude-credentials": "sk-fixture"}}
+	var set creds.Set
+	set.Add("GH_TOKEN", "gh-fixture", "GH_TOKEN")
+
+	out := &bytes.Buffer{}
+	c.renderEnvelope(out, set)
+	got := out.String()
+
+	for _, want := range []string{
+		"SESSION      review",
+		"PROFILE      claude-code",
+		"SANDBOX      brig-claude-code-review (hull)",
+		"WORKSPACE    /Users/me/src/brig (read-write)",
+		"IMAGE        ghcr.io/brig-sh/claude-code:latest (pull missing)",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("the block does not carry %q:\n%s", want, got)
+		}
+	}
+	// Both delivery paths reach the CREDENTIALS row: the store secret written as
+	// a file, and the variable forwarded through the environment.
+	if !strings.Contains(got, "claude-credentials") || !strings.Contains(got, "GH_TOKEN") {
+		t.Errorf("the CREDENTIALS row is missing a credential:\n%s", got)
+	}
+}
+
+// An unnamed run has no session of its own, so the row is left out rather than
+// printed empty -- the profile and sandbox rows already say what a bare run is.
+func TestEnvelopeOmitsSessionWhenUnnamed(t *testing.T) {
+	c := envelopeConfig()
+	c.RawName = ""
+	out := &bytes.Buffer{}
+	c.renderEnvelope(out, creds.Set{})
+	if strings.Contains(out.String(), "SESSION") {
+		t.Errorf("an unnamed run printed a SESSION row:\n%s", out.String())
+	}
+}
+
+// A profile that forwards nothing says so, rather than trailing an empty row.
+func TestEnvelopeSaysNoneWhenNothingIsForwarded(t *testing.T) {
+	c := envelopeConfig()
+	c.Profile.Files = nil
+	out := &bytes.Buffer{}
+	c.renderEnvelope(out, creds.Set{})
+	if !strings.Contains(out.String(), "CREDENTIALS  (none)") {
+		t.Errorf("the empty credential case is not reported:\n%s", out.String())
+	}
+}
+
+// The single promise of the whole block: it names credentials, never their
+// values. The fixture value is recognisable on purpose, and it must not appear
+// in the block or in the full `brig info` report -- neither through the
+// environment set nor through the file-delivered secret whose value the row is
+// built beside.
+func TestEnvelopeNeverPrintsACredentialValue(t *testing.T) {
+	const recognisable = "sk-secret-value-do-not-print-me"
+	c := envelopeConfig()
+	c.secrets = creds.Resolution{Values: map[string]string{"claude-credentials": recognisable}}
+	var set creds.Set
+	set.AddSecret("ANTHROPIC_API_KEY", recognisable, "ANTHROPIC_API_KEY(secret)")
+
+	block := &bytes.Buffer{}
+	c.renderEnvelope(block, set)
+	if strings.Contains(block.String(), recognisable) {
+		t.Errorf("the block printed a credential value:\n%s", block.String())
+	}
+
+	// Info is the block plus the full report; the same value must not surface
+	// anywhere in it either.
+	report := &bytes.Buffer{}
+	c.Out = report
+	c.Info(set)
+	if strings.Contains(report.String(), recognisable) {
+		t.Errorf("brig info printed a credential value:\n%s", report.String())
+	}
+}
+
+// brig info and brig env answer without a runtime on PATH: the runtime is one
+// line of the report, and the person reading it is often the one whose runtime
+// is what broke. The SANDBOX row names the runtime kind, so it is the row that
+// has to say "unavailable" rather than dereference a runtime that is not there.
+func TestEnvelopeReportsWithoutARuntime(t *testing.T) {
+	c := testConfig(t, t.TempDir(), t.TempDir())
+	c.Runtime = nil
+	out := &bytes.Buffer{}
+	c.Out = out
+
+	c.renderEnvelope(out, creds.Set{})
+
+	got := out.String()
+	if !strings.Contains(got, "SANDBOX") {
+		t.Fatalf("the envelope dropped the sandbox row without a runtime:\n%s", got)
+	}
+	if !strings.Contains(got, "unavailable") {
+		t.Errorf("the sandbox row does not mark the runtime unavailable:\n%s", got)
+	}
+}
+
+// A malformed file ref cannot reach here through a loaded profile: Validate
+// refuses one at load, for a file profile and a built-in alike. If one ever
+// did, the envelope must not name a credential it cannot identify, and the run
+// must not proceed on the strength of a report that stayed quiet: writeSecretFiles
+// hard-errors on the same ref. So the contract is under-report, then fail --
+// never report a file as delivered when the binding naming it is unreadable.
+func TestEnvelopeUnderReportsAMalformedFileRefAndTheRunThenFails(t *testing.T) {
+	c := envelopeConfig()
+	c.Profile.Files = []profile.FileBinding{{
+		Ref:  "no-namespace-here",
+		Path: ".claude/.credentials.json",
+		Mode: "0600",
+	}}
+	c.secrets = creds.Resolution{Values: map[string]string{"claude-credentials": "v"}}
+
+	block := &bytes.Buffer{}
+	c.renderEnvelope(block, creds.Set{})
+
+	got := block.String()
+	if !strings.Contains(got, "CREDENTIALS  (none)") {
+		t.Errorf("the envelope named a credential it could not identify:\n%s", got)
+	}
+	if strings.Contains(got, "claude-credentials") {
+		t.Errorf("the envelope reported a file the malformed ref never named:\n%s", got)
+	}
+
+	// The other half: the run does not quietly carry on past it.
+	if err := c.writeSecretFiles(); err == nil {
+		t.Error("a malformed file ref was written rather than failing the run")
+	}
+}

--- a/script/smoke.sh
+++ b/script/smoke.sh
@@ -201,9 +201,10 @@ grep -q '^SANDBOX .*brig-claude-code' "$WORK/run.err" \
   || bad "run prints the execution envelope: $(cat "$WORK/run.err")"
 grep -q '^WORKSPACE ' "$WORK/run.err" \
   && ok "the envelope names the workspace" || bad "the envelope names the workspace"
-# A value must never reach the block, the same promise argv keeps.
-grep '^SANDBOX \|^WORKSPACE \|^IMAGE \|^CREDENTIALS ' "$WORK/run.err" \
-  | grep -q 'env-token-secret\|gh-secret\|host-token' \
+# A value must never reach the block, the same promise argv keeps. Scan the
+# whole envelope output rather than a fixed list of rows, so a row added later
+# is covered without touching this check.
+grep -q 'env-token-secret\|gh-secret\|host-token' "$WORK/run.err" \
   && bad "the envelope printed a credential value" \
   || ok "the envelope names credentials, never values"
 

--- a/script/smoke.sh
+++ b/script/smoke.sh
@@ -192,6 +192,28 @@ grep -q -- "--shared-dir $WS:/home/claude" "$STUB_LOG" \
 grep -q -- '-- claude -p hi' "$STUB_LOG" \
   && ok "agent arguments pass through" || bad "agent arguments pass through"
 
+echo "== envelope =="
+# The block is a notice, printed to stderr so it never pollutes the agent's
+# stdout or a scripted create's sandbox name. It names the boundary before the
+# boot noise.
+grep -q '^SANDBOX .*brig-claude-code' "$WORK/run.err" \
+  && ok "run prints the execution envelope" \
+  || bad "run prints the execution envelope: $(cat "$WORK/run.err")"
+grep -q '^WORKSPACE ' "$WORK/run.err" \
+  && ok "the envelope names the workspace" || bad "the envelope names the workspace"
+# A value must never reach the block, the same promise argv keeps.
+grep '^SANDBOX \|^WORKSPACE \|^IMAGE \|^CREDENTIALS ' "$WORK/run.err" \
+  | grep -q 'env-token-secret\|gh-secret\|host-token' \
+  && bad "the envelope printed a credential value" \
+  || ok "the envelope names credentials, never values"
+
+# --quiet drops the block and changes nothing else about the run.
+: > "$STUB_LOG"
+CLAUDE_CODE_OAUTH_TOKEN=env-token-secret GH_TOKEN=gh-secret \
+  "$WORK/brig" run claude --quiet -p hi > /dev/null 2> "$WORK/quiet.err"
+grep -q '^SANDBOX ' "$WORK/quiet.err" \
+  && bad "--quiet still printed the envelope" || ok "--quiet suppresses the envelope"
+
 echo "== workspace =="
 [ -f "$WS/.claude.json" ] && ok "onboarding is seeded" || bad "onboarding is seeded"
 grep -q hasCompletedOnboarding "$WS/.claude.json" \
@@ -247,6 +269,42 @@ case "$out" in
   *) bad "the failure names the import that replaces it -- got: $out" ;;
 esac
 
+echo "== info =="
+# The full report: the envelope, then everything env has always printed.
+"$WORK/brig" info claude > "$WORK/info.out" 2> "$WORK/info.err"
+grep -q '^SANDBOX .*brig-claude-code' "$WORK/info.out" \
+  && ok "info prints the envelope" || bad "info prints the envelope: $(cat "$WORK/info.out")"
+grep -q 'forwarding' "$WORK/info.out" \
+  && ok "info prints the full report too" || bad "info prints the full report: $(cat "$WORK/info.out")"
+grep -q 'is now `brig info`' "$WORK/info.err" \
+  && bad "info printed a deprecation line about itself" || ok "info is not deprecated"
+
+# info is the preview of what a run is about to trust, so the envelope it shows
+# has to be the envelope the run prints. Compare the rows themselves rather than
+# one grep each: a row that drifts between the preview and the run makes the
+# preview a claim about a boundary nobody is going to use.
+"$WORK/brig" run claude -d > "$WORK/runenv.out" 2>&1
+"$WORK/brig" reset > /dev/null 2>&1
+envelope_rows() { grep -E '^(SESSION|PROFILE|SANDBOX|WORKSPACE|IMAGE|CREDENTIALS) ' "$1"; }
+envelope_rows "$WORK/info.out" > "$WORK/rows.info"
+envelope_rows "$WORK/runenv.out" > "$WORK/rows.run"
+[ -s "$WORK/rows.info" ] \
+  && ok "the info envelope has rows to compare" \
+  || bad "the info envelope has rows to compare: $(cat "$WORK/info.out")"
+if diff -q "$WORK/rows.info" "$WORK/rows.run" > /dev/null 2>&1; then
+  ok "info shows the same envelope the run prints"
+else
+  bad "info and run disagree about the envelope:
+$(diff "$WORK/rows.info" "$WORK/rows.run")"
+fi
+
+# env is the old spelling: the same output plus one line naming the new one.
+"$WORK/brig" env claude > "$WORK/env.out" 2> "$WORK/env.err"
+grep -q 'is now `brig info`' "$WORK/env.err" \
+  && ok "env names the new spelling" || bad "env names the new spelling: $(cat "$WORK/env.err")"
+grep -q '^SANDBOX .*brig-claude-code' "$WORK/env.out" \
+  && ok "env still prints the report" || bad "env still prints the report: $(cat "$WORK/env.out")"
+
 echo "== named session =="
 : > "$STUB_LOG"
 "$WORK/brig" run claude --name 'My Big Refactor' -p hi > /dev/null 2>&1
@@ -269,11 +327,21 @@ grep -q 'CLAUDE_CODE_OAUTH_TOKEN' "$STUB_LOG" \
 
 echo "== lifecycle verbs =="
 : > "$STUB_LOG"
-out="$("$WORK/brig" create claude 2>/dev/null)"
+out="$("$WORK/brig" create claude 2>"$WORK/create.err")"
 [ "$out" = brig-claude-code ] && ok "create prints the sandbox name" \
   || bad "create prints the sandbox name -- got '$out'"
+# The envelope is on stderr, so the scriptable name on stdout stays clean.
+grep -q '^SANDBOX .*brig-claude-code' "$WORK/create.err" \
+  && ok "create prints the execution envelope" \
+  || bad "create prints the execution envelope: $(cat "$WORK/create.err")"
 grep -q -- '-- claude' "$STUB_LOG" \
   && bad "create started the agent" || ok "create starts the sandbox, not the agent"
+
+# exec and shell attach to a sandbox whose envelope the user already saw, so
+# they do not repeat it. The sandbox created just above is still running.
+"$WORK/brig" exec claude -- true > /dev/null 2>"$WORK/exec.err"
+grep -q '^SANDBOX ' "$WORK/exec.err" \
+  && bad "exec printed the envelope" || ok "exec does not print the envelope"
 
 listing="$("$WORK/brig" ls 2>/dev/null)"
 case "$listing" in
@@ -424,6 +492,15 @@ echo "== no runtime =="
 # exit 0: the person most likely to run them is the one whose runtime is broken.
 out="$(PATH="" BRIG_RUNTIME_BIN= "$WORK/brig" env claude 2>&1)"; rc=$?
 [ "$rc" = 0 ] && ok "env with no runtime exits 0" || bad "env with no runtime exits 0 -- got $rc: $out"
+# info is the new spelling of the same report, so it degrades the same way. A
+# recommended spelling that failed where the deprecated one worked would send
+# the person whose runtime is broken to the wrong command.
+out="$(PATH="" BRIG_RUNTIME_BIN= "$WORK/brig" info claude 2>&1)"; rc=$?
+[ "$rc" = 0 ] && ok "info with no runtime exits 0" || bad "info with no runtime exits 0 -- got $rc: $out"
+case "$out" in
+  *"runtime unavailable"*) ok "the envelope marks the runtime unavailable" ;;
+  *) bad "the envelope marks the runtime unavailable -- got: $out" ;;
+esac
 case "$out" in
   *"runtime unavailable"*) ok "env marks the runtime line unavailable" ;;
   *) bad "env marks the runtime line unavailable -- got: $out" ;;
@@ -763,10 +840,12 @@ export BRIG_HYPERVISOR=vz
 
 echo "== shell =="
 : > "$STUB_LOG"
-"$WORK/brig" shell claude echo hi there > /dev/null 2>&1
+"$WORK/brig" shell claude echo hi there > /dev/null 2>"$WORK/shell.err"
 grep -q -- '-- bash -lc echo hi there' "$STUB_LOG" \
   && ok "a trailing command reaches bash as one argument" \
   || bad "a trailing command reaches bash as one argument"
+grep -q '^SANDBOX ' "$WORK/shell.err" \
+  && bad "shell printed the envelope" || ok "shell does not print the envelope"
 
 [ "$fail" = 0 ] && echo PASS || echo FAILURES
 exit "$fail"


### PR DESCRIPTION
## Summary

`brig run` started an agent without saying what boundary the user was about to
trust. The facts already existed, since the status path reports the workspace,
the sandbox, the runtime, the image, the pull policy and the forwarded
credential names, but only `brig env` printed them, and people run `brig env`
after something has already gone wrong.

This prints a short block before the agent starts, and adds a verb for the full
report. The name is part of the fix: the bug report template told reporters to
run `brig status`, which is not a command.

The verb is `brig info`, not `brig inspect` as #10 proposes. #47 settles on
`info`, so shipping `inspect` now would mean renaming it again in one release.

## Related issues

Closes #10
Refs #47

## Changes

- New `internal/wrap/envelope.go` builds the block from the same `Config` and
  `creds.Set` the full report and the run itself use, so the two cannot come to
  disagree about what a sandbox received.
- Rows are a slice rather than fixed fields. The isolation mechanism, the verify
  mode and the network posture each add a row later, and a slice takes one
  without the renderer or any caller changing.
- The block prints on `run` and `create`, not on `exec` or `shell`, which attach
  to a sandbox the user already saw a block for. It goes to stderr, leaving
  stdout to the agent.
- `brig info <profile>` prints the full report. `brig env` stays for one release
  as a deprecated alias and prints the line naming the new spelling.
- `-q`, `--quiet` suppresses the block and changes nothing else about the run.
- `.github/ISSUE_TEMPLATE/bug_report.md` now names commands that exist.
- Tests: the block names the boundary, omits the session row when unnamed, says
  none when nothing is forwarded, and never prints a credential value. Smoke
  gains end-to-end assertions including a grep for a fixture value.

## Checklist

- [x] `make all` passes (vet, test, build)
- [x] `script/smoke.sh` passes
- [x] I have added or updated tests covering the change
- [x] I have run `go test ./... -race`, if the change touches concurrency, subprocesses or the daemon
- [x] I have exercised the change against a real runtime (`brig run <agent>`), if it touches the run, exec or credential path
- [x] I have updated the affected docs (README, `docs/security.md`, `docs/profiles.md`, `docs/brigd.md`)

No run against a real runtime. The block is printed on the run path and its
contents come from the credential set, so it is worth seeing once against a real
sandbox before merge, particularly the CREDENTIALS row with a real store.

One deviation from the issue worth a decision. The issue's example shows
`IMAGE ... (verified)`. This ships `IMAGE ... (pull missing)` instead, on the
grounds that whether a signature verified is a separate fact belonging to the
verify-mode row that #29 adds, so folding it in now means #29 restructures. The
consequence is that the block currently says nothing about verification, which
is fine if #29 follows soon and a gap if it does not.

## Credentials and the sandbox boundary

This touches the second promise by reporting on it: the CREDENTIALS row names
every credential a run hands the guest, both the environment-variable half and
the file half written into the tmpfs, and never a value.

`TestEnvelopeNeverPrintsACredentialValue` is the assertion that matters, and
`script/smoke.sh` repeats it end to end by grepping the real binary's output for
a fixture value that would be recognisable if it leaked.
