### PR TITLE
docs(security): scope the no-host-read claim to credentials

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -32,11 +32,20 @@ them for itself.
 
 ## Credentials
 
-**A run on a shipped profile reads no host source.** Nothing on the `brig run`,
-`exec` or `shell` path reaches a keychain item brig did not write, a file
-outside the workspace, or a host command. Your host login enters brig's own
-store once, when you type `brig secret import <profile>`, and every run
-afterwards reads only that store:
+**A run on a shipped profile reads no host credential source.** Nothing on the
+`brig run`, `exec` or `shell` path reaches a keychain item brig did not write,
+a credential file outside the workspace, or a host command that produces one.
+Two host reads do happen, and no setting turns either off. brig runs `git
+config --get` in the directory you invoked it from, for `user.name`,
+`user.email` and `github.user`, to resolve the commit identity forwarded into
+the guest. If `github.user` comes back empty it then reads the `user:` line
+from the stanza for your git host in gh's `hosts.yml`, under `$GH_CONFIG_DIR`
+or `~/.config/gh`, to find the login that pairs with the forwarded token. That
+file usually carries gh's own OAuth token as well; brig takes the login and
+nothing else. `BRIG_GIT_IDENTITY=0`, `BRIG_GIT_CONFIG=0` and `BRIG_GIT_USER`
+change what brig does with the answers, not whether it asks. Your host login
+enters brig's own store once, when you type `brig secret import <profile>`,
+and every run afterwards reads only that store:
 
 ```bash
 brig run claude-code               # log in inside the sandbox, or:


### PR DESCRIPTION
## Summary

`docs/security.md` said that nothing on the `run`, `exec` or `shell` path
reaches a file outside the workspace or a host command. The git plumbing does
both on every invocation that loads a profile, which includes `stop`, `rm` and
`env` as well: it runs `git config --get` in the invoking directory for the
commit identity it forwards, and when `github.user` is unset it reads the login
from gh's `hosts.yml`. Neither is a credential read, and the paragraph's real
promise, that a run on a shipped profile reads no host credential source,
survives. The sentence as written did not.

The paragraph now says exactly what is read, for what, and that no setting turns
either read off: `BRIG_GIT_IDENTITY`, `BRIG_GIT_CONFIG` and `BRIG_GIT_USER`
change what brig does with the answers, not whether it asks. That last part was
checked against the built binary with a logging `git` shim.

## Related issues

Closes #35

## Changes

- One paragraph in `docs/security.md`, rewritten. Nothing else in the file.

## Checklist

- [x] `make all` passes (vet, test, build)
- [x] `script/smoke.sh` passes
- [ ] ~~I have added or updated tests covering the change~~
- [ ] ~~I have run `go test ./... -race`, if the change touches concurrency, subprocesses or the daemon~~
- [ ] ~~I have exercised the change against a real runtime (`brig run <agent>`), if it touches the run, exec or credential path~~
- [x] I have updated the affected docs (README, `docs/security.md`, `docs/profiles.md`, `docs/brigd.md`)

The claim as rewritten is one the claims suite can defend: the assertion is that
on a run, the only host paths opened outside the workspace are the invoking
directory's git config and gh's `hosts.yml`, and that the `oauth_token:` line
in the latter is never read. That test belongs with #22.

## Credentials and the sandbox boundary

No behaviour changes. This narrows a published claim about the second promise to
what the code does. One thing came out of verifying it: a FIFO planted at
`hosts.yml` blocks brig on open. That file sits outside the workspace, so the
guest cannot plant it, and it is filed separately rather than fixed here.
