### PR TITLE
docs: scope the absolute safety claims in README and help

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,11 @@
   </picture>
 </p>
 
-**Run a coding agent in a sandbox it cannot escape, with the credentials it
-needs and none of the ones it does not.**
+**Run a coding agent in a sandbox where one directory is its whole world and
+the rest of the host is out of reach from inside it.** It boots with no
+credential at all, which is what keeps trying it cheap: log in inside the
+sandbox and that login lives in memory, so `brig stop` takes it with the VM and
+the next run asks again.
 
 ## TL;DR
 
@@ -19,8 +22,9 @@ brig run claude               # boots a sandbox, starts Claude Code in it
 ```
 
 Put the projects the agent should work on in `~/brig/claude-code`. That
-directory is the agent's entire world; the rest of your machine is invisible
-to it. The sandbox stays up between commands, so the second `brig run` is
+directory is the agent's entire world; no other directory on your machine is
+mounted into it, and it cannot reach your keychain, SSH agent or secret
+manager. The sandbox stays up between commands, so the second `brig run` is
 immediate.
 
 <details>
@@ -88,8 +92,10 @@ no concept of:
   *is* the isolation boundary -- so brig resolves credentials on the host and
   passes them in. Only from its own store, and only what a profile names: you
   say once that a host login may enter a sandbox (`brig secret import`), and a
-  run never reads another application's keychain. Never written into the
-  workspace, and never placed in a command line where `ps` could read it.
+  run on a shipped profile never reads another application's keychain. A
+  profile of your own still carrying the deprecated `hostCredential:` is the
+  exception, and reads the host item it names on every run. Never written into
+  the workspace, and never placed in a command line where `ps` could read it.
 - **A billing denylist.** `ANTHROPIC_API_KEY` outranks the OAuth token in
   Claude Code's own precedence, so forwarding it would move a sandbox from
   your subscription onto metered API billing without saying so. It is refused
@@ -225,9 +231,11 @@ copy in your keyring and writes it back in on every boot. If you log in inside
 the sandbox on a host that has no login of its own, expect to repeat it.
 
 `import` reads your host login **once, when you type it**, and copies it into
-brig's own store. Every run after that reads only that store. brig never opens
-another application's keychain item on the run path, so a run raises no
-approval dialog and performs no host read you did not ask for.
+brig's own store. Every run after that reads only that store. On a shipped
+profile brig never opens another application's keychain item on the run path,
+so a run raises no approval dialog and performs no host read you did not ask
+for. A profile of your own still on the deprecated `hostCredential:` is the
+exception: it reads the host item it names on every run.
 
 The copy is a copy: renewing or revoking the login on the host does not change
 it. Run `brig secret import claude-code` again to refresh it, or
@@ -382,8 +390,12 @@ The README is the overview. The details live in [docs/](docs/):
 
 ## Custom agents and your own images
 
-Any Linux CLI in an OCI image already runs under brig. A profile just saves
-you spelling out the image, the guest home and the credential variables every
+Any Linux CLI in an OCI image runs under brig, as long as the image also
+carries the few utilities brig uses to set the sandbox up and deliver the
+credential: a shell (`sh` and `bash`), plus `cat`, `stat`, `chown`, `mkdir`,
+`mount` and `/bin/true`. A stock distribution image has them; a `FROM scratch`
+image holding only your static binary does not. A profile just saves you
+spelling out the image, the guest home and the credential variables every
 time:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -215,12 +215,14 @@ brig run claude-code               # log in inside the sandbox, or:
 brig secret import claude-code     # carry the login already on this Mac in, once
 ```
 
-That in-sandbox login lasts as long as the sandbox does. It is written inside
-`~/.claude`, which is memory-only so that no credential reaches host disk, so
-`brig stop` takes it with the rest of the VM and the next `brig run` asks
-again. Importing is what makes a login outlive a stop: brig keeps that copy in
-your keyring and writes it back in on every boot. If you log in inside the
-sandbox on a host that has no login of its own, expect to repeat it.
+That in-sandbox login lasts as long as the sandbox does. It is written to
+`~/.claude/.credentials.json`, which sits on a memory-backed mount and never
+reaches host disk, so `brig stop` takes it with the rest of the VM and the next
+`brig run` asks again. Other paths under `~/.claude` do reach host disk by
+design; [docs/security.md](docs/security.md#what-reaches-host-disk) names them
+and says why. Importing is what makes a login outlive a stop: brig keeps that
+copy in your keyring and writes it back in on every boot. If you log in inside
+the sandbox on a host that has no login of its own, expect to repeat it.
 
 `import` reads your host login **once, when you type it**, and copies it into
 brig's own store. Every run after that reads only that store. brig never opens

--- a/cmd/brig/main.go
+++ b/cmd/brig/main.go
@@ -68,10 +68,13 @@ flags (before the agent's own arguments; -- ends brig's parsing):
 Workspaces persist. The sandbox keeps running between commands, so a second
 run is immediate; state lives in the workspace on the host either way.
 
-Any Linux CLI in an OCI image already runs under brig. A profile just saves you
-spelling out the image and its credential variables every time: export the
-closest one, edit it, import it back. Building an image for one is documented
-at
+Any Linux CLI in an OCI image runs under brig, if the image also carries the
+utilities brig uses to set the sandbox up and deliver the credential: a shell
+(sh and bash), plus cat, stat, chown, mkdir, mount and /bin/true. A stock
+distro image has them; a scratch image with only your binary does not. A
+profile just saves you spelling out the image and its credential variables
+every time: export the closest one, edit it, import it back. Building an image
+for one is documented at
   https://github.com/brig-sh/community-images/blob/main/docs/bring-your-own-image.md
 
 settings (BRIG_<AGENT>_<KEY> wins over BRIG_<KEY>; see the README for all):

--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -13,9 +13,10 @@ brig run claude-code               # log in inside the sandbox, or:
 brig secret import claude-code     # carry your host login in, once
 ```
 
-The first of those does not persist: an in-sandbox login is written inside the
-memory-only `~/.claude`, which is what keeps credentials off host disk, so it
-dies with the sandbox on `brig stop`. Importing is what survives a stop.
+The first of those does not persist: an in-sandbox login is written to
+`~/.claude/.credentials.json` on a memory-backed mount, which is what keeps that
+credential off host disk, so it dies with the sandbox on `brig stop`. Importing
+is what survives a stop.
 
 If you keep credentials in 1Password, Vault or `pass`, you have two roads.
 Either pipe the value in once (`op read ... | brig secret create <name>`, or

--- a/docs/security.md
+++ b/docs/security.md
@@ -134,6 +134,29 @@ prints a value: a secret-sourced variable comes back annotated, e.g.
 `GH_TOKEN(secret)`, never with the value itself. A credential delivered as a
 file is not an environment variable and does not appear in that list at all.
 
+### What reaches host disk
+
+The credential file is the part that does not. It lands on a `tmpfs` mount
+covering `~/.claude`, checked to be `tmpfs` with no swap before anything is
+written, so `~/.claude/.credentials.json` and the temp file the agent renames
+onto it never touch your disk. `brig stop` takes that mount with the VM, which
+is why an in-sandbox login does not outlive a stop.
+
+The rest of `~/.claude` is not on that mount. Seven paths under it are
+hostmounted, so they live in the workspace on host disk and persist across
+boots:
+
+- `settings.json` and `CLAUDE.md`, your permission allowlist and your
+  user-level memory, written by hand or by the agent on your instruction.
+- `sessions`, `projects` and `history.jsonl`, which are the conversation.
+- `plugins` and `skills`, which are also where `--skills` copies your own, so
+  leaving either off would make that flag do nothing.
+
+Anything else under `~/.claude` is ephemeral, including anything a future
+Claude Code version starts writing there. This list is the `volumes:` block of
+the `claude-code` profile, which is the source it follows rather than a
+restatement that can drift from it.
+
 ### Not in argv
 
 Forwarded values go into the runtime process's own environment, and only the


### PR DESCRIPTION
## Summary

`docs/security.md` opens by saying some of the boundary is weaker than it looks
and that writing that down beats letting someone find out later. The README then
opened with a sandbox the agent cannot escape, which that page retracts in five
places. A reader who reads both concludes the headline was written for people
who would not reach page two, and that costs more than the headline buys.

Two commits, one per issue. Neither weakens a claim that is true: in each case a
narrower version exists and is still strong, and the narrower version is what is
written here. Every non-claim in `docs/security.md` is untouched.

## Related issues

Closes #32
Closes #33

## Changes

Memory-only (`fdd029c`):

- `~/.claude` is not memory-only. The credential file is on a memory-backed
  mount and never reaches host disk; seven paths under the directory are
  hostmounted into the workspace by design and do. The claim now names the file
  rather than the directory, and `docs/security.md` gains a section naming the
  paths that reach disk and why.

Absolute claims (`bec1917`):

- The headline leads with the boundary, which is falsifiable: one directory is
  the agent's whole world and the rest of the host is out of reach from inside
  it. The next sentence covers booting with no credential, and prices it in the
  same paragraph rather than further down.
- "The rest of your machine is invisible to it" becomes the specific version: no
  other directory is mounted in, and the guest cannot reach the keychain, SSH
  agent or secret manager.
- The keychain claim is scoped to shipped profiles. A profile carrying the
  deprecated `hostCredential:` reads the host item it names on every run, and
  that exception is now stated in both places the claim appears.
- "Any Linux CLI in an OCI image already runs under brig" now names the
  utilities the guest must carry. The same correction is applied to the CLI help
  text, which is a published surface too.

## Checklist

- [x] `make all` passes (vet, test, build)
- [x] `script/smoke.sh` passes
- [ ] ~~I have added or updated tests covering the change~~
- [ ] ~~I have run `go test ./... -race`, if the change touches concurrency, subprocesses or the daemon~~
- [ ] ~~I have exercised the change against a real runtime (`brig run <agent>`), if it touches the run, exec or credential path~~
- [x] I have updated the affected docs (README, `docs/security.md`, `docs/profiles.md`, `docs/brigd.md`)

**One known gap, worth fixing before merge.** The guest utility list is
incomplete: it names `sh`, `bash`, `cat`, `stat`, `chown`, `mkdir`, `mount` and
`/bin/true`, and misses `sleep`. The nerdctl path runs `sleep infinity` as the
container command, so a Linux guest without it fails. Publishing an incomplete
list is the same class of error this PR exists to fix, so it should be a one
line edit here rather than a follow-up.

## Credentials and the sandbox boundary

No behaviour changes. This changes what the project claims about both promises,
in the direction of what the code actually does.

The memory-only correction is the load-bearing one: the previous wording implied
that nothing under `~/.claude` reached host disk, which is not true and was not
true when it was written. Someone deciding whether to import a login was reading
a stronger guarantee than they were getting. The credential file guarantee holds
and is now stated on its own terms.
