### PR TITLE
docs(security): add SECURITY.md and a private report channel

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -293,6 +293,12 @@ on drafts. Check each repository's docs for the labels it supports.
 We use issues to track bugs and feature requests, and to anchor PRs to a
 discussion.
 
+**A security vulnerability is not a public issue.** brig handles credentials,
+so a flaw in how it does that should reach the maintainers privately before it
+reaches everyone else. Do not open an issue or a pull request for one: follow
+[SECURITY.md](SECURITY.md), which routes it through GitHub's private
+vulnerability reporting instead. The rest of this section is for ordinary bugs.
+
 When reporting a bug, please include:
 
 - A short, clear description of the problem.

--- a/README.md
+++ b/README.md
@@ -378,6 +378,9 @@ The README is the overview. The details live in [docs/](docs/):
 - [security.md](docs/security.md) -- what the boundary is, and what it is not
 - [brigd.md](docs/brigd.md) -- the session daemon and its protocol
 
+Found a security problem? [SECURITY.md](SECURITY.md) is how to report it
+privately, rather than in a public issue.
+
 ## Custom agents and your own images
 
 Any Linux CLI in an OCI image already runs under brig. A profile just saves

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,75 @@
+# Security policy
+
+brig exists to hold a boundary. An agent gets one directory and the credentials
+it was named, and nothing else on the host. Anything that weakens that boundary,
+or that reaches something the agent was never given, belongs here rather than in
+a public issue.
+
+Tell us privately first and we will fix it with you before it is public. If you
+are unsure whether something counts, report it and we will work that out with
+you.
+
+## Supported versions
+
+There is no stable release yet. brig ships prereleases only, currently the
+`0.1.0-rc` series, and the version you are on is whatever `brig version`
+prints. Fixes land on `main` and go out in the next prerelease. We do not
+backport to an earlier `rc`, so the supported version is the latest one: if you
+are reporting against an older prerelease, please check that the issue still
+reproduces on the newest before you send it, and expect the fix to arrive as a
+newer prerelease rather than a patch to the one you filed against.
+
+## Reporting a vulnerability
+
+Use GitHub's private vulnerability reporting. Open the advisory page and press
+**Report a vulnerability**:
+
+https://github.com/brig-sh/brig/security/advisories
+
+That opens a private thread visible only to you and the maintainers, so nothing
+is disclosed while we work on a fix. Please do not open a public issue for a
+security problem, and do not send a pull request that reveals the flaw before an
+advisory exists.
+
+If you would rather use email, write to **security@brig.sh** instead. Both reach
+the same people.
+
+Include what you would want if you were fixing it: the version from
+`brig version`, the operating system and runtime (hull on macOS, nerdctl or
+runc on Linux), what you did, what happened, and what you expected instead. A
+proof of concept helps, even a rough one.
+
+## What to expect
+
+- **First response within 3 working days.** That is an acknowledgement from a
+  human that the report arrived and is being looked at, not a fix.
+- **A disclosure window of 90 days.** We aim to have a fix released and an
+  advisory published within 90 days of the report. If it takes longer we will
+  say so in the thread and agree a new date with you rather than let it lapse
+  silently. If a fix ships sooner, the advisory goes out sooner. We are happy to
+  credit you in the advisory, or to leave you out of it, whichever you prefer.
+
+These are targets a small project can meet, not a contract. If you have not heard
+back inside the response window, send a reminder to security@brig.sh.
+
+## Scope
+
+In scope is anything that breaks a promise brig actually makes: a run that
+reaches a host credential it was not given or a file outside the workspace, a
+credential that leaks off the intended channel, the secret store handing back an
+item it should not, image verification passing something it should reject, or a
+tampered release verifying as genuine. `CONTRIBUTING.md` calls the first two the
+two promises, and `docs/security.md` is where the exact edges of all of them are
+written down.
+
+Out of scope are the limitations brig already declares. `docs/security.md` lists
+them under
+[Things brig does not claim](docs/security.md#things-brig-does-not-claim): brig
+does not sandbox the agent from the network, does not isolate one sandbox from
+another, does not filter terminal escape sequences the agent writes, and does
+not stop an agent misusing a credential it was deliberately handed. A report
+that brig does one of those is describing a known limitation, not a
+vulnerability. That page is the authority on the boundary, so we point at it
+here rather than restate it, which keeps the two from drifting apart. If you
+think one of those limitations is worse than the page admits, or the page is
+wrong about where a line sits, that is worth a report.

--- a/docs/security.md
+++ b/docs/security.md
@@ -8,6 +8,11 @@ to give it, and nothing else on the host.
 This page is about where that boundary actually is. Some of it is weaker than
 it looks, and we would rather write that down than let someone find out later.
 
+If you have found a flaw in one of these boundaries, [SECURITY.md](../SECURITY.md)
+is how to report it privately. The section below on
+[things brig does not claim](#things-brig-does-not-claim) is the line between a
+vulnerability and a known limitation.
+
 ## The boundary
 
 The sandbox is a microVM on both. On macOS it is booted by


### PR DESCRIPTION
## Summary

There was no security policy and no private channel for reporting a flaw, so the
only route was a public issue. brig stores an OAuth refresh token and writes it
into a guest by design, so a report about that path should reach the maintainers
before it reaches everyone else.

The scope section defers to the existing list of non-claims in
`docs/security.md` rather than restating it, so the line between a vulnerability
and a known limitation lives in one place and the two cannot drift apart.

## Related issues

Closes #34

## Changes

- `SECURITY.md` at the repository root: supported versions written against the
  prerelease-only reality rather than an invented support table, private
  reporting through GitHub as the primary channel, a first response target of
  three working days and a ninety day disclosure window, and a scope section
  pointing at the non-claims already documented.
- Linked from `README.md`, from `docs/security.md`, and from `CONTRIBUTING.md`,
  whose Issues section now routes a security report to the private channel
  rather than the tracker.

## Checklist

- [x] `make all` passes (vet, test, build)
- [x] `script/smoke.sh` passes
- [ ] ~~I have added or updated tests covering the change~~
- [ ] ~~I have run `go test ./... -race`, if the change touches concurrency, subprocesses or the daemon~~
- [ ] ~~I have exercised the change against a real runtime (`brig run <agent>`), if it touches the run, exec or credential path~~
- [x] I have updated the affected docs (README, `docs/security.md`, `docs/profiles.md`, `docs/brigd.md`)

**One thing needs a maintainer.** Private vulnerability reporting is a
repository setting, not a file, and it has to be enabled under Settings for the
Report a vulnerability button to appear. `security@brig.sh` works either way, so
the document is usable before that lands.

## Credentials and the sandbox boundary

No behaviour changes. This is the reporting path for a flaw in either promise,
which is the thing that was missing: the tool holds a refresh token and hands it
to a guest, and there was nowhere to report a problem with that privately.

