### PR TITLE
fix(creds): say which values BRIG_ENV_ARGV puts on the command line

### DIFF
--- a/internal/creds/creds.go
+++ b/internal/creds/creds.go
@@ -36,6 +36,26 @@ type Set struct {
 }
 
 // Add appends a variable and records its reporting name.
+//
+// Add rather than AddSecret for a credential that came out of the ambient
+// environment, and the asymmetry is deliberate rather than an oversight worth
+// closing. Marking every resolved credential Secret whatever its source was
+// considered: it would have left BRIG_ENV_ARGV applying only to values that are
+// not credentials, which is every value that has no need of it. GH_TOKEN and the
+// agent's own token are the whole of what a run forwards from the environment;
+// what would be left for the hatch to carry is GIT_TERMINAL_PROMPT and the git
+// identity. A runtime build that cannot take a bare `--env KEY` -- the one thing
+// the hatch exists for -- would go on being handed `--env GH_TOKEN` with no
+// value attached, and the sandbox would come up unauthenticated with nothing
+// said about why. A hatch that silently stops carrying the values it was built
+// to carry is worse than one whose cost is visible.
+//
+// So the cost is made visible instead: a run that puts values in argv says which
+// ones, every time, before the runtime is invoked, and `brig env` reports the
+// setting. See wrap.warnArgvExposure and wrap.reportArgv. What stays true either
+// way is that a value brig resolved on the user's behalf -- one the user never
+// chose to expose anywhere -- is never on the command line, whatever the hatch
+// says; see AddSecret.
 func (s *Set) Add(name, value, reportAs string) {
 	s.Vars = append(s.Vars, runtime.Var{Name: name, Value: value})
 	if reportAs == "" {

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -253,6 +253,36 @@ func runtimeBinFromProfile(bin string) (string, error) {
 // them, so it is opt-in and says so.
 func envInArgv() bool { return os.Getenv("BRIG_ENV_ARGV") == "1" }
 
+// inArgv is the single rule for whether a value travels on the command line:
+// the hatch is on, and brig did not resolve the value on the user's behalf.
+//
+// Written once because two callers need it. splitEnv builds the command line
+// from it, and ArgvExposed reports what that command line will carry before
+// anything is spawned. A report derived from a second copy of the rule is a
+// report that can be wrong in exactly the case it exists for.
+func inArgv(v Var) bool { return envInArgv() && !v.Secret }
+
+// ArgvExposed names the variables whose values this invocation would put on
+// the runtime's command line, in the order they were given. It returns nothing
+// when the hatch is off, and never names a Var marked Secret: splitEnv keeps
+// those off the command line whatever the setting says.
+//
+// Exported so the exposure can be said out loud before the runtime is invoked.
+// BRIG_ENV_ARGV is opted into once, in a shell profile, and then remembered by
+// nobody: months later such a run looks like every other one, and the only
+// places the difference shows are `ps` and the host's own argv log, neither of
+// which anyone reads until after something has gone wrong. The names are what
+// a caller can act on; the values stay here.
+func ArgvExposed(vars []Var) []string {
+	var names []string
+	for _, v := range vars {
+		if inArgv(v) {
+			names = append(names, v.Name)
+		}
+	}
+	return names
+}
+
 // splitEnv turns guest variables into the argv flags and the child-process
 // environment that carry them, keeping values out of argv unless the escape
 // hatch is set -- and even then, a Var marked Secret stays out of argv, because
@@ -260,7 +290,7 @@ func envInArgv() bool { return os.Getenv("BRIG_ENV_ARGV") == "1" }
 // ambient shell values, not keychain secrets.
 func splitEnv(flag string, vars []Var) (args []string, env []string) {
 	for _, v := range vars {
-		if envInArgv() && !v.Secret {
+		if inArgv(v) {
 			args = append(args, flag, v.Name+"="+v.Value)
 			continue
 		}

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -69,6 +69,53 @@ func TestSplitEnvArgvEscapeHatchNeverExposesSecrets(t *testing.T) {
 	}
 }
 
+// The exposure has to be reportable before anything is spawned, and reported
+// from the same rule the command line is built from: a warning that names one
+// set of variables while argv carries another is wrong in exactly the case it
+// exists for. So the check is against the argv splitEnv actually produces,
+// rather than against a second list that merely looks right.
+func TestArgvExposedNamesWhatReachesArgv(t *testing.T) {
+	t.Setenv("BRIG_ENV_ARGV", "1")
+	vars := []Var{
+		{Name: "GH_TOKEN", Value: "ghp_secret"},
+		{Name: "OAUTH", Value: "sk-fromkeychain", Secret: true},
+		{Name: "GIT_TERMINAL_PROMPT", Value: "0"},
+	}
+
+	got := ArgvExposed(vars)
+	want := []string{"GH_TOKEN", "GIT_TERMINAL_PROMPT"}
+	if len(got) != len(want) {
+		t.Fatalf("ArgvExposed = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("ArgvExposed = %v, want %v", got, want)
+		}
+	}
+
+	args, _ := splitEnv("--env", vars)
+	joined := strings.Join(args, " ")
+	for _, name := range got {
+		if !strings.Contains(joined, "--env "+name+"=") {
+			t.Errorf("%s was reported as reaching argv but did not: %q", name, joined)
+		}
+	}
+	// The other half of the claim: nothing the report left out carries a value
+	// on the command line either.
+	if strings.Contains(joined, "sk-fromkeychain") {
+		t.Errorf("a value not named by the report reached argv: %q", joined)
+	}
+}
+
+// Off, there is nothing to warn about: every value travels in the child's
+// environment, which is what the report has to say by saying nothing.
+func TestArgvExposedIsSilentWithTheHatchOff(t *testing.T) {
+	t.Setenv("BRIG_ENV_ARGV", "")
+	if got := ArgvExposed([]Var{{Name: "GH_TOKEN", Value: "ghp_secret"}}); len(got) != 0 {
+		t.Errorf("ArgvExposed = %v with the hatch off, want nothing", got)
+	}
+}
+
 // hull reads HULL_TELEMETRY_*. Getting this wrong does not break a run, it
 // just misattributes or double-counts, which is exactly the kind of thing
 // nobody notices for months.

--- a/internal/wrap/run.go
+++ b/internal/wrap/run.go
@@ -181,6 +181,13 @@ func (c *Config) EnsureRunning(set creds.Set) error {
 	if err := c.preflightHypervisor(hypervisor); err != nil {
 		return err
 	}
+	// Said on the run, not in BuildEnv: BuildEnv resolves the set for every
+	// verb, brig env included, so a warning from there prints on a preview that
+	// spawns nothing and lands twice on env next to reportArgv. Here it is the
+	// run, once, before the workspace is prepared or a value reaches a command
+	// line. The set is the whole of what the runtime will be handed: the git
+	// plumbing and SetupGit have both added to it.
+	c.warnArgvExposure(set)
 	if err := c.PrepareWorkspace(); err != nil {
 		return err
 	}

--- a/internal/wrap/status.go
+++ b/internal/wrap/status.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/brig-sh/brig/internal/creds"
 	"github.com/brig-sh/brig/internal/profile"
+	"github.com/brig-sh/brig/internal/runtime"
 )
 
 // Status reports what this invocation would do, by name only -- never a
@@ -47,6 +48,7 @@ func (c *Config) Status(set creds.Set) {
 	} else {
 		c.sayf("guest git over HTTPS: off (BRIG_GIT_CONFIG=1 to enable)")
 	}
+	c.reportArgv(set)
 
 	// Where the guest's login comes from, and whether it is usable: an
 	// expired host token is exactly what sends the sandbox back to its login
@@ -103,6 +105,58 @@ func (c *Config) Status(set creds.Set) {
 		c.sayf("guest commit identity, as resolved in %s:", c.Cwd)
 		c.sayf("  %s <%s> (unsigned)", orUnset(c.GitName), orUnset(c.GitEmail))
 	}
+}
+
+// reportArgv says that BRIG_ENV_ARGV is on and which values it will put on the
+// runtime's command line, and says nothing at all when it is off.
+//
+// It is reported here because this preview is where a user asks what a sandbox
+// is about to be handed, and until now the answer left out the one setting that
+// changes where those values end up. The silence when the hatch is off is
+// deliberate rather than an omission: brig keeps values out of argv as a matter
+// of course, and a line restating that on every `brig env` would bury the lines
+// that are about this run.
+//
+// Named from the resolved set for the same reason reportDeny is: the hatch on
+// its own is a claim about the future, and what this run will actually put on
+// the command line is the thing worth knowing.
+func (c *Config) reportArgv(set creds.Set) {
+	names := runtime.ArgvExposed(set.Vars)
+	if len(names) == 0 {
+		return
+	}
+	c.sayf("BRIG_ENV_ARGV=1, so these values go on the runtime's command line, "+
+		"where `ps` can read them: %s", strings.Join(names, " "))
+}
+
+// warnArgvExposure is reportArgv on stderr, for a run rather than a preview.
+//
+// The hatch says it is opt-in in a comment, and the opting in happens once, in
+// a shell profile, for a runtime build that has since been replaced. Nothing
+// has said a word about it since. The shipped codex and claude-code profiles
+// resolve GH_TOKEN from the environment first, and an environment-sourced value
+// is not one brig resolved on the user's behalf, so the common case is a real
+// credential going onto the command line on every run with nothing said -- while
+// the credential deliberately imported into brig's own store, the rarer of the
+// two, is the one the exemption protects.
+//
+// One line, before the runtime is invoked, so it is on screen before the value
+// is anywhere anything else can read it. BuildEnv is the last point where the
+// whole forwarded set is known and nothing has been spawned yet.
+//
+// The list is everything whose value lands on the command line, brig's own
+// plumbing included -- GIT_TERMINAL_PROMPT is not a credential and is on there
+// all the same. A warning that named only the interesting half would be a false
+// statement about the command line, and the command line is the whole subject.
+func (c *Config) warnArgvExposure(set creds.Set) {
+	names := runtime.ArgvExposed(set.Vars)
+	if len(names) == 0 {
+		return
+	}
+	c.warnf("BRIG_ENV_ARGV=1 puts these values on the runtime's command line, where "+
+		"`ps` can read them and the host's argv log keeps them after the sandbox is "+
+		"gone: %s. Unset BRIG_ENV_ARGV to forward them by name only",
+		strings.Join(names, " "))
 }
 
 // reportDeny says what the denylist did to THIS run, rather than reciting the

--- a/internal/wrap/status_test.go
+++ b/internal/wrap/status_test.go
@@ -108,6 +108,159 @@ func TestStatusStillDistinguishesTheEnvironmentAndTheHost(t *testing.T) {
 	}
 }
 
+// The warning belongs to the run, not to BuildEnv. BuildEnv resolves the set
+// for every verb, brig env included, so a warning from there is printed on a
+// preview that spawns nothing and lands twice on env, next to reportArgv.
+// BuildEnv stays silent about the hatch; EnsureRunning is where the run says it.
+func TestBuildEnvDoesNotWarnAboutArgv(t *testing.T) {
+	t.Setenv("BRIG_ENV_ARGV", "1")
+	t.Setenv("GH_TOKEN", "ghp_secret")
+	c := bindingConfig(t, "env:\n  - name: GH_TOKEN\n    ref: env.GH_TOKEN\n")
+
+	if _, err := c.BuildEnv(); err != nil {
+		t.Fatal(err)
+	}
+	if got := c.Err.(*bytes.Buffer).String(); strings.Contains(got, "BRIG_ENV_ARGV") {
+		t.Errorf("BuildEnv warned about the hatch, which doubles it on brig env:\n%s", got)
+	}
+}
+
+// The hatch is opted into once, in a shell profile, and then said nowhere. A
+// run that puts a credential on the command line has to say so on the run, and
+// name the variable, because "some value" is not something a user can act on.
+// The run says it, not BuildEnv, so a preview does not repeat it. Forced to
+// refuse at the hypervisor floor, EnsureRunning still warns first: the warning
+// is before anything the runtime touches.
+func TestEnsureRunningWarnsWhenValuesWouldReachArgv(t *testing.T) {
+	t.Setenv("BRIG_ENV_ARGV", "1")
+	t.Setenv("GH_TOKEN", "ghp_secret")
+	c := bindingConfig(t, "env:\n  - name: GH_TOKEN\n    ref: env.GH_TOKEN\n")
+	// A space in the workspace makes PrepareWorkspace refuse at the very start
+	// of EnsureRunning, so the run stops before it touches a runtime and the
+	// test can assert the warning was printed first.
+	c.Workspace = "/brig warns first/ws"
+
+	set, err := c.BuildEnv()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, v := range set.Vars {
+		if v.Name == "GH_TOKEN" && v.Secret {
+			t.Fatal("GH_TOKEN is exempt from the hatch, so there is nothing to warn about")
+		}
+	}
+	// Clear whatever BuildEnv said, so the warning this test finds can only have
+	// come from EnsureRunning. Without this the test passes on the old code too,
+	// where BuildEnv is the one warning.
+	c.Err.(*bytes.Buffer).Reset()
+	if err := c.EnsureRunning(set); err == nil {
+		t.Fatal("a workspace with a space must refuse, so the test can assert the warning came first")
+	}
+
+	var warnings []string
+	for _, line := range strings.Split(c.Err.(*bytes.Buffer).String(), "\n") {
+		if strings.Contains(line, "BRIG_ENV_ARGV") {
+			warnings = append(warnings, line)
+		}
+	}
+	if len(warnings) != 1 {
+		t.Fatalf("want exactly one warning, got %d:\n%s", len(warnings),
+			strings.Join(warnings, "\n"))
+	}
+	if !strings.Contains(warnings[0], "GH_TOKEN") {
+		t.Errorf("the warning does not name the variable: %s", warnings[0])
+	}
+	if strings.Contains(warnings[0], "ghp_secret") {
+		t.Errorf("the warning printed the value it is warning about: %s", warnings[0])
+	}
+}
+
+// Off is the default, and a run with the hatch off must be exactly as quiet as
+// it was.
+func TestEnsureRunningSaysNothingWithTheHatchOff(t *testing.T) {
+	t.Setenv("BRIG_ENV_ARGV", "")
+	t.Setenv("GH_TOKEN", "ghp_secret")
+	c := bindingConfig(t, "env:\n  - name: GH_TOKEN\n    ref: env.GH_TOKEN\n")
+	c.Workspace = "/brig warns first/ws"
+
+	set, err := c.BuildEnv()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := c.EnsureRunning(set); err == nil {
+		t.Fatal("a workspace with a space must refuse")
+	}
+	if got := c.Err.(*bytes.Buffer).String(); strings.Contains(got, "BRIG_ENV_ARGV") {
+		t.Errorf("a run with the hatch off mentioned it:\n%s", got)
+	}
+}
+
+// brig env resolves the set with BuildEnv, like every verb, then previews it
+// with Status. The hatch line must appear once, from reportArgv, not also from
+// a run warning BuildEnv should not be making.
+func TestEnvReportsTheArgvHatchExactlyOnce(t *testing.T) {
+	t.Setenv("BRIG_ENV_ARGV", "1")
+	t.Setenv("GH_TOKEN", "ghp_secret")
+	c := bindingConfig(t, "env:\n  - name: GH_TOKEN\n    ref: env.GH_TOKEN\n")
+	c.Runtime = fakeRuntime{}
+
+	set, err := c.BuildEnv()
+	if err != nil {
+		t.Fatal(err)
+	}
+	c.Status(set)
+
+	lines := 0
+	for _, w := range []*bytes.Buffer{c.Out.(*bytes.Buffer), c.Err.(*bytes.Buffer)} {
+		for _, line := range strings.Split(w.String(), "\n") {
+			if strings.Contains(line, "command line") {
+				lines++
+			}
+		}
+	}
+	if lines != 1 {
+		t.Fatalf("brig env should mention the command line once, got %d", lines)
+	}
+}
+
+// `brig env` is where a user asks what a sandbox is about to be handed, so it
+// is where the setting that decides how those values travel belongs.
+func TestStatusReportsTheArgvHatch(t *testing.T) {
+	t.Setenv("BRIG_ENV_ARGV", "1")
+	var set creds.Set
+	set.Add("GH_TOKEN", "ghp_secret", "GH_TOKEN")
+	set.AddSecret("TOK", "s3cr3t", "TOK(secret)")
+
+	got := statusOutput(t, "env:\n  - name: GH_TOKEN\n    ref: env.GH_TOKEN\n", set)
+	if !strings.Contains(got, "BRIG_ENV_ARGV=1") {
+		t.Errorf("the report does not mention the setting:\n%s", got)
+	}
+	if !strings.Contains(got, "GH_TOKEN") {
+		t.Errorf("the report does not name what goes on the command line:\n%s", got)
+	}
+	// A value brig resolved is exempt whatever the hatch says, so naming it
+	// here would be a false statement about the command line.
+	for _, v := range []string{"TOK ", "ghp_secret", "s3cr3t"} {
+		if strings.Contains(got, v) {
+			t.Errorf("the report carries %q, which does not reach argv:\n%s", v, got)
+		}
+	}
+}
+
+// With the hatch off, nothing about it is reported: brig keeps values out of
+// argv as a matter of course, and a line saying so on every preview would bury
+// the lines that are about this run.
+func TestStatusIsSilentAboutTheArgvHatchWhenItIsOff(t *testing.T) {
+	t.Setenv("BRIG_ENV_ARGV", "")
+	var set creds.Set
+	set.Add("GH_TOKEN", "ghp_secret", "GH_TOKEN")
+
+	got := statusOutput(t, "env:\n  - name: GH_TOKEN\n    ref: env.GH_TOKEN\n", set)
+	if strings.Contains(got, "BRIG_ENV_ARGV") {
+		t.Errorf("the hatch was reported while off:\n%s", got)
+	}
+}
+
 // What a run could hand the guest is reported by name, and the "forwarding
 // nothing" line names the bindings rather than the retired Forward list.
 func TestStatusNamesTheBindingsWhenNothingIsForwarded(t *testing.T) {


### PR DESCRIPTION
## Summary

`BRIG_ENV_ARGV` puts forwarded values on the runtime's command line, where `ps`
can read them. Values brig resolved on the user's behalf were exempt; a value
from the ambient environment was not, and the shipped `codex` and `claude-code`
profiles resolve `GH_TOKEN` from the environment first. So the exemption
protected the credential a user imported into brig's store, and left on the
command line the one they exported in their shell profile, which is the common
case. Nothing said a word about it, and `brig env` never mentioned the setting.

Now one line on stderr before the runtime is invoked names every variable
whose value will land on the command line, and `brig env` reports the same
thing. Both are silent when the hatch is off, so nothing changes for anyone who
never set it.

## Related issues

Closes #36

## Changes

- `inArgv(Var)` in `internal/runtime/runtime.go` is the single rule for whether
  a value travels on the command line. `splitEnv` builds argv from it and the
  new `ArgvExposed` reports from it, so the report cannot drift from the argv.
- `warnArgvExposure` at the start of `EnsureRunning`, the run path both the CLI
  and the daemon take, before anything the runtime touches. It is not in
  `BuildEnv`, which every verb calls, because a warning from there prints on
  `brig env`, which spawns nothing, and lands twice next to `reportArgv`.
  `reportArgv` in `brig env`, next to the git line.
- The list names everything whose value lands on the command line, brig's own
  plumbing included. A warning that named only the credentials would be a false
  statement about the command line.
- Resolved credentials are deliberately not all marked `Secret`. That would
  leave the hatch applying only to values that never needed it, and a runtime
  build that cannot take a bare `--env KEY`, which is the hatch's only reason
  to exist, would then receive `GH_TOKEN` with no value and come up
  unauthenticated with nothing said. The exposure is made visible instead of
  being removed from a hatch that exists to allow it. The reasoning is recorded
  on `Set.Add` where the next reader will look.
- Tests: the reported names match the argv `splitEnv` produces, a `Secret`
  value appears in neither, a real `BuildEnv` with the hatch on and an ambient
  `GH_TOKEN` prints exactly one warning naming the variable and not the value,
  and both paths are silent with the hatch off.

## Checklist

- [x] `make all` passes (vet, test, build)
- [x] `script/smoke.sh` passes
- [x] I have added or updated tests covering the change
- [x] I have run `go test ./... -race`, if the change touches concurrency, subprocesses or the daemon
- [x] I have exercised the change against a real runtime (`brig run <agent>`), if it touches the run, exec or credential path
- [ ] ~~I have updated the affected docs~~

Driven against a stub runtime only. With the hatch off, `brig env` output is
byte-identical to before. `docs/security.md`'s description of the hatch is
still accurate and was left alone.

## Credentials and the sandbox boundary

This touches the second promise by reporting on it. No value is ever printed;
the warning and the report carry names only, and a test asserts the value is
absent from both.

