### PR TITLE
docs: add a compatibility policy and name removal releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -661,6 +661,7 @@ The README is the overview. The details live in [docs/](docs/):
 - [brigd.md](docs/brigd.md) -- the session daemon and its protocol
 - [runtimes.md](docs/runtimes.md) -- hull, nerdctl and urunc: what each one is, its licence, and every command brig runs against it
 - [support.md](docs/support.md) -- which computers brig runs on
+- [compatibility.md](docs/compatibility.md) -- what a version number promises, and what it does not
 
 Found a security problem? [SECURITY.md](SECURITY.md) is how to report it
 privately, rather than in a public issue.

--- a/cmd/brig/deprecated_test.go
+++ b/cmd/brig/deprecated_test.go
@@ -192,6 +192,11 @@ func TestHostCredentialWarnsAndStillWorks(t *testing.T) {
 	if !strings.Contains(warning, "brig secret import mine") {
 		t.Errorf("the warning does not name what replaces it:\n%s", warning)
 	}
+	// A deadline the reader can act on is a version number, not "next release".
+	// See docs/compatibility.md.
+	if !strings.Contains(warning, "v0.1.0-rc17") {
+		t.Errorf("the warning does not name the release that removes it:\n%s", warning)
+	}
 	p, ok := profile.Lookup("mine")
 	if !ok {
 		t.Fatal("the profile stopped loading")

--- a/cmd/brig/main.go
+++ b/cmd/brig/main.go
@@ -2364,7 +2364,7 @@ func warnf(format string, a ...any) {
 
 // warnDeprecatedProfileKeys says that a profile FILE still carries
 // hostCredential:, which reads another application's keychain on every run and
-// goes in the next release.
+// goes in v0.1.0-rc17.
 //
 // Only for file-backed profiles, and that scoping is the whole point: no
 // built-in carries the key any more, so an unscoped check would have brig warn
@@ -2384,8 +2384,8 @@ func warnDeprecatedProfileKeys() {
 		if path, ok := profile.Path(p.Name); ok {
 			where = path
 		}
-		warnf("hostCredential: in %s is deprecated and goes in the "+
-			"next release -- it reads another application's keychain on every run. "+
+		warnf("hostCredential: in %s is deprecated and goes in "+
+			"v0.1.0-rc17 -- it reads another application's keychain on every run. "+
 			"Declare the credential under secrets: with sources: instead, then: "+
 			"brig secret import %s", where, p.Name)
 	}

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -1,0 +1,106 @@
+# What a version number promises
+
+This page says which parts of brig you can build on and which you cannot, how
+long a name survives after it is deprecated, and where a break is written down.
+It is meant to stay short enough to stay true, so it names surfaces rather than
+restating what each one does; the README and the other docs are where the
+detail lives.
+
+## What 0.x means
+
+brig has no stable release yet. There are twelve `v0.1.0-rc` tags and nothing
+without the `-rc`, so every version to date is a release candidate. Until a
+`1.0` ships, treat the whole tool as prerelease: a covered surface can still
+change between releases, but it changes under the deprecation rule below and
+the change is recorded where [breaking changes](#where-breaking-changes-are-recorded)
+go. `1.0` is the point at which the covered surfaces stop moving without a
+major version bump. The unstable surfaces below carry no such promise even
+then, and they say so on purpose.
+
+## What the promise covers
+
+These are the surfaces a script or a profile can depend on. Within `0.x` they
+change only through a deprecation, and across a `1.0` they will not change
+without a major bump.
+
+- **The CLI verbs.** `run`, `create`, `exec`, `shell`, `stop`, `rm`, `ls`,
+  `reset`, `env`, `version`, `help`, the profile verbs (`profiles`, and
+  `profile ls|export|import|edit|rm`, plus the top-level `export` and `import`
+  aliases), and the secret verbs (`secret create|read|update|delete|ls|import`).
+  The list is `cmd/brig/main.go`.
+- **The run-line flags.** `-n`/`--name`, `-t`/`--image`, `-w`/`--workspace`,
+  `-m`/`--memory`, `--cpus`, `-d`/`--detach`, and `--skills`. Everything else
+  on a run line belongs to the agent, by design, so the set brig owns is the
+  set here and no more.
+- **The settings documented in the README.** Every `BRIG_*` variable in the
+  README's [environment variables](../README.md#environment-variables) tables,
+  read under the `BRIG_<AGENT>_<KEY>` then `BRIG_<KEY>` order stated there. A
+  variable that is not in those tables is not part of this promise; see below.
+- **The profile schema.** The fields `brig profile export` writes and
+  documents in its header: `name`, `desc`, `kind`, `image`, `guestHome`,
+  `binary`, `secrets`, `env`, `files`, `volumes`, `deny`, `mem`, `cpus`,
+  `hypervisor`, `runtimeBin`, `rootfsType`, `genericBoot` and `reserved`. The
+  types are `internal/profile`. The parser refuses an unknown field rather than
+  ignoring it, so adding one is a change you will see, not a silent no-op.
+- **The exit status, coarsely.** `0` is success and non-zero is failure. On
+  `run`, `exec` and `shell` brig replaces itself with the runtime, so the
+  status you get back is the agent's own. The split between success and failure
+  is covered; a specific non-zero number is not a contract yet.
+- **The filesystem layout.** Workspaces under `~/brig/<agent>` (a named session
+  appends `-<slug>`); brig's own runtime sockets under `~/.brig`; and custom
+  profiles under the config directory, `$XDG_CONFIG_HOME/brig` or
+  `~/.config/brig` when that is unset. `brig secret` stores each item in the
+  macOS login keychain under the service `sh.brig.secret`.
+
+## What is explicitly not covered
+
+Depending on any of these is depending on something we intend to move.
+
+- **The `brigd` line protocol.** The JSON operations in
+  [docs/brigd.md](brigd.md) are unstable on purpose. `brigd` is a small,
+  optional daemon that most people never run, and its protocol is free to
+  change between releases without a deprecation. Drive brig through the CLI if
+  you want the promise above.
+- **The JSON output.** There is little of it today, `brig profile export
+  --json` being the main case, and its shape is not fixed. Do not parse it in
+  anything you need to keep working across releases.
+- **The human-readable output.** The wording of messages on stdout and stderr,
+  the warnings, and the column layout of `ls` and `profiles` are for people to
+  read, not for `grep` to match. They get reworded whenever a clearer sentence
+  turns up.
+- **Undocumented and test-only settings.** Any `BRIG_*` variable not in the
+  README tables, including the `BRIG_TEST_*` ones, exists for brig's own use
+  and can change or vanish without notice.
+- **Deprecated spellings.** Anything named in the next section is already on its
+  way out and covered only for its remaining window.
+
+## How long a deprecated spelling lives
+
+When a replacement ships, the old spelling keeps working for two releases and
+is removed in the third. While it works, brig prints a notice that names the
+release which removes it, so the deadline is a version number you can read and
+not a vague "soon".
+
+The spellings deprecated before this policy are already scheduled: `brig
+agents`, `brig template`, the profile keys `hostCredential:`, `forward:` and
+`statePaths:`, and the setting `BRIG_TEMPLATE_DIR`. Their notices name
+`v0.1.0-rc17` as the release that removes them.
+
+`BRIG_CREDENTIALS_CMD` is gone already. A run that still sets it fails and
+names the replacement, rather than warning and carrying on.
+
+## Where breaking changes are recorded
+
+A change that breaks a covered surface carries a `BREAKING CHANGE:` footer on
+its commit, per the Conventional Commits rule in
+[CONTRIBUTING.md](../CONTRIBUTING.md#commit-messages). Those footers are what
+the generated changelog collects, so the changelog for a release is the list of
+what you have to change on the way to it.
+
+## The support matrix
+
+Which operating system versions and architectures brig is supported on is part
+of this surface too, and "recommended and tested" is a statement about what we
+run, not a statement of support. This page does not carry the matrix; it lives
+with the platform notes in the README's [macOS](../README.md#macos) and
+[Linux](../README.md#linux) sections, which another change owns.

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -76,18 +76,27 @@ Depending on any of these is depending on something we intend to move.
 
 ## How long a deprecated spelling lives
 
-When a replacement ships, the old spelling keeps working for two releases and
-is removed in the third. While it works, brig prints a notice that names the
-release which removes it, so the deadline is a version number you can read and
-not a vague "soon".
+When a replacement ships, the old spelling keeps working for at least one
+further release, and the removal release is named in the deprecation notice or
+here. That named release is the authority, so the deadline is a version number
+you can read rather than a vague "soon".
 
-The spellings deprecated before this policy are already scheduled: `brig
-agents`, `brig template`, the profile keys `hostCredential:`, `forward:` and
-`statePaths:`, and the setting `BRIG_TEMPLATE_DIR`. Their notices name
-`v0.1.0-rc17` as the release that removes them.
+The spellings deprecated before this policy are scheduled unevenly, and this is
+what each actually does today:
 
-`BRIG_CREDENTIALS_CMD` is gone already. A run that still sets it fails and
-names the replacement, rather than warning and carrying on.
+- `BRIG_CREDENTIALS_CMD` is gone. It was deprecated in `v0.1.0-rc16` and
+  removed; a run that still sets it fails and names the replacement, rather
+  than warning and carrying on.
+- The `hostCredential:` profile key prints a runtime notice naming
+  `v0.1.0-rc17` as the release that removes it. It was deprecated in
+  `v0.1.0-rc16` and has left the shipped profiles.
+- `brig agents` and `brig template` print a one-line notice pointing at the new
+  spelling (`brig profiles`, `brig profile`), with no removal release named yet.
+  They keep working until one is.
+- The profile keys `forward:` and `statePaths:` are noted only in the exported
+  profile header, not at runtime, and carry no removal release yet.
+- `BRIG_TEMPLATE_DIR` is not deprecated: it is an accepted alias for
+  `BRIG_PROFILE_DIR` and keeps working.
 
 ## Where breaking changes are recorded
 


### PR DESCRIPTION
## Summary

Nothing said what a version number promised. Which surfaces were covered, how
long a deprecated spelling survived, and what a patch release could change were
all answered by whatever the last commit did, and three deprecation messages in
the tool said a thing "goes in the next release" without naming one.

`docs/compatibility.md` states it, short enough to stay true. Every public
surface is classified from the source as covered or explicitly not covered, the
deprecation window is two releases with removal in the third, and breaking
changes are recorded where the changelog is generated from. The `brigd` line
protocol, the JSON output and the human-readable text are declared unstable on
purpose, which is the more useful half of the page.

The three "next release" messages now name `v0.1.0-rc17`, with tests asserting
the release name so a later edit cannot slide back to "next".

## Related issues

Closes #60
Refs #23, #20

## Changes

- `docs/compatibility.md`, linked once from the README's Documentation list.
- `BRIG_CREDENTIALS_CMD` and `hostCredential:` warnings, and the help-text line,
  name `v0.1.0-rc17` instead of "next release". `cmd/brig/deprecated_test.go`
  and `internal/wrap/config_test.go` assert it.

## Two things to know before merging

`BRIG_CREDENTIALS_CMD` is being removed in #23, in flight now. If that lands in
rc17 the message is exactly right; if it slips, the policy's own rule is what
decides the number, not this text.

The policy says the support matrix lives in the README's platform sections. #20
is putting it in `docs/support.md`; whichever merges second fixes the pointer.

## Checklist

- [x] `make all` passes (vet, test, build)
- [x] `script/smoke.sh` passes
- [x] I have added or updated tests covering the change
- [x] I have run `go test ./... -race`, if the change touches concurrency, subprocesses or the daemon
- [ ] ~~I have exercised the change against a real runtime (`brig run <agent>`), if it touches the run, exec or credential path~~
- [x] I have updated the affected docs (README, `docs/security.md`, `docs/profiles.md`, `docs/brigd.md`)

## Credentials and the sandbox boundary

Message text only. No behaviour changes on either promise.
