### PR TITLE
fix(wrap): open the workspace by descending where a guest can reach

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -328,9 +328,32 @@ file in. A symlink that stays *inside* the workspace is refused too: brig
 writes only regular files in there, so a link where a state file belongs was
 put there rather than left there.
 
-The one escape a root cannot see is a symlink *at* the workspace itself, since
-resolving that still leaves every path below it honestly "inside the root".
-That is checked separately, before anything is created.
+The one escape a root cannot see is a symlink *at* the workspace or on the
+way to it, since resolving that still leaves every path below it honestly
+"inside the root". That is checked separately, before anything is created,
+and the check has a shape worth knowing. The guest writes as you, so it can
+swap an entry only inside a directory you can write. The path to the
+workspace is split where the first such directory appears. Above it, every
+entry sits where the guest cannot reach, and that part is opened by name,
+following the links the system or an administrator put there (`/tmp` and
+`/var` on macOS are links). From there down, brig descends one component at a
+time against the directory it already holds, refuses every symlink, and
+confirms after each step that what it opened is what it looked at. The
+workspace itself is always in the descended part, so a link there is refused
+wherever it sits.
+
+Whether you can write a directory is what the kernel says, asked through
+`access(2)`, plus ownership: a directory you own you can always `chmod`. So a
+group membership past the first sixteen and an ACL both count, on both
+platforms. A link above the split whose target passes through a directory
+you can write, a root-owned `/data` pointing into your home, say, is refused
+like any other link the guest could reach; name the real directory instead.
+
+Running brig as root, ownership tells it nothing, because the guest's writes
+are root's too. It then trusts only what nobody but root could have written,
+which keeps the system's own links usable and protects nothing: a sandbox run
+as root can reach a nested workspace's parents like anything else, and this
+is not the control for that.
 
 What this looks like when it fires is a failed run, before anything is
 written, naming the link and where it points:

--- a/internal/wrap/fdroot.go
+++ b/internal/wrap/fdroot.go
@@ -1,0 +1,34 @@
+package wrap
+
+import (
+	"fmt"
+	"os"
+	"runtime"
+)
+
+// rootFromFile builds a root from a descriptor that is already open, without
+// looking the name up again.
+//
+// The descent opens each component with O_DIRECTORY so a fifo cannot block it,
+// and then needs a root to carry on from. os.Root has no constructor that takes
+// a descriptor, so the obvious way is to open the name a second time -- which
+// puts a second lookup in the middle of a walk whose whole purpose is to stop
+// a name being resolved more than once. The kernel names an open descriptor as
+// a path, so the second lookup can be pointed at the descriptor rather than at
+// the name, and there is nothing left for a swap to change.
+//
+// The path is per-platform: /proc/self/fd on Linux, /dev/fd elsewhere. Both
+// resolve to the object the descriptor holds, so a rename of the original name
+// does not move it.
+func rootFromFile(f *os.File) (*os.Root, error) {
+	dir := "/dev/fd"
+	if runtime.GOOS == "linux" {
+		dir = "/proc/self/fd"
+	}
+	r, err := os.OpenRoot(fmt.Sprintf("%s/%d", dir, f.Fd()))
+	if err != nil {
+		return nil, fmt.Errorf("cannot open the directory brig just opened (%s/%d): %w",
+			dir, f.Fd(), err)
+	}
+	return r, nil
+}

--- a/internal/wrap/owner_other.go
+++ b/internal/wrap/owner_other.go
@@ -2,10 +2,9 @@
 
 package wrap
 
-import "io/fs"
+import "os"
 
-// ownedByRoot has no answer on a platform without POSIX ownership, so it says
-// no: every symlink on the path is then checked, which is the strict half of
-// the decision. brig ships for darwin and linux; this keeps the build honest
-// elsewhere.
-func ownedByRoot(fs.FileInfo) bool { return false }
+// dirWritableByUs has no answer without POSIX ownership either, so it says
+// yes: nothing is trusted, and the whole path is walked one component at a
+// time. Slower and stricter, which is the right way round for a guess.
+var dirWritableByUs = func(string, os.FileInfo) bool { return true }

--- a/internal/wrap/owner_unix.go
+++ b/internal/wrap/owner_unix.go
@@ -3,15 +3,66 @@
 package wrap
 
 import (
+	"errors"
 	"io/fs"
+	"os"
 	"syscall"
 )
 
-// ownedByRoot reports whether a path belongs to root, which is how
-// checkWorkspacePath tells a link the operating system ships -- /tmp and /var
-// on macOS -- from one a sandbox planted. A guest writes as the user brig runs
-// as; it cannot create a root-owned link in a directory it can reach.
-func ownedByRoot(info fs.FileInfo) bool {
+// wOK is W_OK from <unistd.h>, which the syscall package does not export on
+// every platform this file builds for.
+const wOK = 0x2
+
+// writableBy reports whether a directory is the given user's to write: to
+// rename an entry out of and plant something in its place.
+//
+// This is the question that decides how far up a workspace path an attacker
+// can reach. The guest writes as the user brig runs as, so a directory that
+// user can write is one where every entry is suspect, and a directory that
+// user cannot write is one the guest cannot touch at all.
+//
+// The owner can always write it, whatever the mode bits say, because the owner
+// can put the bits back. For anyone else the kernel is asked, and access is
+// the result of access(2) on the directory. The kernel weighs the full group
+// list and any ACL, neither of which brig can read for itself: os.Getgroups
+// stops at NGROUPS_MAX on macOS while Open Directory membership does not, and
+// an ACL grants write without touching the bits. The answer is a policy about
+// the directory, not a check before a write, so the usual warning about
+// access(2) does not apply. A read-only filesystem counts as not writable,
+// since nothing can be swapped there either; any other failure counts as
+// writable, which is the safe direction.
+//
+// Root is a different question. Root can write everything, and as root the
+// guest's host-side writes are root's too, so ownership tells brig nothing
+// about who put a link where. Trust then covers only what nobody but root
+// could have written: root-owned, with no write bit for group or other. That
+// keeps the links the machine is made of usable -- /tmp and /var on macOS,
+// /home on an ostree system -- and protects nothing: a sandbox run as root
+// can reach a nested workspace's parents like anything else, and nothing here
+// is the control for that.
+func writableBy(info fs.FileInfo, uid int, access error) bool {
 	st, ok := info.Sys().(*syscall.Stat_t)
-	return ok && st.Uid == 0
+	if !ok {
+		return true
+	}
+	if uid == 0 {
+		return st.Uid != 0 || info.Mode().Perm()&0o022 != 0
+	}
+	if int(st.Uid) == uid {
+		return true
+	}
+	switch {
+	case access == nil:
+		return true
+	case errors.Is(access, syscall.EACCES), errors.Is(access, syscall.EROFS):
+		return false
+	}
+	return true
+}
+
+// dirWritableByUs is writableBy for the user brig is running as. A variable so
+// a test can declare a directory it owns to be one it cannot write, which is
+// the only way to exercise the trusted-prefix walk without running as root.
+var dirWritableByUs = func(path string, info os.FileInfo) bool {
+	return writableBy(info, os.Getuid(), syscall.Access(path, wOK))
 }

--- a/internal/wrap/rootio.go
+++ b/internal/wrap/rootio.go
@@ -12,15 +12,34 @@ import (
 	"syscall"
 )
 
-// errPlantedSymlink marks a refusal caused by a symlink inside the workspace
-// that leads out of it, so a caller that otherwise shrugs off an I/O error --
-// trustGuestCwd treats an unreadable state file as nothing to do -- can tell
-// this one apart and fail the run instead of quietly carrying on.
+// errPlantedSymlink marks a refusal because the workspace, or the path to it,
+// cannot be trusted: a symlink inside it that leads out, one on the way to it
+// that the guest could have planted, or a component that moved while brig was
+// looking. A caller that otherwise shrugs off an I/O error -- trustGuestCwd
+// treats an unreadable state file as nothing to do -- can tell this one apart
+// and fail the run instead of quietly carrying on. A plain configuration
+// error, such as a regular file where a directory was named, does not carry
+// it.
 var errPlantedSymlink = errors.New("a symlink in the workspace leads out of it")
 
-// afterWorkspaceCheck runs between the path check and the open. It does
-// nothing outside tests; see openWorkspace.
+// afterWorkspaceCheck runs after the workspace has been opened and before the
+// root is handed back. It does nothing outside tests; see openWorkspace.
 var afterWorkspaceCheck = func() {}
+
+// duringWorkspaceWalk runs at the start of the last step of the descent,
+// before the workspace itself is looked at. It does nothing outside tests.
+//
+// This is the gap an attacker gets against a walk that resolves strings: a
+// parent flipped here poisons everything a by-name walk does next, and then
+// everything downstream agrees with itself about the wrong directory. Against
+// the descent it is meant to do nothing, and the test that drives it says so.
+var duringWorkspaceWalk = func() {}
+
+// betweenLstatAndOpen runs inside one step of the descent, after the entry has
+// been looked at and before it is opened, with the entry's name. It does
+// nothing outside tests. This is the one window a step has, and the identity
+// check after the open is what closes it.
+var betweenLstatAndOpen = func(name string) {}
 
 // workspaceRoot is the workspace opened once as an [os.Root]. Every host-side
 // read and write brig makes inside the workspace goes through it.
@@ -42,25 +61,16 @@ var afterWorkspaceCheck = func() {}
 type workspaceRoot struct {
 	root *os.Root
 	dir  string
-	// ident is the directory the path check ended on, captured while the path
-	// was known to be symlink-free. Everything that asks "is this still our
-	// workspace?" compares against this, never against a fresh resolution of
-	// the path.
+	// ident is the directory the descent ended on, read from the handle it
+	// holds. Before the path is handed to the runtime, verifyStillOurs resolves
+	// it afresh and compares against this: a resolution can only disagree with
+	// the handle, and disagreement refuses.
 	ident os.FileInfo
 }
 
 // openWorkspace creates the workspace if it is not there yet and opens it as a
 // root.
 func (c *Config) openWorkspace() (*workspaceRoot, error) {
-	// The walk below inspects a path *string*; MkdirAll and OpenRoot then
-	// resolve that same string again, from scratch. Two resolutions, and the
-	// guest owns a component in between them whenever a workspace is nested
-	// under a directory a sandbox can write -- which is the case the walk's own
-	// doc comment names as the reachable one. Flipping that component between
-	// the check and the open redirected everything brig writes next, and one of
-	// those things is a mode-0755 credential helper, so the race was worth
-	// running: it landed outside the workspace in 43 attempts.
-	//
 	// Cleaning first because the walk cleans and the callers did not, so
 	// `<tmp>/link/../real` was checked as `<tmp>/real` -- skipping `link`
 	// entirely -- and then opened as written, through the link.
@@ -80,63 +90,287 @@ func (c *Config) openWorkspace() (*workspaceRoot, error) {
 		return nil, err
 	}
 
-	// The walk hands back the identity of the directory it ended on, taken at
-	// the moment it had just proved that no component on the way to it is a
-	// symlink. That value is the whole fix.
+	// Walk down by handle rather than by path. Each step names one component
+	// relative to a directory that is already open, so no step re-reads the
+	// components above it, and there is no longer a resolution for an attacker
+	// to poison between the check and its result.
 	//
-	// The previous version compared the open root against os.Stat(path), and
-	// os.Stat re-resolves the path from scratch. So the guest only had to have
-	// its symlink present during OpenRoot, absent during the re-walk, and
-	// present again during the comparison: both sides then resolved to the
-	// attacker's directory and agreed. It escaped in about 0.6s, every time.
-	// Nothing is re-resolved now -- the value being compared against was
-	// captured when the path was known good, and a later swap cannot reach back
-	// and change it.
-	want, err := c.checkWorkspacePath()
+	// Two earlier versions of this guard were defeated by variations of one
+	// trick. The first compared the open root against os.Stat(path), and
+	// os.Stat re-resolves from scratch, so a symlink present during the open
+	// and absent during the comparison made both sides agree. The second
+	// captured the identity during the walk, which was better but not enough:
+	// the walk itself resolved a string per component, so flipping a parent
+	// between the last two steps poisoned the captured value, and the
+	// comparison then had two wrong answers to agree about. Walking the part
+	// of the path the guest can reach by handle removes the class rather than
+	// the instance; see openWorkspaceHandle for where that part begins.
+	root, want, err := openWorkspaceHandle(c.Workspace)
 	if err != nil {
 		return nil, err
 	}
 
-	// A seam, so the window between the walk and the open can be opened
-	// deliberately in a test. Without it the identity check below is only
-	// reachable by winning a real race, and a guard that can only be tested by
-	// racing is a guard that goes untested -- which is exactly what happened to
-	// the last one.
+	// A seam, so a test can swap the directory after brig is holding it. The
+	// swap is meant to do nothing now: the handle references the directory it
+	// opened, not the name it was reached by.
 	afterWorkspaceCheck()
 
-	root, err := os.OpenRoot(c.Workspace)
-	if err != nil {
-		return nil, err
-	}
-	if err := rootIs(root, want, c.Workspace); err != nil {
-		_ = root.Close()
-		return nil, err
-	}
 	return &workspaceRoot{root: root, dir: c.Workspace, ident: want}, nil
 }
 
-// rootIs reports whether an open root refers to the directory the walk ended
-// on.
+// openWorkspaceHandle opens the workspace and hands back the directory it
+// ended on together with that directory's identity.
 //
-// `want` must come from checkWorkspacePath and nowhere else. Comparing against
-// a fresh os.Stat of the path is what made the previous version useless: that
-// re-resolves, so an attacker who can flip a component controls both sides of
-// the comparison.
-func rootIs(root *os.Root, want os.FileInfo, path string) error {
-	opened, err := root.Stat(".")
+// It splits the path in two at the point where an attacker could start acting
+// on it. The guest writes as the user brig runs as. That user can rename an
+// entry out of a directory it can write and plant a link in its place, and can
+// do nothing of the kind to a directory it cannot write. So every component
+// whose parent is not writable by us is one the guest cannot redirect, and the
+// longest such prefix is opened by name in one call, letting the kernel resolve
+// it and follow whatever links the system or an administrator put there. That
+// needs only search permission on the way, which is what the shared-host
+// layouts with a 0711 /home rely on.
+//
+// The rest of the path, from the first directory we can write, is where a swap
+// is possible, and it is walked one component at a time against the directory
+// already open above it. Each step looks at one name, refuses it if it is a
+// symlink, then opens it and repeats, so nothing above a component is read
+// again and there is no resolution left for a swap to poison. Every symlink in
+// this part is refused, whoever owns it: a root-owned link here would have to
+// have been placed inside a directory the user controls, which is not a layout
+// worth following blind. The workspace itself is always in this part, since it
+// is the string handed to the runtime as the share, so a link there is refused
+// wherever it sits.
+//
+// Whether a directory is ours to write is the kernel's answer, plus ownership;
+// see writableBy, which also says what the rule degrades to as root.
+func openWorkspaceHandle(path string) (*os.Root, os.FileInfo, error) {
+	abs, err := filepath.Abs(path)
 	if err != nil {
-		return fmt.Errorf("cannot stat the opened workspace: %w", err)
+		return nil, nil, fmt.Errorf("refusing to use %s as the workspace: %w", path, err)
 	}
-	if !os.SameFile(opened, want) {
-		return fmt.Errorf("refusing to use %s as the workspace: it changed between the check "+
-			"and the open, so the directory brig holds is not the one it checked. Something "+
-			"with write access to a parent directory moved it: %w", path, errPlantedSymlink)
+	components := workspaceComponents(abs)
+
+	k, err := trustedPrefix(components)
+	if err != nil {
+		return nil, nil, fmt.Errorf("refusing to use %s as the workspace: %w", abs, err)
 	}
-	return nil
+	prefix, tail := components[k], components[k+1:]
+
+	root, err := os.OpenRoot(prefix)
+	if err != nil {
+		return nil, nil, fmt.Errorf("refusing to use %s as the workspace: cannot open %s: %w",
+			abs, prefix, err)
+	}
+	for i, p := range tail {
+		if i == len(tail)-1 {
+			duringWorkspaceWalk()
+		}
+		name := filepath.Base(p)
+		info, err := root.Lstat(name)
+		if err != nil {
+			// A component that is not there is a component being moved. The
+			// leaf was created moments ago and every parent had to exist for
+			// that to work, so absence here is not a race brig can wait out.
+			_ = root.Close()
+			return nil, nil, fmt.Errorf("refusing to use %s as the workspace: %s could not be "+
+				"read while brig was checking the path (%v), so something is moving it: %w",
+				abs, p, err, errPlantedSymlink)
+		}
+		if info.Mode()&os.ModeSymlink != 0 {
+			target, _ := root.Readlink(name)
+			_ = root.Close()
+			return nil, nil, plantedSymlinkErr(abs, p, target)
+		}
+		if !info.IsDir() {
+			// Only a directory can be on the way to the workspace. The check
+			// matters for what it refuses before the open below, not for
+			// tidiness: os.Root.OpenRoot blocks on a fifo until a writer
+			// arrives, so a component that is one stops the boot rather than
+			// failing it. resolveTrusted and checkWorkspacePathBeforeCreate
+			// both make this check already; the descent was the one that did
+			// not.
+			_ = root.Close()
+			return nil, nil, fmt.Errorf("refusing to use %s as the workspace: %s is %s, "+
+				"not a directory", abs, p, describeType(info.Mode()))
+		}
+		betweenLstatAndOpen(name)
+		// One open, with O_DIRECTORY, and the root is built from the
+		// descriptor it returns.
+		//
+		// O_DIRECTORY is what stops a fifo. Between the look above and this
+		// open the entry can be swapped, and opening a fifo waits for a writer
+		// with nothing to time it out, so a guest that can swap a parent could
+		// stop the boot rather than redirect it. The kernel refuses a
+		// non-directory at open time, so whatever the swap puts there cannot
+		// block us.
+		//
+		// Carrying on from the descriptor is what keeps the name from being
+		// looked up twice. Opening it again to get a root would put a second
+		// lookup in the middle of a walk that exists to stop a name being
+		// resolved more than once. See rootFromFile.
+		opening, err := root.OpenFile(name, syscall.O_DIRECTORY, 0)
+		if err != nil {
+			_ = root.Close()
+			return nil, nil, fmt.Errorf("refusing to use %s as the workspace: %s could not be "+
+				"opened as a directory (%v), so something changed it while brig was "+
+				"looking: %w", abs, p, err, errPlantedSymlink)
+		}
+		next, err := rootFromFile(opening)
+		_ = opening.Close()
+		_ = root.Close()
+		if err != nil {
+			return nil, nil, fmt.Errorf("refusing to use %s as the workspace: cannot open %s: %w",
+				abs, p, err)
+		}
+		// The look and the open are two calls, and os.Root follows a link that
+		// stays under the root, so a link swapped in between them was followed
+		// just now. The handle cannot be redirected after the fact, though: ask
+		// it what it holds and refuse anything but the directory the look saw.
+		opened, err := next.Stat(".")
+		if err != nil {
+			_ = next.Close()
+			return nil, nil, fmt.Errorf("cannot stat %s after opening it: %w", p, err)
+		}
+		if !os.SameFile(opened, info) {
+			_ = next.Close()
+			return nil, nil, fmt.Errorf("refusing to use %s as the workspace: %s changed between "+
+				"the look and the open, so something is moving it: %w", abs, p, errPlantedSymlink)
+		}
+		root = next
+	}
+
+	ident, err := root.Stat(".")
+	if err != nil {
+		_ = root.Close()
+		return nil, nil, fmt.Errorf("cannot stat the opened workspace %s: %w", abs, err)
+	}
+
+	// The descent is holding the right directory. The path is a separate
+	// question, and it is the one that matters downstream: the share handed to
+	// the runtime is a string, resolved in another process later, so a path
+	// that has stopped naming this directory is a path brig must not pass on.
+	//
+	// Resolving it again here is safe in a way the old walk was not. The value
+	// it is checked against came from the descent, so a poisoned resolution can
+	// only disagree, and disagreement only ever refuses. There is no reading of
+	// this that lets a swapped component be accepted.
+	byPath, err := os.Stat(abs)
+	if err != nil {
+		_ = root.Close()
+		return nil, nil, fmt.Errorf("refusing to use %s as the workspace: it could not be read "+
+			"after brig opened it (%v), so something is moving it: %w", abs, err, errPlantedSymlink)
+	}
+	if !os.SameFile(byPath, ident) {
+		_ = root.Close()
+		return nil, nil, fmt.Errorf("refusing to use %s as the workspace: the name stopped "+
+			"pointing at the directory brig opened, so the sandbox would be handed somewhere "+
+			"else as its home: %w", abs, errPlantedSymlink)
+	}
+	return root, ident, nil
 }
 
-// verifyStillOurs re-walks the path and reports whether it still names the
-// directory this root holds.
+// trustedPrefix returns the index of the last component an attacker cannot
+// redirect: for every i up to it, opening components[i] by name resolves
+// through directories none of which is ours to write.
+//
+// Trust runs from the top and never resumes. Once a directory we can write is
+// reached, every entry below it can be swapped out wholesale at that level,
+// however the lower directories are owned, so the walk stops there for good.
+//
+// The judgement is made on the directories the kernel will pass through, not
+// on the spelling. A link met on the way is resolved here by the same rule, so
+// a root-owned /data that points into a user's home ends trust above /data
+// rather than extending it through the home: the link itself cannot be
+// touched, but the entry it names can, and a by-name open would resolve
+// through it. The link is then refused by the walk below, like any other link
+// in territory the guest can reach, and the message says to name the real
+// directory instead.
+//
+// The workspace itself is never part of the prefix. It is the string handed to
+// the runtime as the share, resolved by another process later, so a link
+// there is refused wherever it sits. A component that does not exist yet ends
+// the prefix too: it is about to be created.
+func trustedPrefix(components []string) (int, error) {
+	k, dir := 0, components[0]
+	for i := 1; i < len(components)-1; i++ {
+		real, ok, err := resolveTrusted(dir, filepath.Base(components[i]))
+		if err != nil {
+			return 0, err
+		}
+		if !ok {
+			break
+		}
+		k, dir = i, real
+	}
+	return k, nil
+}
+
+// resolveTrusted follows name inside dir the way the kernel would and returns
+// the real directory it lands on. It reports ok=false the moment the
+// resolution passes through a directory this user can write, or reaches an
+// entry that is not there. dir must itself be real, which is what lets a
+// relative link target and a ".." be applied to it lexically.
+//
+// Everything here is checked by name, which is fine for the same reason the
+// prefix is opened by name: every directory looked at has just been found to
+// be one the guest cannot write, so there is nothing for a race to swap.
+func resolveTrusted(dir, name string) (real string, ok bool, err error) {
+	names := []string{name}
+	hops := 0
+	for len(names) > 0 {
+		n := names[0]
+		names = names[1:]
+		switch n {
+		case "", ".":
+			continue
+		case "..":
+			dir = filepath.Dir(dir)
+			continue
+		}
+		info, err := os.Stat(dir)
+		if err != nil {
+			return "", false, fmt.Errorf("%s could not be read while brig was checking the "+
+				"path (%v): %w", dir, err, errPlantedSymlink)
+		}
+		if dirWritableByUs(dir, info) {
+			return "", false, nil
+		}
+		p := filepath.Join(dir, n)
+		entry, err := os.Lstat(p)
+		if err != nil {
+			if os.IsNotExist(err) {
+				return "", false, nil
+			}
+			return "", false, fmt.Errorf("%s could not be read while brig was checking the "+
+				"path (%v): %w", p, err, errPlantedSymlink)
+		}
+		if entry.Mode()&os.ModeSymlink != 0 {
+			hops++
+			if hops > 40 {
+				return "", false, fmt.Errorf("%s: too many levels of symbolic links", p)
+			}
+			target, err := os.Readlink(p)
+			if err != nil {
+				return "", false, fmt.Errorf("%s could not be read while brig was checking "+
+					"the path (%v): %w", p, err, errPlantedSymlink)
+			}
+			if filepath.IsAbs(target) {
+				dir = filepath.VolumeName(target) + string(filepath.Separator)
+			}
+			names = append(strings.Split(filepath.ToSlash(filepath.Clean(target)), "/"), names...)
+			continue
+		}
+		if !entry.IsDir() {
+			return "", false, fmt.Errorf("%s is not a directory", p)
+		}
+		dir = p
+	}
+	return dir, true, nil
+}
+
+// verifyStillOurs reports whether the path still names the directory this
+// root holds.
 //
 // This is NOT a narrow window. The share handed to the runtime is a path
 // string, and hull resolves it on its own time -- after the image digest is
@@ -146,54 +380,75 @@ func rootIs(root *os.Root, want os.FileInfo, path string) error {
 // the resolution that matters happens in another process later.
 //
 // What it does buy is that brig refuses to hand over a path that has ALREADY
-// stopped meaning what it checked. That is worth doing and worth being honest
-// about: closing the rest needs hull to accept a descriptor rather than a path.
+// stopped meaning what it checked. Resolving the path afresh is safe here
+// because the value it is compared with came from the handle: a poisoned
+// resolution can only disagree, and disagreement only refuses. Closing the
+// rest needs hull to accept a descriptor rather than a path.
 func (r *workspaceRoot) verifyStillOurs() error {
-	c := &Config{Workspace: r.dir}
-	want, err := c.checkWorkspacePath()
+	now, err := os.Stat(r.dir)
 	if err != nil {
-		return err
+		return fmt.Errorf("refusing to hand %s to the runtime: it could not be read (%v), so "+
+			"something is moving it: %w", r.dir, err, errPlantedSymlink)
 	}
-	if !os.SameFile(want, r.ident) {
+	if !os.SameFile(now, r.ident) {
 		return fmt.Errorf("refusing to hand %s to the runtime: it no longer names the "+
 			"directory brig prepared, so the sandbox would get somewhere else as its home: %w",
 			r.dir, errPlantedSymlink)
 	}
-	return rootIs(r.root, r.ident, r.dir)
+	return nil
 }
 
 // checkWorkspacePathBeforeCreate walks the path before the workspace exists.
 //
-// It is the same refusal as checkWorkspacePath with one difference: a component
-// that is simply absent is fine here, because MkdirAll is about to create it.
-// Everything else -- a symlink, or a stat that fails for any other reason -- is
-// a refusal, so nothing is ever created through a planted link.
+// It is the same refusal as openWorkspaceHandle with one difference: a
+// component that is simply absent is fine here, because MkdirAll is about to
+// create it. A symlink below the trusted prefix, or a stat that fails for any
+// other reason, is a refusal, so nothing is ever created through a planted
+// link. It walks by string, which leaves one thing on the table: an empty
+// directory created through a link planted between this pass and the descent,
+// in a directory the attacker could write anyway, before the run is refused.
 func (c *Config) checkWorkspacePathBeforeCreate() error {
-	for _, p := range workspaceComponents(c.Workspace) {
+	components := workspaceComponents(c.Workspace)
+	workspace := components[len(components)-1]
+	k, err := trustedPrefix(components)
+	if err != nil {
+		return fmt.Errorf("refusing to use %s as the workspace: %w", workspace, err)
+	}
+	for _, p := range components[k+1:] {
 		info, err := os.Lstat(p)
 		if err != nil {
 			if os.IsNotExist(err) {
 				continue
 			}
 			return fmt.Errorf("refusing to use %s as the workspace: %s could not be read "+
-				"(%v): %w", c.Workspace, p, err, errPlantedSymlink)
+				"(%v): %w", workspace, p, err, errPlantedSymlink)
 		}
-		if info.Mode()&os.ModeSymlink == 0 || ownedByRoot(info) {
-			continue
+		if info.Mode()&os.ModeSymlink != 0 {
+			target, _ := os.Readlink(p)
+			return plantedSymlinkErr(workspace, p, target)
 		}
-		target, _ := os.Readlink(p)
-		if p == filepath.Clean(c.Workspace) {
-			return fmt.Errorf("refusing to use %s as the workspace: it is a symlink to %q, "+
-				"and the workspace is mounted read-write as the sandbox's home, so brig will not "+
-				"write a guest's home through a link. Point BRIG_WORKSPACE (or --workspace) at the "+
-				"real directory: %w", c.Workspace, target, errPlantedSymlink)
+		if !info.IsDir() {
+			return fmt.Errorf("refusing to use %s as the workspace: %s is not a directory",
+				workspace, p)
 		}
-		return fmt.Errorf("refusing to use %s as the workspace: %s on the way to it is a "+
-			"symlink to %q, so the sandbox's home would be created somewhere other than where "+
-			"you asked for it. Point BRIG_WORKSPACE (or --workspace) at the real directory: %w",
-			c.Workspace, p, target, errPlantedSymlink)
 	}
 	return nil
+}
+
+// plantedSymlinkErr is the refusal for a symlink at or on the way to the
+// workspace, in the part of the path the guest can reach. Both walks produce
+// it, so the advice stays the same whether or not the workspace existed yet.
+func plantedSymlinkErr(workspace, component, target string) error {
+	if component == workspace {
+		return fmt.Errorf("refusing to use %s as the workspace: it is a symlink to %q, and the "+
+			"workspace is mounted read-write as the sandbox's home, so brig will not write a "+
+			"guest's home through a link. Point BRIG_WORKSPACE (or --workspace) at the real "+
+			"directory: %w", workspace, target, errPlantedSymlink)
+	}
+	return fmt.Errorf("refusing to use %s as the workspace: %s on the way to it is a symlink "+
+		"to %q, so the sandbox's home would be created somewhere other than where you asked "+
+		"for it. Point BRIG_WORKSPACE (or --workspace) at the real directory: %w",
+		workspace, component, target, errPlantedSymlink)
 }
 
 // workspaceComponents returns the path and every ancestor, outermost first, so
@@ -214,63 +469,6 @@ func workspaceComponents(workspace string) []string {
 		components[i], components[j] = components[j], components[i]
 	}
 	return components
-}
-
-// checkWorkspacePath walks the workspace path a component at a time and
-// refuses a symlink in any of them.
-//
-// Lstat'ing the workspace itself catches a link AT the workspace and nothing
-// else, and it is not the last component that matters -- it is every one of
-// them. `MkdirAll` and `OpenRoot` resolve the whole path, so a link at any
-// level redirects the guest's home just as completely, and the case that makes
-// it reachable is ordinary: a workspace nested under another sandbox's
-// workspace, or under any directory a guest can write, is a path whose parent
-// components the guest chooses. The root cannot see this -- by the time it has
-// a directory handle, the redirection has already happened.
-//
-// Links the machine itself is made of are skipped, by owner: /tmp and /var on
-// macOS are symlinks, root-owned, and nothing a sandbox can replace, so
-// refusing them would refuse every workspace under a temporary directory for a
-// hazard that does not exist. What a guest plants is owned by the user brig
-// runs as, and that is what this looks at. (brig running as root therefore
-// checks nothing here; running an agent sandbox as root is its own problem,
-// and this is not the control that would fix it.)
-func (c *Config) checkWorkspacePath() (os.FileInfo, error) {
-	var last os.FileInfo
-	for _, p := range workspaceComponents(c.Workspace) {
-		info, err := os.Lstat(p)
-		if err != nil {
-			// Previously this skipped. That was the hole: making a component
-			// briefly VANISH -- a rename, or a symlink removed and put back --
-			// walked past the check for free, which is how the identity
-			// comparison downstream was defeated. Every component of a path
-			// whose leaf we have just created must exist; one that does not is
-			// being moved underneath us right now.
-			return nil, fmt.Errorf("refusing to use %s as the workspace: %s could not be "+
-				"read while brig was checking the path (%v), so something is moving it: %w",
-				c.Workspace, p, err, errPlantedSymlink)
-		}
-		last = info
-		if info.Mode()&os.ModeSymlink == 0 || ownedByRoot(info) {
-			continue
-		}
-		target, _ := os.Readlink(p)
-		if p == filepath.Clean(c.Workspace) {
-			return nil, fmt.Errorf("refusing to use %s as the workspace: it is a symlink to %q, "+
-				"and the workspace is mounted read-write as the sandbox's home, so brig will not "+
-				"write a guest's home through a link. Point BRIG_WORKSPACE (or --workspace) at the "+
-				"real directory: %w", c.Workspace, target, errPlantedSymlink)
-		}
-		return nil, fmt.Errorf("refusing to use %s as the workspace: %s on the way to it is a "+
-			"symlink to %q, so the sandbox's home would be created somewhere other than where "+
-			"you asked for it. Point BRIG_WORKSPACE (or --workspace) at the real directory: %w",
-			c.Workspace, p, target, errPlantedSymlink)
-	}
-	if last == nil {
-		return nil, fmt.Errorf("refusing to use %s as the workspace: it has no components",
-			c.Workspace)
-	}
-	return last, nil
 }
 
 // Close releases the directory handle the root holds open.

--- a/internal/wrap/rootio_prefix_test.go
+++ b/internal/wrap/rootio_prefix_test.go
@@ -1,0 +1,238 @@
+package wrap
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// trustDirs declares the named directories, and every directory above them,
+// to be ones brig's user cannot write, for the duration of the test. That is
+// what a root-owned /Users or a root-owned, search-only /home looks like to the
+// walk, and it is the only way to put one on a test path without running as
+// root.
+//
+// The ancestors have to come along, because trust cannot resume once it is
+// lost: a test directory sits under a temp directory the user owns, and an
+// attacker who can write there can swap out everything below it wholesale,
+// however that lower directory is owned. Declaring only the directory itself
+// trusted would leave the walk correctly stopping above it, and test nothing.
+func trustDirs(t *testing.T, dirs ...string) {
+	t.Helper()
+	trusted := map[string]bool{}
+	for _, d := range dirs {
+		// The walk asks about real directories, so a temp dir under macOS's
+		// /var -> private/var has to be declared by its resolved name as well
+		// as by the name the test spelled.
+		real, err := filepath.EvalSymlinks(d)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, top := range []string{filepath.Clean(d), real} {
+			for p := top; ; p = filepath.Dir(p) {
+				trusted[p] = true
+				if p == filepath.Dir(p) {
+					break
+				}
+			}
+		}
+	}
+	old := dirWritableByUs
+	t.Cleanup(func() { dirWritableByUs = old })
+	dirWritableByUs = func(path string, info os.FileInfo) bool {
+		if trusted[filepath.Clean(path)] {
+			return false
+		}
+		return old(path, info)
+	}
+}
+
+// TestWorkspaceUnderASearchOnlyAncestorOpens is the shared-host layout: a
+// root-owned, search-only directory on the way to the workspace, such as a
+// /home or /srv/agents set to 0711 so users cannot list each other. Traversing
+// it needs only search permission. Reading it is not required and must not be,
+// because on that layout the user cannot.
+func TestWorkspaceUnderASearchOnlyAncestorOpens(t *testing.T) {
+	base := t.TempDir()
+	gate := filepath.Join(base, "gate")
+	home := filepath.Join(gate, "home")
+	work := filepath.Join(home, "ws")
+	if err := os.MkdirAll(work, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(gate, 0o311); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(gate, 0o755) })
+	trustDirs(t, base, gate)
+
+	c := &Config{Workspace: work}
+	r, err := c.openWorkspace()
+	if err != nil {
+		t.Fatalf("a search-only ancestor refused the workspace: %v", err)
+	}
+	defer func() { _ = r.Close() }()
+	if err := r.writeFile("probe", []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(filepath.Join(work, "probe")); err != nil {
+		t.Fatalf("the write did not land in the workspace: %v", err)
+	}
+}
+
+// TestWorkspaceBehindATrustedAbsoluteSymlinkOpens is the admin layout: a
+// root-owned absolute link on the way, /data pointing at /mnt/data. It is
+// inside the part of the path the guest cannot touch, so it is safe to follow,
+// and refusing it would break a layout that worked before.
+func TestWorkspaceBehindATrustedAbsoluteSymlinkOpens(t *testing.T) {
+	base := t.TempDir()
+	gate := filepath.Join(base, "gate")
+	real := filepath.Join(base, "real")
+	work := filepath.Join(real, "ws")
+	if err := os.MkdirAll(gate, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(work, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(gate, "data")
+	if err := os.Symlink(real, link); err != nil { // absolute target
+		t.Fatal(err)
+	}
+	trustDirs(t, base, gate)
+
+	c := &Config{Workspace: filepath.Join(link, "ws")}
+	r, err := c.openWorkspace()
+	if err != nil {
+		t.Fatalf("a trusted absolute symlink refused the workspace: %v", err)
+	}
+	defer func() { _ = r.Close() }()
+	if err := r.writeFile("probe", []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(filepath.Join(work, "probe")); err != nil {
+		t.Fatalf("the write did not land in the real directory: %v", err)
+	}
+}
+
+// TestWorkspaceRefusesAnUntrustedSymlinkInTheTail is the other half of the
+// same rule. A link the guest could have planted sits in a directory brig's
+// user can write, and it is refused however it is spelled.
+func TestWorkspaceRefusesAnUntrustedSymlinkInTheTail(t *testing.T) {
+	base := t.TempDir()
+	real := filepath.Join(base, "real")
+	if err := os.MkdirAll(filepath.Join(real, "ws"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(base, "planted")
+	if err := os.Symlink(real, link); err != nil {
+		t.Fatal(err)
+	}
+	// base is ours, so nothing under it is trusted.
+	c := &Config{Workspace: filepath.Join(link, "ws")}
+	if r, err := c.openWorkspace(); err == nil {
+		_ = r.Close()
+		t.Fatal("a symlink in a writable directory was followed")
+	}
+}
+
+// TestWorkspaceBehindATrustedLinkThroughWritableTerritoryIsRefused is the
+// admin layout gone wrong: a root-owned /data that points into a user's home.
+// The link itself sits where the guest cannot touch it, but what it names is
+// reached through a directory the guest can write, where the entry can be
+// swapped like any other. Opening that by name would let the kernel resolve
+// through the guest's territory, so trust has to stop above the link.
+func TestWorkspaceBehindATrustedLinkThroughWritableTerritoryIsRefused(t *testing.T) {
+	base := t.TempDir()
+	gate := filepath.Join(base, "gate")
+	mine := filepath.Join(base, "mine") // ours, so writable
+	real := filepath.Join(mine, "stuff")
+	work := filepath.Join(real, "ws")
+	if err := os.MkdirAll(gate, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(work, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(gate, "data")
+	if err := os.Symlink(real, link); err != nil {
+		t.Fatal(err)
+	}
+	trustDirs(t, base, gate)
+
+	c := &Config{Workspace: filepath.Join(link, "ws")}
+	r, err := c.openWorkspace()
+	if err == nil {
+		_ = r.Close()
+		t.Fatal("a trusted link into writable territory was followed")
+	}
+	if !errors.Is(err, errPlantedSymlink) {
+		t.Fatalf("refused for the wrong reason: %v", err)
+	}
+}
+
+// TestWorkspaceThatIsATrustedSymlinkIsRefused: the workspace itself is never
+// part of the trusted prefix, however safe the directory holding it. It is
+// the string handed to the runtime as the share, which another process
+// resolves later, and the security doc says a link there is refused.
+func TestWorkspaceThatIsATrustedSymlinkIsRefused(t *testing.T) {
+	base := t.TempDir()
+	gate := filepath.Join(base, "gate")
+	real := filepath.Join(base, "real")
+	for _, d := range []string{gate, real} {
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	link := filepath.Join(gate, "ws")
+	if err := os.Symlink(real, link); err != nil {
+		t.Fatal(err)
+	}
+	trustDirs(t, base, gate)
+
+	c := &Config{Workspace: link}
+	r, err := c.openWorkspace()
+	if err == nil {
+		_ = r.Close()
+		t.Fatal("a workspace that is itself a symlink was opened")
+	}
+	if !errors.Is(err, errPlantedSymlink) || !strings.Contains(err.Error(), "it is a symlink") {
+		t.Fatalf("refused for the wrong reason: %v", err)
+	}
+}
+
+// TestANonDirectoryOnThePathIsAPlainError: a typo in BRIG_WORKSPACE that puts
+// a regular file on the path is a configuration error, not a planted link,
+// and must not carry the sentinel that makes callers treat it as one.
+func TestANonDirectoryOnThePathIsAPlainError(t *testing.T) {
+	for _, trusted := range []bool{false, true} {
+		name := "in writable territory"
+		if trusted {
+			name = "in trusted territory"
+		}
+		t.Run(name, func(t *testing.T) {
+			base := t.TempDir()
+			file := filepath.Join(base, "notes.txt")
+			if err := os.WriteFile(file, []byte("x"), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			if trusted {
+				trustDirs(t, base)
+			}
+			c := &Config{Workspace: filepath.Join(file, "ws")}
+			r, err := c.openWorkspace()
+			if err == nil {
+				_ = r.Close()
+				t.Fatal("a workspace under a regular file was opened")
+			}
+			if errors.Is(err, errPlantedSymlink) {
+				t.Fatalf("a plain not-a-directory was reported as a planted link: %v", err)
+			}
+			if !strings.Contains(err.Error(), "not a directory") {
+				t.Fatalf("the message does not say what is wrong: %v", err)
+			}
+		})
+	}
+}

--- a/internal/wrap/rootio_race_test.go
+++ b/internal/wrap/rootio_race_test.go
@@ -109,14 +109,16 @@ func TestAVanishingComponentIsRefused(t *testing.T) {
 	// Remove the parent between the pre-create pass and the strict walk, using
 	// the seam so this is deterministic rather than a race.
 	afterWorkspaceCheck = func() {}
-	c := &Config{Workspace: work}
-	if _, err := c.checkWorkspacePath(); err != nil {
+	if root, _, err := openWorkspaceHandle(work); err != nil {
 		t.Fatalf("the honest path should pass: %v", err)
+	} else {
+		_ = root.Close()
 	}
 	if err := os.Rename(parent, filepath.Join(base, "gone")); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := c.checkWorkspacePath(); err == nil {
+	if root, _, err := openWorkspaceHandle(work); err == nil {
+		_ = root.Close()
 		t.Fatal("a component that vanished mid-check was accepted")
 	} else if !errors.Is(err, errPlantedSymlink) {
 		t.Fatalf("refused for the wrong reason: %v", err)
@@ -155,38 +157,5 @@ func TestWalkChecksEveryComponentNotJustTheParent(t *testing.T) {
 	}
 	if !errors.Is(err, errPlantedSymlink) {
 		t.Fatalf("refused for the wrong reason: %v", err)
-	}
-}
-
-// rootIs must compare against the identity captured during the walk, never a
-// fresh resolution of the path.
-func TestRootIsComparesAgainstTheCapturedIdentity(t *testing.T) {
-	base := t.TempDir()
-	a := filepath.Join(base, "a")
-	b := filepath.Join(base, "b")
-	for _, d := range []string{a, b} {
-		if err := os.MkdirAll(d, 0o755); err != nil {
-			t.Fatal(err)
-		}
-	}
-	rootA, err := os.OpenRoot(a)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer func() { _ = rootA.Close() }()
-
-	wantB, err := os.Lstat(b)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if err := rootIs(rootA, wantB, a); err == nil {
-		t.Fatal("a root was accepted as a directory it is not")
-	}
-	wantA, err := os.Lstat(a)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if err := rootIs(rootA, wantA, a); err != nil {
-		t.Fatalf("a root was rejected as the directory it is: %v", err)
 	}
 }

--- a/internal/wrap/rootio_walk_test.go
+++ b/internal/wrap/rootio_walk_test.go
@@ -1,0 +1,313 @@
+package wrap
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// TestWorkspaceParentSwappedDuringTheWalk drives the window inside the walk
+// rather than the one after it.
+//
+// The walk proves that no component on the way to the workspace is a symlink,
+// and hands back the identity of the directory it ended on. Both halves are
+// done by resolving a path string, and a string is resolved from the top every
+// time. So the step that reaches the leaf re-reads the prefix that the earlier
+// steps had just finished vouching for.
+//
+// Flip a parent into a symlink in that gap and the leaf is reached through it.
+// The identity handed back is then the attacker's directory, the open resolves
+// the same string the same way and lands in the same place, and the comparison
+// between them is two wrong answers agreeing. Nothing downstream can tell,
+// because everything downstream was derived from the poisoned resolution.
+//
+// The undirected version of this is TestWorkspaceWritesNeverLandOutsideUnderARace,
+// which wins the same race by spinning. This one takes it deterministically
+// through the seam, so the window is pinned by a test that cannot pass by
+// getting lucky.
+func TestWorkspaceParentSwappedDuringTheWalk(t *testing.T) {
+	base := t.TempDir()
+	parent := filepath.Join(base, "parent")
+	work := filepath.Join(parent, "work")
+	outside := filepath.Join(base, "outside")
+	if err := os.MkdirAll(work, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(outside, "work"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	old := duringWorkspaceWalk
+	t.Cleanup(func() { duringWorkspaceWalk = old })
+	duringWorkspaceWalk = func() {
+		duringWorkspaceWalk = func() {} // once, so only the leaf step is hit
+		if err := os.Rename(parent, filepath.Join(base, "parent.real")); err != nil {
+			t.Error(err)
+			return
+		}
+		if err := os.Symlink(outside, parent); err != nil {
+			t.Error(err)
+		}
+	}
+
+	c := &Config{Workspace: work}
+	r, err := c.openWorkspace()
+	if err != nil {
+		// Refusing is a correct outcome, as long as it is refused for being
+		// what it is rather than by accident.
+		if !errors.Is(err, errPlantedSymlink) {
+			t.Fatalf("refused for the wrong reason: %v", err)
+		}
+		return
+	}
+	defer func() { _ = r.Close() }()
+
+	// Allowed, so it must be holding the real workspace. Writing the guest git
+	// credential helper is the write that matters: it is mode 0755 and git
+	// runs it on the host, so a redirected one is host code execution.
+	if err := r.writeFile(".brig-git-credential", []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatalf("write through the root failed: %v", err)
+	}
+	if _, err := os.Lstat(filepath.Join(outside, "work", ".brig-git-credential")); err == nil {
+		t.Fatal("the parent was swapped during the walk and brig wrote through it")
+	}
+}
+
+// TestWorkspaceParentVanishesDuringTheWalk is the same seam with the parent
+// removed rather than replaced. A component that is not there is a component
+// being moved, so the run has to stop rather than resolve whatever appears
+// next.
+//
+// This one does not pin the window above. It was checked against the commit
+// before this change and passed there too, because the walk had already been
+// taught to refuse a component it could not read rather than skip it. What it
+// pins is that older fix: putting the skip back makes it fail. Worth keeping
+// for that, and worth saying so, because a test that looks like it guards the
+// change it ships with and does not is worse than no test at all.
+func TestWorkspaceParentVanishesDuringTheWalk(t *testing.T) {
+	base := t.TempDir()
+	parent := filepath.Join(base, "parent")
+	work := filepath.Join(parent, "work")
+	if err := os.MkdirAll(work, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	old := duringWorkspaceWalk
+	t.Cleanup(func() { duringWorkspaceWalk = old })
+	duringWorkspaceWalk = func() {
+		duringWorkspaceWalk = func() {}
+		if err := os.Rename(parent, filepath.Join(base, "gone")); err != nil {
+			t.Error(err)
+		}
+	}
+
+	c := &Config{Workspace: work}
+	r, err := c.openWorkspace()
+	if err == nil {
+		_ = r.Close()
+		t.Fatal("a parent that vanished mid-walk was accepted")
+	}
+	if !errors.Is(err, errPlantedSymlink) {
+		t.Fatalf("refused for the wrong reason: %v", err)
+	}
+}
+
+// TestWorkspaceSwappedBetweenLstatAndOpen drives the one window left inside a
+// step of the descent. A step looks at a name, sees a directory, and opens it.
+// os.Root follows a symlink that stays under the root, so a link swapped in
+// between those two calls is followed, and the path check that comes after
+// agrees with it, because the name now resolves to where the handle landed.
+// The step has to ask the handle what it opened and compare that with what it
+// looked at.
+func TestWorkspaceSwappedBetweenLstatAndOpen(t *testing.T) {
+	base := t.TempDir()
+	parent := filepath.Join(base, "parent")
+	work := filepath.Join(parent, "work")
+	outside := filepath.Join(parent, "outside") // under the same root, so os.Root follows a link to it
+	for _, d := range []string{work, outside} {
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	old := betweenLstatAndOpen
+	t.Cleanup(func() { betweenLstatAndOpen = old })
+	betweenLstatAndOpen = func(name string) {
+		if name != "work" {
+			return
+		}
+		betweenLstatAndOpen = func(string) {}
+		if err := os.Rename(work, filepath.Join(parent, "work.real")); err != nil {
+			t.Error(err)
+			return
+		}
+		if err := os.Symlink("outside", work); err != nil {
+			t.Error(err)
+		}
+	}
+
+	c := &Config{Workspace: work}
+	r, err := c.openWorkspace()
+	if err != nil {
+		if !errors.Is(err, errPlantedSymlink) {
+			t.Fatalf("refused for the wrong reason: %v", err)
+		}
+		return
+	}
+	defer func() { _ = r.Close() }()
+	if err := r.writeFile(".brig-git-credential", []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatalf("write through the root failed: %v", err)
+	}
+	if _, err := os.Lstat(filepath.Join(outside, ".brig-git-credential")); err == nil {
+		t.Fatal("the workspace was swapped for a link between the look and the open, and brig wrote through it")
+	}
+}
+
+// TestVerifyStillOursRefusesAWorkspaceThatMoved pins the check made just
+// before the path is handed to the runtime: the name must still resolve to the
+// directory brig holds.
+func TestVerifyStillOursRefusesAWorkspaceThatMoved(t *testing.T) {
+	base := t.TempDir()
+	work := filepath.Join(base, "work")
+	other := filepath.Join(base, "other")
+	for _, d := range []string{work, other} {
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	c := &Config{Workspace: work}
+	r, err := c.openWorkspace()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = r.Close() }()
+	if err := r.verifyStillOurs(); err != nil {
+		t.Fatalf("an untouched workspace was refused: %v", err)
+	}
+	if err := os.Rename(work, filepath.Join(base, "work.real")); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Rename(other, work); err != nil {
+		t.Fatal(err)
+	}
+	err = r.verifyStillOurs()
+	if err == nil {
+		t.Fatal("a workspace whose name now points elsewhere was handed on")
+	}
+	if !errors.Is(err, errPlantedSymlink) {
+		t.Fatalf("refused for the wrong reason: %v", err)
+	}
+}
+
+// A component swapped for a fifo between the look and the open hangs the boot.
+//
+// The descent refuses a symlink, and that was the only type it looked at.
+// os.Root.OpenRoot on a fifo blocks until a writer arrives, so a guest that
+// can swap a parent component -- the same capability the swap above assumes --
+// can stop brig rather than redirect it. A hang is not an escape, but it is
+// reachable from the same position and it never times out on its own.
+//
+// The test runs the open in a goroutine because a regression here does not
+// fail, it stops: without the bound below the whole package would hang.
+func TestWorkspaceSwappedForAFifoDoesNotHang(t *testing.T) {
+	base := t.TempDir()
+	parent := filepath.Join(base, "parent")
+	work := filepath.Join(parent, "work")
+	if err := os.MkdirAll(work, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	old := betweenLstatAndOpen
+	t.Cleanup(func() { betweenLstatAndOpen = old })
+	betweenLstatAndOpen = func(name string) {
+		if name != "work" {
+			return
+		}
+		betweenLstatAndOpen = func(string) {}
+		if err := os.Rename(work, filepath.Join(parent, "work.real")); err != nil {
+			t.Error(err)
+			return
+		}
+		if err := syscall.Mkfifo(work, 0o644); err != nil {
+			t.Error(err)
+		}
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		c := &Config{Workspace: work}
+		r, err := c.openWorkspace()
+		if r != nil {
+			_ = r.Close()
+		}
+		done <- err
+	}()
+
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("a fifo was accepted as the workspace")
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("opening a fifo hung: the descent looked only for symlinks, so a component " +
+			"swapped for a fifo blocks the boot with no timeout")
+	}
+}
+
+// The descent must not resolve a component's name twice.
+//
+// Guarding the open with O_DIRECTORY stops a fifo blocking us, but the step
+// then opened the same name again to get a root, and a swap landing between
+// those two opens was caught only afterwards. The step opens the descriptor
+// once now and builds the root from that, so there is no second lookup to
+// race. The test renames the component away between the two, which under the
+// old shape is the moment the second open would have found something else.
+func TestDescentDoesNotResolveAComponentTwice(t *testing.T) {
+	base := t.TempDir()
+	parent := filepath.Join(base, "parent")
+	work := filepath.Join(parent, "work")
+	decoy := filepath.Join(parent, "decoy")
+	for _, d := range []string{work, decoy} {
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// A marker only the real workspace has, so the assertion is about which
+	// directory the handle holds rather than about the walk finishing.
+	if err := os.WriteFile(filepath.Join(work, "real"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	old := betweenLstatAndOpen
+	t.Cleanup(func() { betweenLstatAndOpen = old })
+	betweenLstatAndOpen = func(name string) {
+		if name != "work" {
+			return
+		}
+		betweenLstatAndOpen = func(string) {}
+		// Put a different directory at the name the step is about to open.
+		if err := os.Rename(work, filepath.Join(parent, "work.real")); err != nil {
+			t.Error(err)
+			return
+		}
+		if err := os.Rename(decoy, work); err != nil {
+			t.Error(err)
+		}
+	}
+
+	c := &Config{Workspace: work}
+	r, err := c.openWorkspace()
+	if err != nil {
+		// Refusing is a correct outcome: the name stopped naming what was
+		// opened. What must not happen is opening the decoy and calling it the
+		// workspace.
+		return
+	}
+	defer func() { _ = r.Close() }()
+	if _, err := r.lstat("real"); err != nil {
+		t.Fatalf("the handle is not the directory the walk looked at: %v", err)
+	}
+}

--- a/internal/wrap/run.go
+++ b/internal/wrap/run.go
@@ -258,9 +258,11 @@ func (c *Config) EnsureRunning(set creds.Set) error {
 	// home. Re-checking here, holding a directory handle, is what makes the
 	// path we hand over mean what it meant when we looked.
 	//
-	// This does not make the handover atomic -- nothing can, short of passing a
-	// descriptor the runtime accepts -- but it moves the window from "the whole
-	// boot" to "between these two statements".
+	// This does not narrow the window and does not make the handover atomic:
+	// the resolution that matters happens in the runtime, another process,
+	// later. What it buys is that brig refuses to hand over a path that has
+	// already stopped meaning what it checked. Closing the rest needs the
+	// runtime to accept a descriptor rather than a path. See verifyStillOurs.
 	ws, err := c.openWorkspace()
 	if err != nil {
 		return err

--- a/internal/wrap/trust_test.go
+++ b/internal/wrap/trust_test.go
@@ -1,0 +1,86 @@
+//go:build darwin || linux
+
+package wrap
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// statInfo is a FileInfo whose Sys is a Stat_t, which is all writableBy reads.
+type statInfo struct {
+	mode fs.FileMode
+	uid  uint32
+	gid  uint32
+}
+
+func (s statInfo) Name() string       { return "dir" }
+func (s statInfo) Size() int64        { return 0 }
+func (s statInfo) Mode() fs.FileMode  { return fs.ModeDir | s.mode }
+func (s statInfo) ModTime() time.Time { return time.Time{} }
+func (s statInfo) IsDir() bool        { return true }
+func (s statInfo) Sys() any           { return &syscall.Stat_t{Uid: s.uid, Gid: s.gid} }
+
+// TestWritableByFollowsOwnershipAndTheKernel pins the rule that decides how
+// far up the path an attacker can reach. A directory is ours to write if we
+// own it, whatever its bits, or if the kernel says so; a read-only filesystem
+// says no; an answer brig cannot get counts as yes. As root, only what nobody
+// but root could have written is trusted.
+func TestWritableByFollowsOwnershipAndTheKernel(t *testing.T) {
+	const us, other, root = 1000, 1001, 0
+	cases := []struct {
+		name   string
+		info   statInfo
+		uid    int
+		access error
+		want   bool
+	}{
+		{"owned by us", statInfo{0o755, us, us}, us, nil, true},
+		{"owned by us, write bit off", statInfo{0o555, us, us}, us, syscall.EACCES, true},
+		{"other user, kernel says no", statInfo{0o755, other, other}, us, syscall.EACCES, false},
+		{"root-owned, kernel says no", statInfo{0o711, root, root}, us, syscall.EACCES, false},
+		{"other user, kernel says yes", statInfo{0o755, other, other}, us, nil, true},
+		{"other user, read-only filesystem", statInfo{0o777, other, other}, us, syscall.EROFS, false},
+		{"other user, no answer", statInfo{0o755, other, other}, us, syscall.ENOENT, true},
+		{"root, root-owned 755", statInfo{0o755, root, root}, root, nil, false},
+		{"root, root-owned search only", statInfo{0o711, root, root}, root, nil, false},
+		{"root, root-owned sticky tmp", statInfo{0o1777, root, root}, root, nil, true},
+		{"root, root-owned group-writable", statInfo{0o775, root, root}, root, nil, true},
+		{"root, user-owned", statInfo{0o755, us, us}, root, nil, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := writableBy(tc.info, tc.uid, tc.access); got != tc.want {
+				t.Fatalf("writableBy = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestDirWritableByUsAsksTheKernel drives the real thing on a directory we
+// own with its write bit off: the kernel says no, ownership says yes, and
+// ownership wins because the owner can chmod it back.
+func TestDirWritableByUsAsksTheKernel(t *testing.T) {
+	if os.Getuid() == 0 {
+		t.Skip("root owns nothing it cannot write")
+	}
+	dir := filepath.Join(t.TempDir(), "locked")
+	if err := os.Mkdir(dir, 0o555); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(dir, 0o755) })
+	info, err := os.Stat(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := syscall.Access(dir, wOK); err == nil {
+		t.Fatalf("the kernel let us write a 0555 directory; is the filesystem ignoring modes?")
+	}
+	if !dirWritableByUs(dir, info) {
+		t.Fatal("a directory we own was called not ours to write")
+	}
+}


### PR DESCRIPTION
## What this fixes

A guest that can write a parent directory of its workspace could make brig
write outside the workspace, at a path the guest chooses. brig prepares the
workspace on the host before boot, as the user brig runs as, and one of the
files it writes is the guest git credential helper: mode 0755, run by git on
the host, outside any sandbox. Closes #68.

The path was validated by resolving the path string more than once. Every
resolution follows symlinks from the top, so a guest that flips a parent
component into a symlink between two resolutions redirects the write, and the
comparison afterwards agrees with it, because both resolutions followed the
same planted link.

## How it works

The user brig runs as can swap a directory entry only inside a directory it can
write. The path splits at the first such directory:

- The prefix above it is opened by name in one call. The kernel resolves it and
  follows whatever links the system or an administrator put there; brig needs
  only search permission on the way.
- From there down, brig descends one component at a time against the directory
  already open above it, refusing every symlink. Nothing above a component is
  resolved again.

`trustedPrefix` finds the split from ownership and `access(2)`, so an ACL, or a
group beyond `NGROUPS_MAX`, counts the way the kernel counts it. As root, brig
trusts only what nobody but root could have written (root-owned, no group or
other write), which keeps the system's own links usable.

After the descent, `verifyStillOurs` confirms the handle still resolves to the
directory it opened, because the workspace reaches the runtime as a string that
another process resolves later.

## Behaviour change

A root-owned symlink inside a directory the user can write is now refused
rather than followed, with a message naming it. That is a layout an
administrator would have had to create inside user-writable territory.

## Limits

`checkWorkspacePathBeforeCreate`, on the `MkdirAll` path, still walks by string.
Worst case is one empty directory created through a planted link, in a directory
the attacker can already write, before the run is refused. The ACL question is
tracked in #71.

Not yet exercised against a real `brig run` on each platform; this is the path
that prepares the workspace for every run, so it wants one before merge.

## Tests

Each window is driven through a seam and fails against the previous code: a
parent swapped during the descent, a symlink in the tail, a trusted absolute
link on the prefix, and a search-only `0711` ancestor. `go test -race ./...`
and `script/smoke.sh` pass.

Closes #68. Refs #71, brig-sh/hull#7
