### PR TITLE
feat(verify): verify the digest that boots, not the tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,10 +346,18 @@ third-party images included. `BRIG_VERIFY=off` skips the check.
 [docs/security.md](docs/security.md) explains the reasoning, and what brig does
 not protect you from.
 
-Two limitations worth knowing: under the default `missing` pull policy cosign
-verifies the tag in the registry, not necessarily the copy already in your
-local store; and `claude-desktop` and `ubuntu` still point at
-`ghcr.io/nofireai/` images, so they warn on every boot until those move.
+For an image under `ghcr.io/brig-sh/`, brig resolves the tag to a digest,
+verifies that digest, and boots it, so the image it checked is the image that
+runs and the line saying so names the digest. If the registry cannot be reached
+the boot stops and asks, as it does for a bad signature. Images brig did not
+publish boot by tag with no registry round trip, as before. Pinning needs a
+runtime whose store answers a digest: containerd on Linux, and hull from
+0.1.0-rc23 on macOS. An older hull cannot, so brig verifies and boots the
+tag there and says so; under the default `missing` pull policy that check is of
+the tag in the registry, not necessarily the copy already in your store, and
+`BRIG_PULL=always` is the workaround until you upgrade. `claude-desktop` and
+`ubuntu` still point at `ghcr.io/nofireai/` images, so they warn on every boot
+until those move.
 
 ### Image tags
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -399,11 +399,46 @@ setting falls back to `warn` rather than silently disabling it.
 Point `BRIG_VERIFY_REGISTRY`, `BRIG_VERIFY_IDENTITY` and `BRIG_VERIFY_ISSUER`
 at your own registry and workflow if you publish signed images yourself.
 
-### Two limitations
+### The digest, not the tag
 
-Under the default `missing` pull policy, cosign verifies the tag in the
-registry, not necessarily the copy already in your local store. Use
-`BRIG_PULL=always` when that distinction matters to you.
+A tag is a name, and a name can resolve to different bytes in the registry and
+in your local store. The provenance claim is about the bytes that run, so brig
+resolves the reference to the digest the registry serves before the check,
+verifies that digest, and boots it. The object cosign checked is the object that
+runs, and the success line names the digest rather than the tag it came from. A
+local store holding a different digest under the tag is treated as the
+signature-failure row above: it stops, and a yes boots the verified digest
+rather than the copy on disk. A registry that cannot be reached stops in the
+same way, because one of our images could not be checked, and a network
+failure must not be what turns the default mode into "unchecked";
+`BRIG_VERIFY=require` refuses outright. Every cosign call is bounded, so an
+outage fails in seconds rather than hanging the boot.
+
+All of this is for images under `ghcr.io/brig-sh/`. An image brig did not
+publish carries no signature of ours to check, so brig makes no cosign call for
+it at all: it boots by tag, as it always has, with the one line saying whose
+image it is. Resolving a digest for it would cost a registry round trip on every
+boot and buy a pin brig cannot vouch for.
+
+This holds wherever the runtime's store answers a digest: containerd on Linux,
+and hull from 0.1.0-rc23 on macOS. brig asks the hull it is driving rather than
+assuming, because the one on PATH may be older than brig. An older hull cannot
+find a digest reference in its store, so a pinned boot there would re-pull on
+every run and fail outright under `BRIG_PULL=never` with the bytes on disk.
+brig therefore verifies and boots the tag on such a hull, prints one line
+saying so, and the gap remains there until you upgrade: under the default
+`missing` pull policy cosign checks the tag in the registry, not necessarily
+the copy hull already holds, and `BRIG_PULL=always` is the workaround. brig
+never prints the digest-named line on a boot that did not pin a digest, so the
+message never claims more than the runtime delivered.
+
+Two things are still narrower on macOS than on Linux. An image pulled under an
+older hull has no index digest on record, and a multi-arch tag resolves to its
+index digest, so the first pinned boot of such an image after upgrading hull
+misses the cache and pulls once; under `BRIG_PULL=never` it fails until the
+image is pulled again. And hull does not yet expose the digest its store holds
+for a reference, so the report that the local copy differs from what the
+registry serves is Linux-only for now. The boot is pinned either way.
 
 `claude-desktop` and `ubuntu` still point at `ghcr.io/nofireai` images, which
 brig has no signing policy for, so they warn on every boot until those images

--- a/internal/runtime/hull.go
+++ b/internal/runtime/hull.go
@@ -8,12 +8,20 @@ import (
 	"os/exec"
 	"strconv"
 	"strings"
+	"sync"
 	"syscall"
 	"time"
 )
 
 // hull drives the macOS microVM runtime.
-type hull struct{ bin string }
+type hull struct {
+	bin string
+	// pins caches the one question PinsDigest asks the binary, because the
+	// verify path may ask more than once per run and the answer cannot change
+	// while brig is running.
+	pinsOnce sync.Once
+	pins     bool
+}
 
 func newHull(bin string) (Runtime, error) {
 	if bin != "" {
@@ -29,6 +37,98 @@ func newHull(bin string) (Runtime, error) {
 
 func (h *hull) Kind() string { return "hull" }
 func (h *hull) Bin() string  { return h.bin }
+
+// PinsDigest asks the hull on this machine whether it can boot a digest
+// reference from its own store, which it can from 0.1.0-rc23. Before that a
+// repo@sha256:... boot missed the cache and re-pulled every run, and failed
+// outright under --pull=never with the bytes on disk, so brig verified and
+// booted the tag there and said so rather than claim a pin it did not make.
+//
+// The binary is asked, not a build-time constant, because the hull brig drives
+// is whatever is on PATH or in BRIG_RUNTIME_BIN, and it may be older than brig.
+// See hullVersionPinsDigest for how the answer is read and why an unreadable
+// one pins.
+//
+// One thing to know when upgrading: an image pulled under an older hull has no
+// index digest on record, and a multi-arch tag resolves to its index digest,
+// so the first pinned boot of such an image misses the cache and pulls once.
+// From then on the store answers. Under --pull=never that first boot fails
+// until the image is pulled again.
+func (h *hull) PinsDigest() bool {
+	h.pinsOnce.Do(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		cmd := exec.CommandContext(ctx, h.bin, "--version")
+		cmd.Env = mergeEnv(telemetryEnv(false))
+		out, _ := cmd.Output()
+		h.pins = hullVersionPinsDigest(string(out))
+	})
+	return h.pins
+}
+
+// LocalDigest answers "" on hull, which the verify path reads as "cannot say"
+// and raises no mismatch over. The boot is still pinned; what is missing is
+// the report that the copy on disk differs from what the registry serves.
+//
+// It cannot answer yet because hull exposes nothing brig could compare: `hull
+// images` prints a truncated manifest digest and no index digest, and a
+// multi-arch tag resolves to its index digest, which is a different object
+// from the per-platform manifest the store is keyed by. Handing back the
+// manifest digest would make every multi-arch image look like a mismatch and
+// stop a first-party boot with a prompt for nothing. Silence is the honest
+// answer until hull prints the index digest it recorded.
+func (h *hull) LocalDigest(string) (string, error) { return "", nil }
+
+// hullVersionPinsDigest reads `hull --version` and reports whether that hull
+// resolves a digest reference against its own store.
+//
+// Before 0.1.0-rc23 the store lookup compared the reference as a string, so a
+// repo@sha256:... boot missed the cache and re-pulled every run, and failed
+// outright under --pull=never with the bytes on disk. From rc23 the lookup
+// parses the reference and answers a digest, the index digest included, so a
+// pinned boot finds its bytes.
+//
+// Anything that does not read as a version is a build from source, and it
+// pins. A wrong guess in that direction costs a re-pull, never a weaker check:
+// a digest the store cannot answer is fetched from the registry, and that is
+// the verified bytes either way. A wrong guess the other way would silently
+// leave a capable hull on the tag, which is the outcome this function exists
+// to avoid.
+func hullVersionPinsDigest(out string) bool {
+	fields := strings.Fields(out)
+	if len(fields) == 0 {
+		return true
+	}
+	base, pre, _ := strings.Cut(fields[len(fields)-1], "-")
+	parts := strings.Split(base, ".")
+	if len(parts) != 3 {
+		return true
+	}
+	var v [3]int
+	for i, p := range parts {
+		n, err := strconv.Atoi(p)
+		if err != nil {
+			return true
+		}
+		v[i] = n
+	}
+	switch {
+	case v[0] > 0 || v[1] > 1 || (v[1] == 1 && v[2] > 0):
+		return true // past 0.1.0 altogether
+	case v[0] == 0 && v[1] == 1 && v[2] == 0:
+		if pre == "" {
+			return true // 0.1.0 final
+		}
+		rc, ok := strings.CutPrefix(pre, "rc")
+		if !ok {
+			return true
+		}
+		n, err := strconv.Atoi(rc)
+		return err != nil || n >= 23
+	default:
+		return false // 0.0.x, which never shipped a digest-aware store
+	}
+}
 
 // hypervisor is vz because that is the backend with a graphical console, a
 // virtiofs share per directory and the notarised runner. A profile names
@@ -242,7 +342,9 @@ func runArgs(spec RunSpec, hv, net, gatewaySock, gatewayCidr string, locate asse
 	}
 	envArgs, envVals := splitEnv("--env", spec.Env)
 	args = append(args, envArgs...)
-	args = append(args, spec.Image)
+	// The verified digest when one was resolved, so the bytes that boot are the
+	// bytes cosign checked; hull resolves it against its store from rc23.
+	args = append(args, withDigest(spec.Image, spec.Digest))
 	return args, envVals, nil
 }
 

--- a/internal/runtime/hull_digest_test.go
+++ b/internal/runtime/hull_digest_test.go
@@ -1,0 +1,111 @@
+package runtime
+
+import (
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+)
+
+// TestHullVersionPinsDigest pins the version at which hull resolves a digest
+// reference against its own store. Before 0.1.0-rc23 a repo@sha256:... boot
+// missed the cache and re-pulled every time, and failed outright under
+// --pull=never with the bytes on disk, so brig verified and booted the tag
+// there instead. From rc23 the store answers a digest, and brig pins it.
+//
+// Anything brig cannot read as a version is a build from source, which is a
+// maintainer's, and it pins: a wrong guess there costs a re-pull, never a
+// weaker check, because a digest the store does not hold is fetched from the
+// registry and is the verified bytes either way.
+func TestHullVersionPinsDigest(t *testing.T) {
+	cases := []struct {
+		out  string
+		want bool
+	}{
+		{"hull version 0.1.0-rc21\n", false},
+		{"hull version 0.1.0-rc9\n", false},
+		{"hull version 0.1.0-rc22\n", false},
+		{"hull version 0.1.0-rc23\n", true},
+		{"hull version 0.1.0-rc30\n", true},
+		{"hull version 0.1.0\n", true},
+		{"hull version 0.2.0-rc1\n", true},
+		{"hull version 1.0.0\n", true},
+		{"hull version \n", true},
+		{"hull version dev\n", true},
+		{"", true},
+		{"garbage\n", true},
+	}
+	for _, tc := range cases {
+		if got := hullVersionPinsDigest(tc.out); got != tc.want {
+			t.Errorf("hullVersionPinsDigest(%q) = %v, want %v", tc.out, got, tc.want)
+		}
+	}
+}
+
+// stubHull writes a hull that answers --version with the given line and does
+// nothing else, which is all PinsDigest needs from the binary.
+func stubHull(t *testing.T, versionLine string) Runtime {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "hull")
+	script := "#!/bin/sh\ncase \"$1\" in --version) echo \"" + versionLine + "\";; esac\n"
+	if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	rt, err := newHull(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return rt
+}
+
+// TestHullPinsDigestAsksTheBinary: the answer comes from the hull on this
+// machine, not from a build-time constant, because the hull brig drives is
+// whatever is on PATH or in BRIG_RUNTIME_BIN and may be older than brig.
+func TestHullPinsDigestAsksTheBinary(t *testing.T) {
+	if stubHull(t, "hull version 0.1.0-rc21").PinsDigest() {
+		t.Fatal("rc21 cannot resolve a digest against its store, and was reported as pinning")
+	}
+	if !stubHull(t, "hull version 0.1.0-rc23").PinsDigest() {
+		t.Fatal("rc23 resolves a digest against its store, and was reported as not pinning")
+	}
+}
+
+// TestRunArgsBootsThePinnedDigest: when the verify path resolved a digest, hull
+// boots repo@digest rather than the tag, so the bytes that boot are the bytes
+// cosign checked. With no digest the tag boots as before.
+func TestRunArgsBootsThePinnedDigest(t *testing.T) {
+	digest := "sha256:" + strings.Repeat("a", 64)
+	pinned := RunSpec{Name: "s", Image: "ghcr.io/brig-sh/x:latest", Digest: digest}
+	args, _, err := runArgs(pinned, "vz", "shared", "", "", nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !slices.Contains(args, "ghcr.io/brig-sh/x@"+digest) {
+		t.Fatalf("the pinned digest did not reach hull run: %q", args)
+	}
+	if slices.Contains(args, "ghcr.io/brig-sh/x:latest") {
+		t.Fatalf("the tag was passed alongside the digest: %q", args)
+	}
+
+	unpinned := RunSpec{Name: "s", Image: "ghcr.io/brig-sh/x:latest"}
+	args, _, err = runArgs(unpinned, "vz", "shared", "", "", nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !slices.Contains(args, "ghcr.io/brig-sh/x:latest") {
+		t.Fatalf("with no digest the tag should boot: %q", args)
+	}
+}
+
+// TestHullLocalDigestIsUnknown documents a limit rather than a feature: hull
+// exposes no way to read the full digest, let alone the index digest, that its
+// store holds for a reference, so brig cannot compare the copy on disk against
+// the registry there. It answers "" for "cannot say", which the verify path
+// treats as no local copy and raises no mismatch over. The boot is still pinned.
+func TestHullLocalDigestIsUnknown(t *testing.T) {
+	got, err := stubHull(t, "hull version 0.1.0-rc23").LocalDigest("ghcr.io/brig-sh/x:latest")
+	if err != nil || got != "" {
+		t.Fatalf("LocalDigest = %q, %v; want \"\", nil", got, err)
+	}
+}

--- a/internal/runtime/nerdctl.go
+++ b/internal/runtime/nerdctl.go
@@ -49,6 +49,56 @@ func newNerdctl(bin string) (Runtime, error) {
 func (n *nerdctl) Kind() string { return "nerdctl" }
 func (n *nerdctl) Bin() string  { return n.bin }
 
+// PinsDigest is true here: containerd's store is content-addressed, so a
+// reference of the form repo@sha256:... resolves to that exact object and, when
+// it is already present, is served from the store without a re-pull. That is
+// what lets brig boot the digest it verified rather than the tag, and it is the
+// property hull's store does not share -- see the hull adapter.
+func (n *nerdctl) PinsDigest() bool { return true }
+
+// LocalDigest reports the digest the local store holds for ref.
+//
+// image inspect's RepoDigests is the reference the image was pulled by, digest
+// and all: for a tag that is repo@sha256:<the digest the registry served then>,
+// which is the same object cosign resolves the tag to now, so the two are
+// comparable. Both nerdctl and docker answer the dockercompat shape, so one
+// format string serves whichever binary newNerdctl settled on.
+//
+// A miss is not an error: an image that was never pulled, or one built locally
+// with no repo digest at all, simply has nothing on disk to compare, so the
+// verify path treats "" as "no local copy" and does not raise a mismatch over
+// it. Only a genuine failure to ask is worth returning.
+func (n *nerdctl) LocalDigest(ref string) (string, error) {
+	cmd := exec.Command(n.bin, "image", "inspect", "--format", "{{index .RepoDigests 0}}", ref)
+	cmd.Env = mergeEnv(telemetryEnv(false))
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	if err := cmd.Run(); err != nil {
+		// The overwhelmingly common cause is that the tag is simply not in the
+		// store yet, which inspect reports as a failure. That is a miss, not a
+		// fault, so it must not stop a boot.
+		return "", nil
+	}
+	return repoDigest(out.String()), nil
+}
+
+// repoDigest pulls the bare digest out of an image inspect RepoDigests entry.
+//
+// The entry is repo@sha256:..., and only the digest half is comparable against
+// what cosign resolved -- the repo half is just a name. A pulled-by-tag image
+// with no recorded digest prints Go's zero value for the missing slice element
+// rather than an empty string, so that is a miss too, reported as "".
+func repoDigest(out string) string {
+	line := strings.TrimSpace(out)
+	if line == "" || line == "<no value>" {
+		return ""
+	}
+	if _, digest, found := strings.Cut(line, "@"); found {
+		return digest
+	}
+	return ""
+}
+
 func (n *nerdctl) Running(name string) bool {
 	cmd := exec.Command(n.bin, "ps", "--filter", "name=^"+name+"$", "--format", "{{.Names}}")
 	cmd.Env = mergeEnv(telemetryEnv(false))
@@ -156,7 +206,12 @@ func (n *nerdctl) runArgs(spec RunSpec) (args, env []string, err error) {
 	// A container exits when its command does, and the sandbox has to outlive
 	// the exec that uses it -- the whole point is that the VM keeps running
 	// between invocations. Park it on a shell that never returns.
-	args = append(args, spec.Image, "sleep", "infinity")
+	//
+	// The image is booted by the verified digest when verify resolved one, so
+	// the object that boots is the object that was checked, whatever the tag has
+	// moved to since. containerd resolves the digest against its store, so a
+	// copy already present is not re-pulled.
+	args = append(args, withDigest(spec.Image, spec.Digest), "sleep", "infinity")
 	return args, envVals, nil
 }
 

--- a/internal/runtime/nerdctl_test.go
+++ b/internal/runtime/nerdctl_test.go
@@ -106,6 +106,69 @@ func TestTmpfsReachesTheCreateLine(t *testing.T) {
 	}
 }
 
+// A resolved digest is what boots: the image on the command line is
+// repo@sha256:..., not the tag, so containerd boots the object verify checked.
+func TestNerdctlBootsTheVerifiedDigest(t *testing.T) {
+	digest := "sha256:" + strings.Repeat("a", 64)
+	n := &nerdctl{bin: "nerdctl"}
+	args, _, err := n.runArgs(RunSpec{Name: "s", Image: "ghcr.io/brig-sh/claude-code:arm64", Digest: digest})
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := strings.Join(args, " ")
+	if !strings.Contains(got, "ghcr.io/brig-sh/claude-code@"+digest+" sleep infinity") {
+		t.Errorf("the tag was booted instead of the digest: %s", got)
+	}
+	if strings.Contains(got, ":arm64") {
+		t.Errorf("the tag was left on the reference alongside the digest: %s", got)
+	}
+}
+
+// With no digest resolved -- the hull path, or a run that could not reach the
+// registry -- the tag boots as given, unchanged.
+func TestNerdctlBootsTheTagWhenNoDigestResolved(t *testing.T) {
+	n := &nerdctl{bin: "nerdctl"}
+	args, _, err := n.runArgs(RunSpec{Name: "s", Image: "ghcr.io/brig-sh/claude-code:arm64"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := strings.Join(args, " "); !strings.HasSuffix(got, "ghcr.io/brig-sh/claude-code:arm64 sleep infinity") {
+		t.Errorf("the tag was not booted as given: %s", got)
+	}
+}
+
+func TestWithDigest(t *testing.T) {
+	d := "sha256:" + strings.Repeat("a", 64)
+	cases := map[string]string{
+		"ghcr.io/brig-sh/x:arm64":     "ghcr.io/brig-sh/x@" + d,
+		"ghcr.io/brig-sh/x":           "ghcr.io/brig-sh/x@" + d,
+		"ghcr.io:443/brig-sh/x:arm64": "ghcr.io:443/brig-sh/x@" + d,
+		"repo@sha256:old":             "repo@" + d,
+	}
+	for in, want := range cases {
+		if got := withDigest(in, d); got != want {
+			t.Errorf("withDigest(%q) = %q, want %q", in, got, want)
+		}
+	}
+	// An empty digest leaves the reference untouched.
+	if got := withDigest("ghcr.io/brig-sh/x:arm64", ""); got != "ghcr.io/brig-sh/x:arm64" {
+		t.Errorf("withDigest with no digest = %q, want the tag unchanged", got)
+	}
+}
+
+func TestRepoDigest(t *testing.T) {
+	d := "sha256:" + strings.Repeat("a", 64)
+	if got := repoDigest("ghcr.io/brig-sh/claude-code@" + d + "\n"); got != d {
+		t.Errorf("repoDigest = %q, want the bare digest %q", got, d)
+	}
+	// A miss must read as no local copy, not as a digest.
+	for _, in := range []string{"", "<no value>", "no-at-sign"} {
+		if got := repoDigest(in); got != "" {
+			t.Errorf("repoDigest(%q) = %q, want empty", in, got)
+		}
+	}
+}
+
 func TestBootArtifactsReportsWhichFileIsMissing(t *testing.T) {
 	dir := t.TempDir()
 	// Only the initrd: the kernel is the one that should be named.

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -47,8 +47,14 @@ type Var struct {
 
 // RunSpec is a request to boot a sandbox.
 type RunSpec struct {
-	Name     string
-	Image    string
+	Name  string
+	Image string
+	// Digest is the registry digest verify resolved and checked for Image, or
+	// "" when none was resolved. A runtime whose store is addressable by digest
+	// boots Image@Digest instead of the tag, so the bytes that boot are the ones
+	// that verified; one that is not ignores it and boots the tag. See
+	// PinsDigest, and the note on the nerdctl and hull adapters.
+	Digest   string
 	Pull     string // missing (default) | always | never
 	Net      string // none | shared
 	Mem      int    // MB
@@ -121,6 +127,19 @@ type Runtime interface {
 	List() ([]Instance, error)
 	// Run boots a sandbox, detached.
 	Run(spec RunSpec) error
+	// PinsDigest reports whether Run honours RunSpec.Digest -- that is, whether
+	// this runtime's store is addressable by digest, so that booting
+	// Image@Digest boots that exact object and resolves it against the local
+	// store the way containerd does. brig only claims digest-level verification
+	// on a runtime that returns true; on one that returns false it verifies and
+	// boots the tag, and says so, rather than promise bytes it cannot pin.
+	PinsDigest() bool
+	// LocalDigest reports the digest the local store already holds for ref, or
+	// "" when it holds nothing under that reference or cannot say. It is how the
+	// verify path learns that the copy on disk is a different object from the
+	// one the registry serves. Only meaningful on a PinsDigest runtime; the
+	// caller does not ask the others.
+	LocalDigest(ref string) (string, error)
 	// Probe runs a command and reports only whether it succeeded, with all
 	// output discarded. Used for reachability checks.
 	Probe(spec ExecSpec) bool
@@ -230,6 +249,29 @@ func splitEnv(flag string, vars []Var) (args []string, env []string) {
 		env = append(env, v.Name+"="+v.Value)
 	}
 	return args, env
+}
+
+// withDigest rewrites image to name digest in place of its tag, so the runtime
+// boots the exact object verify checked. An empty digest leaves image as it is:
+// a runtime that cannot pin, or a path that resolved no digest, still boots the
+// tag it was given.
+//
+// A digest and a tag do not coexist on a reference, so the tag goes first: an
+// existing @digest is replaced, and a trailing :tag is cut -- but not a ":port"
+// on the registry host, which the slash after the colon distinguishes from a
+// tag. verify.refWithDigest does the same for the reference cosign checks; the
+// two are kept apart because this one speaks the runtime's ref grammar and that
+// one cosign's, and neither package should reach into the other for six lines.
+func withDigest(image, digest string) string {
+	if digest == "" {
+		return image
+	}
+	if i := strings.IndexByte(image, '@'); i >= 0 {
+		image = image[:i]
+	} else if i := strings.LastIndexByte(image, ':'); i >= 0 && !strings.Contains(image[i+1:], "/") {
+		image = image[:i]
+	}
+	return image + "@" + digest
 }
 
 // telemetryEnv attributes events to brig and suppresses the wrapper's own

--- a/internal/verify/verify.go
+++ b/internal/verify/verify.go
@@ -16,9 +16,12 @@ package verify
 
 import (
 	"bytes"
+	"context"
+	"errors"
 	"fmt"
 	"os/exec"
 	"strings"
+	"time"
 )
 
 // Mode is how strict the check is.
@@ -96,12 +99,34 @@ const (
 	NoTooling
 	// Failed: it claims to be ours and the signature does not check out.
 	Failed
+	// Mismatch: the reference resolved to one digest in the registry, and the
+	// copy already in the local store is a different one. Treated as the
+	// signature-failure row of the table -- fail-closed for our own images,
+	// warn for a third party's -- because a tag that names one object in the
+	// registry and another on disk is exactly the gap booting by digest closes.
+	Mismatch
+	// Unresolved: the reference could not be resolved to a registry digest, so
+	// there was nothing to pin or verify. A registry that cannot be reached
+	// lands here, and that is "could not check", not "failed": like NoTooling
+	// it warns and boots the tag, and only Require refuses it.
+	Unresolved
 )
 
 // Result carries the outcome and the detail worth printing.
 type Result struct {
 	Outcome Outcome
 	Image   string
+	// Digest is the registry digest the reference resolved to, and -- for a
+	// Verified result -- the digest whose signature checked out. Empty when the
+	// reference could not be resolved (NoTooling, Unresolved).
+	Digest string
+	// Local is the digest the local store already held for the reference, set
+	// only on a Mismatch so the message can name both sides.
+	Local string
+	// Ours reports whether the image sits under the policy's registry prefix.
+	// It is what turns a Mismatch into a stop rather than a warning, the same
+	// way it separates Failed from NotOurs.
+	Ours bool
 	// Detail is cosign's own output when it failed, trimmed.
 	Detail string
 }
@@ -110,7 +135,9 @@ type Result struct {
 func (r Result) Message() string {
 	switch r.Outcome {
 	case Verified:
-		return fmt.Sprintf("image %s: signature verified", r.Image)
+		// Naming the digest is the point of this whole path: the line vouches
+		// for the bytes that boot, not for a tag that can move under them.
+		return fmt.Sprintf("image %s: signature verified, booting %s", r.Image, r.Digest)
 	case NotOurs:
 		return fmt.Sprintf("image %s is not published by brig-sh, so there is no "+
 			"signature of ours to check. That is expected for your own image -- "+
@@ -118,6 +145,18 @@ func (r Result) Message() string {
 	case NoTooling:
 		return fmt.Sprintf("cannot verify image %s: cosign is not installed "+
 			"(`brew install cosign`). Booting it unchecked", r.Image)
+	case Unresolved:
+		return fmt.Sprintf("cannot reach the registry to verify image %s: %s. The copy "+
+			"on disk could not be checked against what the registry serves",
+			r.Image, r.Detail)
+	case Mismatch:
+		if r.Ours {
+			return fmt.Sprintf("image %s claims to be published by brig-sh, but the copy "+
+				"in your local store is %s, NOT the %s that verified. Booting the verified "+
+				"digest", r.Image, r.Local, r.Digest)
+		}
+		return fmt.Sprintf("image %s in your local store is %s, not the %s the registry "+
+			"now serves. Booting the registry digest", r.Image, r.Local, r.Digest)
 	default:
 		return fmt.Sprintf("image %s claims to be published by brig-sh, but its "+
 			"signature DID NOT VERIFY: %s", r.Image, r.Detail)
@@ -170,12 +209,168 @@ func (p Policy) Image(ref string) Result {
 	return Result{Outcome: Verified, Image: ref}
 }
 
+// Verify resolves the reference to a registry digest, verifies that digest,
+// and reports whether the copy already in the local store is the same object.
+//
+// This is the stronger sibling of Image. Image checks the tag, and under the
+// default pull policy the tag cosign checks and the copy the runtime boots are
+// not required to be the same bytes. Verify closes that gap: it resolves the
+// tag to the digest the registry serves right now, checks the signature on
+// THAT digest, and hands the digest back so the caller can boot it rather than
+// the tag. The digest resolved is the digest verified is the digest booted.
+//
+// localDigest is what brig's runtime already holds for the reference in its
+// local store, or "" when the runtime holds nothing or cannot say. When it is
+// present and differs from the digest we resolved, the local copy is not the
+// object we verified, and that is a Mismatch -- fail-closed for our own images,
+// a warning for a third party's.
+//
+// Only the runtimes whose store is addressable by digest use this path; see
+// Runtime.PinsDigest. hull's is not, so on macOS brig stays on Image and the
+// tag it names, rather than claim a guarantee that runtime cannot deliver.
+func (p Policy) Verify(ref, localDigest string) Result {
+	subject := normalizeRef(ref)
+	ours := strings.HasPrefix(subject, p.Registry)
+
+	// A third party's image carries no signature of ours to check, and that
+	// settles it before cosign is so much as looked up. Resolving its digest
+	// anyway was tried and withdrawn: it cost a registry round trip on every
+	// boot, stalled a laptop that was off the network for the full dial
+	// timeout, and bought a pin brig could not vouch for. The tag path never
+	// charged for an image it had nothing to say about, and neither does this.
+	if !ours {
+		return Result{Outcome: NotOurs, Image: ref}
+	}
+
+	// cosign resolves the digest as well as the signature here, so its absence
+	// stops both halves at once, exactly as it does for Image.
+	if _, err := lookPath(p.Cosign); err != nil {
+		return Result{Outcome: NoTooling, Image: ref, Ours: ours}
+	}
+
+	// Resolve the reference to a digest BEFORE the check. A registry that cannot
+	// be reached fails here, and that is "could not check" rather than "failed":
+	// it must not read like a bad signature, so it lands on Unresolved.
+	digest, err := p.resolveDigest(ref)
+	if err != nil {
+		return Result{Outcome: Unresolved, Image: ref, Ours: ours, Detail: err.Error()}
+	}
+
+	// The signature check, on the digest rather than the tag.
+	out, verr := run(p.Cosign,
+		"verify",
+		"--certificate-identity-regexp", p.Identity,
+		"--certificate-oidc-issuer", p.Issuer,
+		refWithDigest(ref, digest),
+	)
+	if verr != nil {
+		return Result{Outcome: Failed, Image: ref, Digest: digest, Ours: ours, Detail: firstLine(out, verr)}
+	}
+
+	// The copy on disk must be the object we just resolved -- and, for our own
+	// images, verified. A local digest that differs is the tag pointing at one
+	// thing in the registry and another in the store, which is the case this
+	// path exists to catch.
+	if localDigest != "" && localDigest != digest {
+		return Result{Outcome: Mismatch, Image: ref, Digest: digest, Local: localDigest, Ours: ours}
+	}
+	return Result{Outcome: Verified, Image: ref, Digest: digest, Ours: ours}
+}
+
+// resolveDigest asks cosign for the digest the registry serves for ref.
+//
+// cosign is already the one tool brig links its trust to, and it can name the
+// digest without a second registry client or a new dependency. `cosign
+// triangulate ref` prints where cosign would look for the signature, which is
+// <repo>:sha256-<the image's own digest>.sig -- so the digest is right there in
+// the tag it prints. A cosign new enough to take `--type=digest` prints
+// <repo>@sha256:<digest> instead; digestFromOutput reads either spelling, so
+// brig does not have to know which cosign it is driving.
+//
+// Resolving through cosign, not the runtime, is deliberate: the runtime's store
+// is on disk and is the very thing we are checking the registry against, so
+// asking it to resolve the tag would compare the local copy with itself.
+func (p Policy) resolveDigest(ref string) (string, error) {
+	out, err := run(p.Cosign, "triangulate", ref)
+	if err != nil {
+		return "", errors.New(firstLine(out, err))
+	}
+	if d := digestFromOutput(out); d != "" {
+		return d, nil
+	}
+	return "", fmt.Errorf("cosign named no digest for %s", ref)
+}
+
+// digestFromOutput pulls a sha256 digest out of cosign's triangulate output.
+//
+// Both spellings cosign uses -- the "sha256-<hex>.sig" signature tag and the
+// "sha256:<hex>" of --type=digest -- carry the same 64 hex characters after a
+// single separator, so the first "sha256" followed by ":" or "-" and 64 hex
+// characters is the digest in either. Scanning for that rather than splitting
+// on a fixed position steps over cosign's own warning lines, which mention no
+// such run of hex.
+func digestFromOutput(out string) string {
+	const marker = "sha256"
+	for i := strings.Index(out, marker); i >= 0; {
+		rest := out[i+len(marker):]
+		if len(rest) >= 1+64 && (rest[0] == ':' || rest[0] == '-') && isHex(rest[1:1+64]) {
+			return marker + ":" + rest[1:1+64]
+		}
+		next := strings.Index(out[i+len(marker):], marker)
+		if next < 0 {
+			return ""
+		}
+		i += len(marker) + next
+	}
+	return ""
+}
+
+func isHex(s string) bool {
+	for _, c := range s {
+		if (c < '0' || c > '9') && (c < 'a' || c > 'f') {
+			return false
+		}
+	}
+	return true
+}
+
+// refWithDigest rewrites ref to name a digest in place of its tag, so cosign
+// verifies the exact object the tag resolved to. A digest and a tag cannot both
+// sit on a reference (repo:tag@sha256:... is not a thing), so the tag is
+// dropped first: an existing @digest is replaced, and a trailing :tag is cut --
+// but only when the colon is a tag separator and not the ":port" of a registry
+// host, which is what the slash test distinguishes.
+func refWithDigest(ref, digest string) string {
+	if i := strings.IndexByte(ref, '@'); i >= 0 {
+		ref = ref[:i]
+	} else if i := strings.LastIndexByte(ref, ':'); i >= 0 && !strings.Contains(ref[i+1:], "/") {
+		ref = ref[:i]
+	}
+	return ref + "@" + digest
+}
+
 // lookPath and run are variables so tests can drive the decision table
 // without a cosign on PATH.
 var lookPath = exec.LookPath
 
+// cosignTimeout bounds every cosign invocation. The registry is on the other
+// end of each one, and a dial that never completes is the ordinary shape of an
+// outage; without a bound that outage would sit on the boot path for as long
+// as the network stack cares to wait. A cosign that is cut off here reads as
+// "could not be verified", the same as any other failure to reach the registry.
+var cosignTimeout = 30 * time.Second
+
 var run = func(bin string, args ...string) (string, error) {
-	cmd := exec.Command(bin, args...)
+	ctx, cancel := context.WithTimeout(context.Background(), cosignTimeout)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, bin, args...)
+	// Killing the process is not the same as being done with it. Anything it
+	// spawned inherits the pipes below, and Run waits for those to close, so a
+	// helper left behind by a killed cosign would hold the boot for as long as
+	// it lived. WaitDelay is the bound on that wait: once the deadline has
+	// killed the process, a second is all the grandchildren get before Run
+	// returns without them.
+	cmd.WaitDelay = time.Second
 	var out bytes.Buffer
 	cmd.Stdout = &out
 	cmd.Stderr = &out

--- a/internal/verify/verify_test.go
+++ b/internal/verify/verify_test.go
@@ -5,6 +5,7 @@ import (
 	"os/exec"
 	"strings"
 	"testing"
+	"time"
 )
 
 func stub(t *testing.T, found bool, output string, err error) {
@@ -51,6 +52,183 @@ func TestImageDecisionTable(t *testing.T) {
 	stub(t, false, "", nil)
 	if got := p.Image("ghcr.io/brig-sh/claude-code:arm64"); got.Outcome != NoTooling {
 		t.Errorf("missing cosign outcome = %v, want NoTooling", got.Outcome)
+	}
+}
+
+// digestStub drives the digest path: triangulate resolves a reference to a
+// digest, verify checks it. Either can be told to fail, which is how the
+// unreachable-registry and bad-signature rows are reached without a network.
+func digestStub(t *testing.T, triangulate string, triErr error, verifyErr error) {
+	t.Helper()
+	origLook, origRun := lookPath, run
+	t.Cleanup(func() { lookPath, run = origLook, origRun })
+	lookPath = func(string) (string, error) { return "/usr/bin/cosign", nil }
+	run = func(_ string, args ...string) (string, error) {
+		if len(args) == 0 {
+			return "", nil
+		}
+		switch args[0] {
+		case "triangulate":
+			return triangulate, triErr
+		case "verify":
+			if verifyErr != nil {
+				return "Error: no matching signatures\n", verifyErr
+			}
+			return "", nil
+		}
+		return "", nil
+	}
+}
+
+// digestHex is a stand-in for a real sha256, and sigTag spells the reference
+// cosign triangulate prints for it -- <repo>:sha256-<hex>.sig -- so the tests
+// resolve a digest the way the code parses one.
+const digestHex = "1111111111111111111111111111111111111111111111111111111111111111"
+
+func sigTag(repo string) string { return repo + ":sha256-" + digestHex + ".sig\n" }
+
+// The whole point of the path: the digest resolved is the digest verified is
+// the digest reported, and a local copy that matches raises nothing.
+func TestVerifyResolvesVerifiesAndPinsAMatchingDigest(t *testing.T) {
+	p := DefaultPolicy()
+	digestStub(t, sigTag("ghcr.io/brig-sh/claude-code"), nil, nil)
+
+	// The local store holds the very digest the registry resolved to.
+	got := p.Verify("ghcr.io/brig-sh/claude-code:arm64", "sha256:"+digestHex)
+	if got.Outcome != Verified {
+		t.Fatalf("outcome = %v, want Verified", got.Outcome)
+	}
+	if got.Digest != "sha256:"+digestHex {
+		t.Errorf("digest = %q, want the resolved one", got.Digest)
+	}
+	if !strings.Contains(got.Message(), got.Digest) {
+		t.Errorf("the success message does not name the digest: %q", got.Message())
+	}
+	// No local copy at all is the clean first boot, and still verifies.
+	if got := p.Verify("ghcr.io/brig-sh/claude-code:arm64", ""); got.Outcome != Verified {
+		t.Errorf("a first boot with nothing cached = %v, want Verified", got.Outcome)
+	}
+}
+
+// Our own tag over a local copy that is not the digest that verified is the
+// signature-failure row: it stops. Ours is what says so.
+func TestVerifyMismatchOnAFirstPartyImageFailsClosed(t *testing.T) {
+	p := DefaultPolicy()
+	digestStub(t, sigTag("ghcr.io/brig-sh/claude-code"), nil, nil)
+
+	got := p.Verify("ghcr.io/brig-sh/claude-code:arm64", "sha256:"+strings.Repeat("b", 64))
+	if got.Outcome != Mismatch {
+		t.Fatalf("outcome = %v, want Mismatch", got.Outcome)
+	}
+	if !got.Ours {
+		t.Error("a mismatch on our own image must be marked Ours so it stops")
+	}
+	if got.Digest != "sha256:"+digestHex || got.Local != "sha256:"+strings.Repeat("b", 64) {
+		t.Errorf("the result names the wrong digests: verified %q local %q", got.Digest, got.Local)
+	}
+}
+
+// A third party's tag over a differing local copy is a warning, not a stop:
+// same fact, lighter weight, exactly as NotOurs is lighter than Failed.
+// A third party's image carries no signature of ours to check, so there is
+// nothing to resolve either: resolving costs a registry round trip on every
+// boot, stalls a laptop that is off the network, and buys a pin brig cannot
+// vouch for. The answer is NotOurs before cosign is so much as looked up,
+// which is what the tag path always did.
+func TestVerifyThirdPartyMakesNoCosignCall(t *testing.T) {
+	p := DefaultPolicy()
+	origLook, origRun := lookPath, run
+	t.Cleanup(func() { lookPath, run = origLook, origRun })
+	lookPath = func(string) (string, error) { return "/usr/bin/cosign", nil }
+	calls := 0
+	run = func(_ string, args ...string) (string, error) {
+		calls++
+		return "", nil
+	}
+
+	got := p.Verify("docker.io/library/ubuntu:24.04", "")
+	if got.Outcome != NotOurs {
+		t.Fatalf("outcome = %v, want NotOurs", got.Outcome)
+	}
+	if got.Digest != "" {
+		t.Errorf("a third-party image is booted by tag, so no digest should be resolved: %q", got.Digest)
+	}
+	if calls != 0 {
+		t.Errorf("cosign was invoked %d time(s) for an image it has nothing to say about", calls)
+	}
+}
+
+// A registry that cannot be reached resolves no digest, which is "could not
+// check", not "failed": it must not read like a bad signature.
+func TestVerifyUnreachableRegistryIsUnresolvedNotFailed(t *testing.T) {
+	p := DefaultPolicy()
+	digestStub(t, "", errors.New("dial tcp: i/o timeout"), nil)
+
+	got := p.Verify("ghcr.io/brig-sh/claude-code:arm64", "sha256:"+digestHex)
+	if got.Outcome != Unresolved {
+		t.Fatalf("outcome = %v, want Unresolved", got.Outcome)
+	}
+	if got.Digest != "" {
+		t.Errorf("nothing was resolved, so there is no digest to report: %q", got.Digest)
+	}
+}
+
+// Our own image whose signature does not check out on the resolved digest is
+// Failed, carrying cosign's own reason.
+func TestVerifyFailedSignatureOnTheResolvedDigest(t *testing.T) {
+	p := DefaultPolicy()
+	digestStub(t, sigTag("ghcr.io/brig-sh/claude-code"), nil, errors.New("exit 1"))
+
+	got := p.Verify("ghcr.io/brig-sh/claude-code:arm64", "")
+	if got.Outcome != Failed {
+		t.Fatalf("outcome = %v, want Failed", got.Outcome)
+	}
+	if !strings.Contains(got.Detail, "no matching signatures") {
+		t.Errorf("detail = %q, want cosign's own reason", got.Detail)
+	}
+}
+
+// Without cosign neither the resolve nor the check can happen, which is a
+// different thing from a bad signature.
+func TestVerifyDigestWithoutCosignIsNoTooling(t *testing.T) {
+	p := DefaultPolicy()
+	origLook := lookPath
+	t.Cleanup(func() { lookPath = origLook })
+	lookPath = func(string) (string, error) { return "", exec.ErrNotFound }
+	if got := p.Verify("ghcr.io/brig-sh/claude-code:arm64", ""); got.Outcome != NoTooling {
+		t.Errorf("outcome = %v, want NoTooling", got.Outcome)
+	}
+}
+
+func TestDigestFromOutput(t *testing.T) {
+	want := "sha256:" + digestHex
+	for _, in := range []string{
+		// The default triangulate spelling, with a cosign warning ahead of it.
+		"WARNING: the ref uses a tag, not a digest\nghcr.io/brig-sh/x:sha256-" + digestHex + ".sig\n",
+		// The --type=digest spelling.
+		"ghcr.io/brig-sh/x@sha256:" + digestHex + "\n",
+	} {
+		if got := digestFromOutput(in); got != want {
+			t.Errorf("digestFromOutput(%q) = %q, want %q", in, got, want)
+		}
+	}
+	if got := digestFromOutput("no digest here\n"); got != "" {
+		t.Errorf("a line with no digest returned %q", got)
+	}
+}
+
+func TestRefWithDigest(t *testing.T) {
+	d := "sha256:" + digestHex
+	cases := map[string]string{
+		"ghcr.io/brig-sh/x:arm64":         "ghcr.io/brig-sh/x@" + d,
+		"ghcr.io/brig-sh/x":               "ghcr.io/brig-sh/x@" + d,
+		"ghcr.io:443/brig-sh/x:arm64":     "ghcr.io:443/brig-sh/x@" + d,
+		"ghcr.io/brig-sh/x@sha256:oldold": "ghcr.io/brig-sh/x@" + d,
+	}
+	for in, want := range cases {
+		if got := refWithDigest(in, d); got != want {
+			t.Errorf("refWithDigest(%q) = %q, want %q", in, got, want)
+		}
 	}
 }
 
@@ -103,5 +281,30 @@ func TestMessagesNameTheImageAndTheRemedy(t *testing.T) {
 		if !strings.Contains(msg, "img") {
 			t.Errorf("%v message does not name the image: %q", outcome, msg)
 		}
+	}
+}
+
+// A cosign that hangs must not hang the boot. The registry is on the other end
+// of every call it makes, and a dial that never completes is the ordinary shape
+// of an outage, so `run` gives up after cosignTimeout and the caller sees the
+// same "could not be verified" it would see for any other failure to reach the
+// registry.
+func TestRunGivesUpOnAHangingCosign(t *testing.T) {
+	orig := cosignTimeout
+	t.Cleanup(func() { cosignTimeout = orig })
+	cosignTimeout = 200 * time.Millisecond
+
+	// The sleep runs as the shell's child, not in its place, so killing the
+	// shell at the deadline leaves a process holding the output pipe. That is
+	// the shape a real hang takes, and the one a naive kill-and-wait misses:
+	// on a shell that execs a lone command the sleep would die with the shell
+	// and the test would pass without proving anything.
+	start := time.Now()
+	_, err := run("/bin/sh", "-c", "sleep 5 & wait")
+	if err == nil {
+		t.Fatal("a hanging cosign returned no error")
+	}
+	if took := time.Since(start); took > 2*time.Second {
+		t.Fatalf("run waited %v for a cosign that never answers", took)
 	}
 }

--- a/internal/wrap/config.go
+++ b/internal/wrap/config.go
@@ -71,8 +71,14 @@ type Config struct {
 
 	// Verify is how strictly the guest image is checked before boot, and
 	// VerifyPolicy is what counts as ours.
-	Verify         verify.Mode
-	VerifyPolicy   verify.Policy
+	Verify       verify.Mode
+	VerifyPolicy verify.Policy
+	// BootDigest is the registry digest verifyDigest resolved and checked, set
+	// only on a runtime that boots by digest. EnsureRunning hands it to the
+	// runtime so the object that boots is the object that verified; empty means
+	// boot the tag as given, which is every hull run and any path that could not
+	// resolve a digest.
+	BootDigest     string
 	AllowRefs      bool
 	AllowDenied    bool
 	CredentialsCmd string

--- a/internal/wrap/run.go
+++ b/internal/wrap/run.go
@@ -250,12 +250,16 @@ func (c *Config) EnsureRunning(set creds.Set) error {
 	// mount itself; see createTimeVolumes.
 	tmpfs, volumeShares := c.createTimeVolumes()
 	spec := runtime.RunSpec{
-		Name:  c.VMName,
-		Image: c.Image,
-		Pull:  c.Pull,
-		Net:   "shared",
-		Mem:   c.Mem,
-		CPUs:  c.CPUs,
+		Name: c.VMName,
+		// The tag stays as the image; the resolved digest rides alongside it and
+		// the runtime boots Image@Digest when it can pin one. Empty Digest boots
+		// the tag, which is the hull path and any run that resolved no digest.
+		Image:  c.Image,
+		Digest: c.BootDigest,
+		Pull:   c.Pull,
+		Net:    "shared",
+		Mem:    c.Mem,
+		CPUs:   c.CPUs,
 		// The workspace, which is the guest's home. The host's agent
 		// configuration is copied into it rather than mounted, so it needs no
 		// share of its own -- see seedHostConfig. volumeShares is empty on

--- a/internal/wrap/verify.go
+++ b/internal/wrap/verify.go
@@ -19,10 +19,33 @@ import (
 // our registry and fails verification is the one case that stops, because
 // that combination has no innocent reading -- it means something is
 // pretending to be us.
+//
+// There are two checks behind this one method, and the runtime decides which.
+// A runtime whose store is addressable by digest (containerd on Linux, hull
+// from 0.1.0-rc23) can boot the exact bytes cosign checked, so it takes
+// verifyDigest: resolve the tag to a digest, verify that digest, compare it
+// against the copy on disk, and hand the digest on to boot. One whose store is
+// not stays on verifyTag, which checks the tag as brig always has -- because
+// claiming a digest was pinned when it was not is worse than the gap the claim
+// would paper over -- and says so, because a user who reads "verified" on that
+// path is owed the difference. See runtime.Runtime.PinsDigest.
 func (c *Config) verifyImage() error {
 	if c.Verify == verify.Off {
 		return nil
 	}
+	if c.Runtime.PinsDigest() {
+		return c.verifyDigest()
+	}
+	c.warnf("this %s cannot boot by digest (hull 0.1.0-rc23 or newer can), so the tag "+
+		"is verified and booted rather than a pinned digest", c.Runtime.Kind())
+	return c.verifyTag()
+}
+
+// verifyTag is the tag-level check, kept for a runtime that cannot boot by
+// digest. It is brig's original behaviour, unchanged: the tag is what cosign
+// sees and what the runtime boots, and under the default pull policy those need
+// not be the same bytes -- the limitation documented in docs/security.md.
+func (c *Config) verifyTag() error {
 	res := c.VerifyPolicy.Image(c.Image)
 
 	switch res.Outcome {
@@ -38,6 +61,108 @@ func (c *Config) verifyImage() error {
 		return nil
 
 	default:
+		c.warnf("%s", res.Message())
+		if c.Verify == verify.Require {
+			return errors.New("refusing to boot an image that failed verification")
+		}
+		if !c.confirm("Boot it anyway?") {
+			return errors.New("aborted: the image failed verification. " +
+				"Pull it again, or set BRIG_VERIFY=off if you know why it fails")
+		}
+		return nil
+	}
+}
+
+// verifyDigest is the digest-level check, for a runtime that boots the object
+// it is handed rather than a name. It resolves the reference to the digest the
+// registry serves, verifies that digest, and -- when the resolve succeeds --
+// records it in BootDigest so EnsureRunning boots that exact object.
+//
+// The decision table is the same shape as verifyTag's, with two rows the tag
+// path cannot express. Unresolved (a registry that could not be reached) joins
+// NoTooling: nothing could be checked, so it warns and boots the tag, and only
+// Require refuses. Mismatch (the local store holds a different digest than the
+// one verified) joins the failure row, and splits the way Failed and NotOurs
+// do: our own image stops to ask, a third party's warns. Either way brig boots
+// the digest it resolved, not the copy on disk, so a "yes" boots the verified
+// object rather than the suspect one.
+func (c *Config) verifyDigest() error {
+	// What the store already holds for this reference, so the resolve can be
+	// compared against it. A runtime that cannot say returns "", which reads as
+	// "no local copy" and raises no mismatch.
+	local, _ := c.Runtime.LocalDigest(c.Image)
+	res := c.VerifyPolicy.Verify(c.Image, local)
+
+	switch res.Outcome {
+	case verify.Verified, verify.NotOurs:
+		// Both boot the digest we resolved. A third party's carries no signature
+		// of ours, but pinning the digest still boots the bytes the registry
+		// serves rather than a stale local tag.
+		c.BootDigest = res.Digest
+		if res.Outcome == verify.NotOurs && c.Verify == verify.Require {
+			return fmt.Errorf("%s (BRIG_VERIFY=require)", res.Message())
+		}
+		c.warnf("%s", res.Message())
+		return nil
+
+	case verify.NoTooling:
+		// Nothing could be checked or pinned, so the tag boots as given. Leaving
+		// BootDigest empty is what makes that happen. A missing cosign is a gap
+		// in the machine's setup, said so on every boot, not something that
+		// changes between one run and the next.
+		if c.Verify == verify.Require {
+			return fmt.Errorf("%s (BRIG_VERIFY=require)", res.Message())
+		}
+		c.warnf("%s", res.Message())
+		return nil
+
+	case verify.Unresolved:
+		// The registry could not be reached, so one of our own images could not
+		// be checked. That is the outage case, and it stops exactly as it did
+		// before the digest check existed, when the same outage failed inside
+		// `cosign verify` and asked. A boot that goes ahead here on its own
+		// would let anyone who can make the registry unreachable, a captive
+		// portal or a sinkhole, turn the default mode into "unchecked". Nothing
+		// is pinned either way: a yes boots the cached tag.
+		c.warnf("%s", res.Message())
+		if c.Verify == verify.Require {
+			return errors.New("refusing to boot an image that could not be verified " +
+				"(BRIG_VERIFY=require)")
+		}
+		if !c.confirm("Boot the cached copy unverified?") {
+			return errors.New("aborted: the registry could not be reached, so the image " +
+				"could not be verified. Try again with the registry reachable")
+		}
+		return nil
+
+	case verify.Mismatch:
+		// Boot the resolved digest whatever we decide below: the object on disk
+		// is the one we are refusing to trust, so a "yes" must not boot it.
+		c.BootDigest = res.Digest
+		c.warnf("%s", res.Message())
+		if !res.Ours {
+			// A third party's copy differing from the registry is a warning, the
+			// same weight as NotOurs -- unless Require, which trusts nothing it
+			// cannot positively verify.
+			if c.Verify == verify.Require {
+				return errors.New("refusing under BRIG_VERIFY=require: the local image " +
+					"is not the digest the registry serves")
+			}
+			return nil
+		}
+		// Our own tag over a copy that is not the one that verified has no
+		// innocent reading, so it stops exactly as a failed signature does.
+		if c.Verify == verify.Require {
+			return errors.New("refusing to boot: the local copy is not the verified digest")
+		}
+		if !c.confirm("The local copy is not the verified image. Boot the verified digest anyway?") {
+			return errors.New("aborted: the local copy does not match the verified digest. " +
+				"Set BRIG_PULL=always to replace it, or BRIG_VERIFY=off if you know why it differs")
+		}
+		return nil
+
+	default: // verify.Failed
+		c.BootDigest = res.Digest
 		c.warnf("%s", res.Message())
 		if c.Verify == verify.Require {
 			return errors.New("refusing to boot an image that failed verification")

--- a/internal/wrap/verify_test.go
+++ b/internal/wrap/verify_test.go
@@ -3,12 +3,28 @@ package wrap
 import (
 	"bytes"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
+	"github.com/brig-sh/brig/internal/runtime"
 	"github.com/brig-sh/brig/internal/ttytest"
 	"github.com/brig-sh/brig/internal/verify"
 )
+
+// verifyRuntime is the seam the verify decision reaches through: whether the
+// runtime boots by digest, and what digest it already holds. Everything else
+// panics through the embedded nil interface, which is louder than a stub that
+// answers questions it was never asked.
+type verifyRuntime struct {
+	runtime.Runtime
+	pins  bool
+	local string
+}
+
+func (v verifyRuntime) Kind() string                       { return "hull" }
+func (v verifyRuntime) PinsDigest() bool                   { return v.pins }
+func (v verifyRuntime) LocalDigest(string) (string, error) { return v.local, nil }
 
 func verifyConfig(t *testing.T, image string, mode verify.Mode) *Config {
 	t.Helper()
@@ -19,7 +35,139 @@ func verifyConfig(t *testing.T, image string, mode verify.Mode) *Config {
 	// No cosign on the machine running the tests, which is itself one of the
 	// cases worth pinning.
 	c.VerifyPolicy.Cosign = "cosign-that-does-not-exist"
+	// These cases are about the tag path, which is the runtime that does not
+	// pin a digest. The digest path has its own cases below.
+	c.Runtime = verifyRuntime{pins: false}
 	return c
+}
+
+// fakeCosign writes a cosign stand-in that resolves every reference to digest
+// and either passes or fails verification, so the digest decision runs without
+// a network. It mirrors the stub script script/smoke.sh installs.
+func fakeCosign(t *testing.T, digest string, verifyFails bool) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "cosign")
+	script := "#!/bin/bash\n" +
+		"case \"$1\" in\n" +
+		"  triangulate) echo \"ghcr.io/example/image:$(echo " + digest + " | sed 's/:/-/').sig\" ;;\n"
+	if verifyFails {
+		script += "  verify) echo 'Error: no matching signatures' >&2; exit 1 ;;\n"
+	} else {
+		script += "  verify) exit 0 ;;\n"
+	}
+	script += "esac\nexit 0\n"
+	if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+// digestConfig is verifyConfig for the runtime that boots by digest, with a
+// working fake cosign and a chosen local-store digest.
+func digestConfig(t *testing.T, image string, mode verify.Mode, cosign, local string) *Config {
+	t.Helper()
+	c := testConfig(t, t.TempDir(), t.TempDir())
+	c.Image = image
+	c.Verify = mode
+	c.VerifyPolicy = verify.DefaultPolicy()
+	c.VerifyPolicy.Cosign = cosign
+	c.Runtime = verifyRuntime{pins: true, local: local}
+	return c
+}
+
+const testDigest = "sha256:1111111111111111111111111111111111111111111111111111111111111111"
+
+// The digest brig resolved and verified is the digest it records to boot, and
+// the line names it.
+func TestVerifyDigestPinsAndReportsTheDigest(t *testing.T) {
+	cosign := fakeCosign(t, testDigest, false)
+	c := digestConfig(t, "ghcr.io/brig-sh/claude-code:arm64", verify.Warn, cosign, testDigest)
+	if err := c.verifyImage(); err != nil {
+		t.Fatalf("a verified image was refused: %v", err)
+	}
+	if c.BootDigest != testDigest {
+		t.Errorf("BootDigest = %q, want the resolved digest so EnsureRunning boots it", c.BootDigest)
+	}
+	if said := c.Err.(*bytes.Buffer).String(); !strings.Contains(said, testDigest) {
+		t.Errorf("the message did not name the digest: %q", said)
+	}
+}
+
+// Our own tag over a local copy that is not the verified digest stops, and on
+// a boot it boots the verified digest rather than the copy on disk.
+func TestVerifyDigestFirstPartyMismatchFailsClosed(t *testing.T) {
+	other := "sha256:2222222222222222222222222222222222222222222222222222222222222222"
+	cosign := fakeCosign(t, testDigest, false)
+	c := digestConfig(t, "ghcr.io/brig-sh/claude-code:arm64", verify.Warn, cosign, other)
+	err := c.verifyImage()
+	if err == nil {
+		t.Fatal("a first-party mismatch booted without stopping (no terminal to say yes)")
+	}
+	if c.BootDigest != testDigest {
+		t.Errorf("a yes would boot %q, not the verified digest", c.BootDigest)
+	}
+	if said := c.Err.(*bytes.Buffer).String(); !strings.Contains(said, "NOT the") {
+		t.Errorf("the warning did not say the local copy is not the verified one: %q", said)
+	}
+}
+
+// A third party's tag over a differing local copy warns and boots.
+func TestVerifyDigestThirdPartyBootsTheTagWithoutCosign(t *testing.T) {
+	// A cosign that records every invocation. For an image brig did not publish
+	// there is nothing to verify, so there must be nothing to run either: the
+	// tag path never cost a registry round trip, and the digest path must not
+	// start charging one.
+	dir := t.TempDir()
+	marker := filepath.Join(dir, "invoked")
+	cosign := filepath.Join(dir, "cosign")
+	if err := os.WriteFile(cosign, []byte("#!/bin/bash\ntouch "+marker+"\nexit 0\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	c := digestConfig(t, "docker.io/library/ubuntu:24.04", verify.Warn, cosign, "")
+	if err := c.verifyImage(); err != nil {
+		t.Fatalf("a third-party image was refused: %v", err)
+	}
+	if c.BootDigest != "" {
+		t.Errorf("a third-party image boots by tag, nothing should be pinned: %q", c.BootDigest)
+	}
+	if _, err := os.Stat(marker); err == nil {
+		t.Error("cosign was invoked for an image it has nothing to say about")
+	}
+	if said := c.Err.(*bytes.Buffer).String(); !strings.Contains(said, "not published by brig-sh") {
+		t.Errorf("the warning did not say whose image it is: %q", said)
+	}
+}
+
+// A registry that cannot be reached resolves nothing, so the tag boots unpinned
+// and only require refuses. cosign-that-does-not-exist stands in for a cosign
+// that is present but whose resolve fails, by being absent -- which lands on
+// NoTooling, the same warn-and-boot row -- so here a real failing resolve is
+// used instead.
+func TestVerifyDigestUnreachableRegistryRefusesWithoutATerminal(t *testing.T) {
+	// A cosign whose triangulate always fails: a resolve that cannot reach the
+	// registry. Before the digest check existed the same outage failed inside
+	// `cosign verify`, which stopped the boot and asked; a network failure must
+	// not be the thing that turns the default mode into "boot it unchecked".
+	dir := t.TempDir()
+	cosign := filepath.Join(dir, "cosign")
+	if err := os.WriteFile(cosign, []byte("#!/bin/bash\ncase \"$1\" in triangulate) echo 'dial tcp: timeout' >&2; exit 1 ;; esac\nexit 0\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	c := digestConfig(t, "ghcr.io/brig-sh/claude-code:arm64", verify.Warn, cosign, "")
+	if err := c.verifyImage(); err == nil {
+		t.Fatal("an unreachable registry booted a first-party image unchecked, with no terminal to say yes")
+	}
+	if c.BootDigest != "" {
+		t.Errorf("nothing resolved, so nothing should be pinned: %q", c.BootDigest)
+	}
+	if said := c.Err.(*bytes.Buffer).String(); !strings.Contains(said, "cannot reach") && !strings.Contains(said, "could not be verified") {
+		t.Errorf("the refusal did not say the registry was the problem: %q", said)
+	}
+	c = digestConfig(t, "ghcr.io/brig-sh/claude-code:arm64", verify.Require, cosign, "")
+	if err := c.verifyImage(); err == nil {
+		t.Error("BRIG_VERIFY=require booted an image it could not resolve")
+	}
 }
 
 // A bring-your-own image is reported and booted. Blocking it would make the
@@ -150,5 +298,19 @@ func TestVerifyAsksWhenThereIsSomebodyToAsk(t *testing.T) {
 		if said := c.Err.(*bytes.Buffer).String(); !strings.Contains(said, "Boot it anyway?") {
 			t.Errorf("answering %q: the question was never asked: %q", tc.answer, said)
 		}
+	}
+}
+
+// TestVerifyTagPathSaysWhyItIsNotPinned: a runtime that cannot boot by digest
+// gets the tag check, and the user is told that is what happened and what
+// would change it. Silence here would read as "verified", which on this path
+// means less than it does on the other.
+func TestVerifyTagPathSaysWhyItIsNotPinned(t *testing.T) {
+	c := verifyConfig(t, "docker.io/library/ubuntu:24.04", verify.Warn)
+	if err := c.verifyImage(); err != nil {
+		t.Fatalf("the tag path refused a third-party image: %v", err)
+	}
+	if said := c.Err.(*bytes.Buffer).String(); !strings.Contains(said, "cannot boot by digest") {
+		t.Errorf("nothing said why the digest was not pinned: %q", said)
 	}
 }

--- a/script/smoke.sh
+++ b/script/smoke.sh
@@ -33,6 +33,11 @@ cat > "$WORK/hull" <<'STUB'
 { printf 'argv:'; printf ' %s' "$@"; printf '\n'; } >> "$STUB_LOG"
 verb="$1"; shift
 case "$verb" in
+  --version)
+    # What the real one prints. rc23 is the first that resolves a digest
+    # reference against its store; a case below drives an older one.
+    printf 'hull version %s\n' "${STUB_HULL_VERSION:-0.1.0-rc23}"
+    ;;
   ps)
     # `ps -a` also lists an instance that is merely holding its name.
     [ -f "$STUB_STATE" ] && printf '%s running\n' "$(cat "$STUB_STATE")"
@@ -464,6 +469,12 @@ echo "== image verification =="
 mkdir -p "$WORK/bin"
 cat > "$WORK/bin/cosign" <<'COSIGN'
 #!/bin/bash
+# `triangulate <ref>` names the signature tag for the digest a reference
+# resolves to, which is how brig learns the digest to verify and boot.
+if [ "$1" = triangulate ]; then
+  printf '%s:sha256-%s.sig\n' "${2%%:*}" "$(printf 'a%.0s' $(seq 64))"
+  exit 0
+fi
 [ "${COSIGN_FAIL:-0}" = 1 ] && { echo "Error: no matching signatures"; exit 1; }
 exit 0
 COSIGN
@@ -478,6 +489,19 @@ case "$out" in
   *"signature verified"*) ok "a signature that checks out is reported" ;;
   *) bad "a signature that checks out is reported -- got: $out" ;;
 esac
+grep 'argv: run ' "$STUB_LOG" | tail -1 | grep -q '@sha256:' \
+  && ok "the verified digest is what hull was told to boot" \
+  || bad "hull was told to boot the tag, not the verified digest: $(grep 'argv: run ' "$STUB_LOG" | tail -1)"
+
+fresh
+out="$(STUB_HULL_VERSION=0.1.0-rc21 BRIG_VERIFY=warn "$WORK/brig" run claude -p hi 2>&1)"
+case "$out" in
+  *"cannot boot by digest"*) ok "an older hull is told why the tag is booted" ;;
+  *) bad "an older hull is told why the tag is booted -- got: $out" ;;
+esac
+grep 'argv: run ' "$STUB_LOG" | tail -1 | grep -q '@sha256:' \
+  && bad "an older hull was handed a digest it cannot resolve" \
+  || ok "an older hull boots the tag"
 
 fresh
 out="$(BRIG_VERIFY=warn COSIGN_FAIL=1 "$WORK/brig" run claude -p hi 2>&1)"; rc=$?


### PR DESCRIPTION
## Summary

Provenance is the strongest supply-chain claim brig makes: not that an image was
signed, but that it was built by that workflow in that repo. The claim is about
the bytes that run. The check was about a name in a registry, and under the
default `missing` pull policy those need not be the same object, so brig could
print "signature verified" about an image it had not checked.

brig now resolves the reference to a digest, verifies that digest, and boots it,
on both platforms. Whether a runtime can boot a digest from its store is a fact
about that runtime, so the seam asks it rather than assuming.

## Related issues

Closes #14
Refs brig-sh/hull#5, brig-sh/hull#14

## Changes

- `verify.Policy.Verify(ref, localDigest)` resolves the reference through
  `cosign triangulate`, verifies that digest, and compares it against what the
  store holds under the tag. A local copy that differs stops the boot as a failed
  signature would, and a yes boots the verified digest rather than the copy on
  disk.
- An image brig did not publish makes no cosign call: `NotOurs` before anything
  is resolved, and it boots by tag as it always has. Resolving it anyway cost a
  registry round trip per boot and a stall off the network, for a pin brig
  cannot vouch for.
- A registry that cannot be reached stops a first-party boot and asks, and
  refuses under `require`. That is what the same outage did before this PR, when
  it failed inside `cosign verify`; an earlier revision of this PR booted the
  cached tag unchecked in that case, which review caught.
- Every cosign call is bounded by a 30 second timeout, so an outage fails in
  seconds rather than hanging the boot.
- `PinsDigest()` and `LocalDigest()` on the runtime seam. containerd always
  pins. hull asks its binary: `hull --version` at 0.1.0-rc23 or newer pins,
  because that is where hull's store lookup started answering a digest
  reference (brig-sh/hull#5, shipped in rc23). Older prints one line saying the
  tag is verified and booted instead, and why. A version brig cannot read is a
  build from source and pins, since a wrong guess that way costs a re-pull and
  never a weaker check.
- The success line names the digest, and is never printed on a boot that did not
  pin one.
- `docs/security.md` and the README state which runtime gives which guarantee.
- Smoke now drives the pinned path end to end against the stub hull: the digest
  reaches `hull run`, and an rc21 stub boots the tag and is told why.

## What stays narrower on macOS, and why

**The first pinned boot after upgrading hull pulls once.** An image pulled under
an older hull has no index digest on record, and a multi-arch tag resolves to its
index digest, so the store misses and pulls. From then on it answers. Under
`BRIG_PULL=never` that first boot fails until the image is pulled again. Verified
against the store on this machine: the one image in it, pulled under rc21, is
recorded by manifest digest `14a04b7a…` while cosign resolves its tag to index
digest `ccbb91d6…`.

**The mismatch report is Linux-only for now.** `hull images` prints a truncated
manifest digest and no index digest, so there is nothing brig can compare
against the digest cosign resolved. Answering the manifest digest would make
every multi-arch image look like a mismatch and stop a first-party boot with a
prompt for nothing, so `LocalDigest` answers "cannot say" on hull and the boot
is pinned without that report. Tracked as brig-sh/hull#14.

**Users cannot get rc23 yet.** The tag pins hull's cask to rc21 and the rc23
release is not cut yet. Until both move, a Homebrew
user is on the tag path with the one-line notice. Nothing here breaks on rc21.

## Checklist

- [x] `make all` passes (vet, test, build)
- [x] `script/smoke.sh` passes
- [x] I have added or updated tests covering the change
- [x] I have run `go test ./... -race`, if the change touches concurrency, subprocesses or the daemon
- [ ] I have exercised the change against a real runtime (`brig run <agent>`), if it touches the run, exec or credential path
- [x] I have updated the affected docs (README, `docs/security.md`, `docs/profiles.md`, `docs/brigd.md`)

No run against a real runtime. Everything was exercised against the stub runtime
and stub cosign. This changes what brig passes to the runtime on the boot path,
which is exactly the class the checklist warns can pass every test here and still
be wrong, so it wants a real `brig run` on both platforms before merge: a Linux
boot to confirm the digest resolves against the containerd store, and a macOS
boot on hull rc23 once a release binary exists, to confirm the pinned boot finds
its bytes after the one re-pull.

## Credentials and the sandbox boundary

This affects the first promise by way of what the guest is: the image is the code
that runs inside the boundary, and verifying a different object than the one that
boots is a false assurance about it.

The assertions that matter are negative: a local digest that differs from the
verified one stops the boot for a first-party image, warns for a third-party one,
and the digest-named success line does not appear on a path that did not pin.




