### PR TITLE
docs: write down what a guest image has to provide

### DIFF
--- a/README.md
+++ b/README.md
@@ -396,8 +396,9 @@ privately, rather than in a public issue.
 Any Linux CLI in an OCI image runs under brig, as long as the image also
 carries the utilities brig invokes to set the sandbox up and deliver the
 credential. [docs/guest-image.md](docs/guest-image.md) is the list, with the
-file that runs each one, and `script/check-guest-image.sh <image>` checks an
-image against it. A stock distribution image passes as it ships; a
+file that runs each one, and `script/check-guest-image.sh <image> [profile]`
+checks an image against it by booting it as that profile's sandbox, default
+`claude-code`. A stock distribution image passes as it ships; a
 `FROM scratch` image holding only your static binary fails every line. A
 profile just saves you spelling out the image, the guest home and the
 credential variables every time:

--- a/README.md
+++ b/README.md
@@ -394,12 +394,13 @@ privately, rather than in a public issue.
 ## Custom agents and your own images
 
 Any Linux CLI in an OCI image runs under brig, as long as the image also
-carries the few utilities brig uses to set the sandbox up and deliver the
-credential: a shell (`sh` and `bash`), plus `cat`, `stat`, `chown`, `mkdir`,
-`mount` and `/bin/true`. A stock distribution image has them; a `FROM scratch`
-image holding only your static binary does not. A profile just saves you
-spelling out the image, the guest home and the credential variables every
-time:
+carries the utilities brig invokes to set the sandbox up and deliver the
+credential. [docs/guest-image.md](docs/guest-image.md) is the list, with the
+file that runs each one, and `script/check-guest-image.sh <image>` checks an
+image against it. A stock distribution image passes as it ships; a
+`FROM scratch` image holding only your static binary fails every line. A
+profile just saves you spelling out the image, the guest home and the
+credential variables every time:
 
 ```bash
 brig profile export claude-code mine   # start from the closest one

--- a/docs/guest-image.md
+++ b/docs/guest-image.md
@@ -7,8 +7,8 @@ image carries what those commands need.
 
 This page is that list, taken from the code that runs it rather than from
 memory, so each entry names the file you can go and read. There is also a
-script: `script/check-guest-image.sh <image>` runs the list against a real
-image and prints one line per requirement.
+script: `script/check-guest-image.sh <image> [profile]` runs the list against a
+real image and prints one line per requirement.
 
 Nothing here is a brig-specific format. A stock distribution image satisfies
 all of it without being told about brig, which is the point. What follows
@@ -112,6 +112,20 @@ the agent runs as. Set it to the guest user, and set its home to `guestHome`.
 carry `User: "root"` (`guestRootUser` in `internal/wrap/secretfiles.go`). Only
 the mount syscall actually needs the privilege; every target sits under a
 directory root already owns, which is what keeps the rest of it unprivileged.
+
+That privilege comes from the boot, and there are two boots to tell apart. A
+bare `hull run <image>` or `nerdctl run <image>` starts the image as an
+ordinary container, and root inside it holds the runtime's default capability
+set, `CapEff: 00000000a80425fb`, with no `CAP_SYS_ADMIN`: `mount -t tmpfs`
+there fails with `permission denied`, in an image brig mounts a tmpfs in every
+day. brig never boots that way. It passes the profile's hypervisor and rootfs
+type, and for a `genericBoot` profile the kernel and initrd annotations, so
+the image comes up as a microVM whose root holds everything,
+`CapEff: 000001ffffffffff` (`runArgs` in `internal/runtime/hull.go`, and the
+nerdctl equivalent in `internal/runtime/nerdctl.go`). Checking an image under
+the bare boot therefore reports failures against a boundary brig never gives
+it, which is why `script/check-guest-image.sh` boots through `brig create`
+rather than through the runtime.
 
 ## What `genericBoot` changes
 
@@ -247,12 +261,20 @@ image: docker.io/me/mine:latest
 guestHome: /home/mine
 binary: mine
 genericBoot: true
+mem: 2048
+cpus: 2
 ```
 
-Then check it rather than trusting this file:
+`mem:` and `cpus:` are not optional in a profile of your own: brig refuses one
+that leaves either at zero, so a file without them is skipped rather than
+imported.
+
+Then check it rather than trusting this file, naming the profile it will run
+under. That profile has to be one brig knows, so import it first:
 
 ```bash
-script/check-guest-image.sh docker.io/me/mine:latest /home/mine mine
+brig profile import mine.yaml
+script/check-guest-image.sh docker.io/me/mine:latest mine
 ```
 
 Debian and Ubuntu bases pass as they ship: bash, coreutils and util-linux are
@@ -295,10 +317,33 @@ further clue.
 ## Checking an image
 
 ```bash
-script/check-guest-image.sh <image> [guest-home] [binary]
+script/check-guest-image.sh <image> [profile]
 ```
 
-It uses the container runtime on your `PATH`, boots the image the way brig
-does, runs each requirement above as a separate exec, and prints one line per
-requirement. It is not part of CI, which has no registry access, so it is
-something you run yourself against an image you are building.
+The profile defaults to `claude-code`, and naming one is how the check gets
+the boot the contract describes. The script boots the image with
+`BRIG_IMAGE=<image> brig create <profile> --name image-check`, in a scratch
+workspace, and tears it down with `brig rm` when it is done. Going through
+brig is what supplies the hypervisor, the rootfs type, the generic-boot
+annotations and the capabilities described above; a bare `hull run` or
+`nerdctl run` supplies none of them and fails the mount line on an image that
+works.
+
+The profile also decides what is checked. Its `guestHome:` is the guest home,
+its last path element is the user `chown` has to resolve, and its `binary:` is
+the agent CLI the last line looks for. So the check is of this image under
+this profile rather than of an image in the abstract, which is the question
+you actually have. A profile of your own has to be one brig knows, through
+`brig profile import`.
+
+The requirements themselves run as root through the runtime's own exec against
+the sandbox brig created, one exec per line of the table above, so what they
+report is behaviour rather than a file being present. An image that will not
+come up falls back to listing the image filesystem, and says so: those checks
+are presence only. `BRIG_VERIFY=off` is set for the boot, so an image nobody
+has signed is not refused on the way in.
+
+It is not part of CI, which has no registry access and no runtime to boot
+with, so it is something you run yourself against an image you are building.
+Bear in mind that it is a real run of a real profile: the credentials that
+profile delivers are delivered into the image under test.

--- a/docs/guest-image.md
+++ b/docs/guest-image.md
@@ -1,0 +1,304 @@
+# What a guest image has to provide
+
+brig boots an OCI image and then runs commands inside it: a readiness probe,
+the mounts that keep a credential off host disk, the file the agent reads that
+credential from. Any Linux CLI in an image works under brig as long as the
+image carries what those commands need.
+
+This page is that list, taken from the code that runs it rather than from
+memory, so each entry names the file you can go and read. There is also a
+script: `script/check-guest-image.sh <image>` runs the list against a real
+image and prints one line per requirement.
+
+Nothing here is a brig-specific format. A stock distribution image satisfies
+all of it without being told about brig, which is the point. What follows
+matters when you are building something smaller than that.
+
+## The binaries
+
+Resolved through the guest's `PATH` unless the table says otherwise.
+
+| binary | why brig runs it | where |
+| --- | --- | --- |
+| `/bin/true` | the readiness probe. The runtime reports a sandbox running as soon as the VMM starts, seconds before the in-guest agent binds its listener, so brig execs this until it succeeds | `internal/wrap/run.go`, `waitReady` |
+| `cat` | reads the workspace marker back out of the guest home, and reads `/proc/self/mountinfo` and `/proc/swaps`. Also the body of the exec that writes a credential: `sh -c 'cat > "$1"'`, with the value on stdin | `internal/wrap/run.go`, `guestMountsWorkspace`; `internal/wrap/secretfiles.go`, `guestMountpoints`, `verifyVolumes`, `writeSecretFile` |
+| `sh` | three short scripts: create a credential file with `set -C`, write the value into it, create a mount target | `internal/wrap/secretfiles.go`, `writeSecretFile`, `createGuestTarget` |
+| `stat` | `stat -c '%F\|%U\|%a'` proves a credential's target is a regular file of the right ownership and mode before the value goes into it, `stat -c %s` proves it is not empty afterwards, and `stat -f -c %T` reports the filesystem a path sits on | `internal/wrap/secretfiles.go`, `verifySecretFile`, `writeSecretFile`, `guestFstype` |
+| `mount` | `mount -t tmpfs` covers a directory the profile declares, and `mount --bind` pins each hostmount out of the way first and binds it back after | `internal/wrap/secretfiles.go`, `mountVolumes` |
+| `mkdir` | creates mount targets, as `mkdir -p` and inside a shell script as `mkdir -p -- "$(dirname "$1")"` | `internal/wrap/secretfiles.go`, `createGuestTarget` |
+| `dirname` | inside that same script. It is an external command, not a shell builtin, and it is the one nobody guesses | `internal/wrap/secretfiles.go`, `createGuestTarget` |
+| `chown` | hands the covered directories to root across a credential write and back to the guest user afterwards, and sets the owner of the credential file itself | `internal/wrap/secretfiles.go`, `chownGuest`, `writeSecretFile` |
+| `chmod` | sets the mode a `files:` binding declares, inside the create script | `internal/wrap/secretfiles.go`, `writeSecretFile` |
+| `rm` | `rm -f --` at the credential path before creating it, so a planted symlink is removed rather than followed | `internal/wrap/secretfiles.go`, `writeSecretFile` |
+| `sleep` | **Linux only.** nerdctl runs the container as `sleep infinity`, because a container exits when its command does and the sandbox has to outlive the exec that uses it | `internal/runtime/nerdctl.go`, `runArgs` |
+| `bash` | `brig shell` runs `bash -l`, and `brig shell <agent> '<command>'` runs `bash -lc`. It is also the `binary:` of the `ubuntu` profile | `internal/wrap/run.go`, `Shell` |
+| the profile's `binary:` | `brig run` execs it. `claude` for claude-code, `codex` for codex, and so on | `cmd/brig/main.go`, `runAgent` |
+
+Two of these are conditional, and it is worth knowing which.
+
+`sleep` is the container command on the nerdctl path only. hull boots the
+image and lets its own entrypoint run, so a macOS-only image can get away
+without it and then fail on Linux. Since `:latest` on the published profiles
+is a multi-arch index meant to work on both, treat `sleep` as required.
+
+`bash` is only reached by `brig shell`. That is also the verb people reach for
+when a sandbox is misbehaving, so an image without it works right up to the
+moment somebody needs to look inside it.
+
+Everything from `sh` down to `rm` is only run when the profile declares
+`volumes:` or `files:`. A profile with neither returns before any of it
+(`deliverSecretFiles` in `internal/wrap/secretfiles.go`), so such an image
+needs `/bin/true`, `cat`, `sleep` on Linux and its own binary, and no more.
+Two of the eight shipped profiles declare them, `claude-code` and
+`claude-desktop`, which are the two that deliver a credential as a file. If
+your profile forwards everything as environment variables, most of this table
+is dead weight for you.
+
+Build against that narrower list and know what it costs: adding one `files:`
+binding later brings the whole table back, and the run then fails at delivery
+rather than at boot, well after the sandbox looked fine.
+
+`stat` is the fussiest entry. The `-c` and `-f` format flags are the GNU
+coreutils spelling, which busybox also implements when it was compiled with
+its format feature. BSD `stat` spells them differently and fails the run.
+`%F` has to answer `regular file` or `regular empty file` for a file brig just
+created, `%U` the owner's name, `%a` the octal mode, and `-f -c %T` the
+filesystem type as a word, `tmpfs` for what brig mounted.
+
+## Paths and kernel interfaces
+
+- **`/proc`, mounted.** `cat /proc/self/mountinfo` is how brig decides what is
+  already a mountpoint. It reads the kernel's own table rather than running
+  `mountpoint -q` precisely because a minimal image may not carry that binary,
+  and a missing binary would read as "not mounted" and stack a second mount on
+  every run until the guest ran out. `cat /proc/swaps` is the swap tripwire:
+  more than a header line there and brig refuses to hand the sandbox a
+  credential, because a tmpfs page that reached swap is a credential on a disk
+  brig never wrote to.
+- **`/run`, writable by root.** Each hostmount is pinned at
+  `/run/brig/persist/<escaped path>` while the tmpfs goes over its real
+  location, then bound back. `/run` rather than anywhere in the workspace is
+  deliberate: it is root-owned and the agent runs as an ordinary user, so
+  nothing the sandbox can write to sits between a privileged mount and its
+  source. See `persistRoot` in `internal/wrap/secretfiles.go`.
+- **`/bin/true`, at that literal path.** The probe is not `true` resolved
+  through `PATH`.
+- **tmpfs in the guest kernel**, accepting `size=`, `mode=0700`, `nodev` and
+  `nosuid`. Not ramfs: ramfs ignores `size=` silently, which would let a guest
+  process exhaust VM memory through a mount brig created. See `TmpfsOptions`
+  in `internal/profile/volumes.go`.
+- **No swap.** There is none in the guest today, so this is a tripwire rather
+  than a mitigation, but a guest that turns swap on stops the run.
+
+## The user the image runs as
+
+brig derives the guest account from the profile's `guestHome:`, taking the
+last path element: `/home/claude` means the user `claude` (`GuestUser` in
+`internal/profile/profile.go`). The profile states the home once and the user
+follows from it. There is no field to set the user separately.
+
+Three things follow for the image.
+
+**That account has to exist in the image.** The name is passed to `chown`
+inside the guest, so it has to resolve in `/etc/passwd`. An image whose home
+directory is `/home/claude` but which has no `claude` user fails the run with
+`could not hand /home/claude/.claude to claude in the sandbox`.
+
+**The image should run as that account.** Every exec except the privileged
+ones goes in with no `-u` flag, so the image's configured `USER` decides who
+the agent runs as. Set it to the guest user, and set its home to `guestHome`.
+
+**Root has to be available to exec as.** The mounting and file-writing execs
+carry `User: "root"` (`guestRootUser` in `internal/wrap/secretfiles.go`). Only
+the mount syscall actually needs the privilege; every target sits under a
+directory root already owns, which is what keeps the rest of it unprivileged.
+
+## What `genericBoot` changes
+
+A profile with `genericBoot: true` says its image was never built to be a
+guest: no kernel inside it, no urunc metadata. Six of the eight shipped
+profiles set it, `ubuntu` included, which boots
+`docker.io/library/ubuntu:latest` unmodified. `claude-desktop` and `cursor`
+leave it off.
+
+brig supplies the kernel and initrd, and passes them as two OCI annotations:
+
+```
+com.urunc.unikernel.bootKernel
+com.urunc.unikernel.bootInitrd
+```
+
+hull takes them on its command line and urunc reads them out of the
+container's OCI spec, so the pair is the whole contract on both operating
+systems (`internal/runtime/boot.go`). They are never read from the image's own
+metadata, which is what stops an image nominating a file on the host.
+
+The kernel file is named `Image` on arm64 and `bzImage` on x86_64; the initrd
+is `container-initrd` on both. They come from `BRIG_BOOT_ASSETS` if it is set,
+otherwise from whatever `hull assets dir` reports on macOS, otherwise from
+`$XDG_DATA_HOME/brig/assets` (default `~/.local/share/brig/assets`) on Linux.
+Missing, they are fetched: with hull on macOS, which downloads the same bundle
+for its own use, and with `oras` on Linux, where hull does not build. A
+zero-length file counts as missing rather than passing an existence check and
+failing at boot. The one case brig refuses to fix is `BRIG_BOOT_ASSETS`
+pointing at a directory you chose: it will not download over a build somebody
+is iterating on.
+
+Two consequences for the image itself:
+
+- **It does not have to carry a guest agent.** The agent comes out of the
+  initrd and is copied into the guest, which is what lets brig exec into a
+  stock image at all.
+- **On Linux, docker is refused for a `genericBoot` profile.** docker does not
+  carry annotations through to the runtime, so the sandbox would boot without
+  a kernel and fail somewhere further from the cause. Use nerdctl, or point
+  `BRIG_RUNTIME_BIN` at it (`internal/runtime/nerdctl.go`).
+
+An image that carries its own kernel and urunc metadata leaves `genericBoot`
+off and needs none of the above.
+
+## The tmpfs mounts brig creates
+
+One per `kind: tmpfs` entry in the profile's `volumes:`, at `guestHome` plus
+the entry's path, with options `size=<size>,mode=0700,nodev,nosuid` and a
+default size of `64m`. This is what keeps a credential off host disk: the
+workspace is a host directory mounted as the guest home, and a tmpfs over part
+of it is a region with no path to the host at all.
+
+How they get there differs by runtime, and the image does not have to care,
+but it explains what you will see inside the guest:
+
+- **hull** has no create-time tmpfs, so brig mounts them with a privileged
+  exec, in three phases: pin every hostmount that sits under a directory about
+  to be covered, mount the tmpfs, bind the pins back in through it. Any other
+  order loses the state it was meant to keep.
+- **nerdctl** gets them in the create request instead, as `--tmpfs` and `-v`,
+  because a container runtime has no privileged exec to mount with
+  (`createTimeVolumes` in `internal/wrap/secretfiles.go`).
+
+Either way brig verifies the result from inside the guest rather than assuming
+it: each covered directory must read as `tmpfs`, each hostmount must not, and
+a guest that cannot answer fails the run. The covered directory stays
+root-owned until every credential is written and is handed to the guest user
+last, so there is no window in which the agent could plant a symlink at a
+credential's path.
+
+## What `volumes:` and `files:` assume of the image
+
+Both are relative to `guestHome` and neither may escape it.
+
+**The workspace mount covers the guest home entirely.** Anything the image
+ships inside `guestHome` is invisible once the sandbox is up, because a host
+directory is mounted over it. Dotfiles baked into `/home/claude` at image
+build time never appear. Put them somewhere else, or have the agent create
+them on first run.
+
+**`volumes:` targets do not have to exist in the image.** brig creates the
+host-side path in the workspace before the sandbox is created, through an
+`os.Root` so a planted symlink is refused rather than written through, and
+creates the guest-side target under a directory root owns. What it will not do
+is change the kind of something already there: a bind mount onto the wrong
+kind of target fails, so a directory in the workspace where the profile says
+`file: true` stops the run and names both, rather than surfacing later as the
+kernel's own `EINVAL`.
+
+**A tmpfs entry hides whatever the workspace had under that path**, not what
+the image had: the image's copy was already hidden by the workspace mount, one
+layer down. What the agent writes into the tmpfs is gone at shutdown, and a
+hostmount under it is how a path is carved back out and kept. brig checks
+every hostmount really is a mountpoint once the cover is on, and fails the run
+if one is not, because a path the agent writes to believing it persists is the
+kind of loss nobody notices until they go looking for last week's work.
+
+**`files:` targets must land in a declared tmpfs.** That is validation, not
+convention: a `files:` path not covered by a tmpfs is a refused profile,
+because an uncovered target writes a credential into the workspace, which is
+host disk.
+
+**A `files:` binding is an ordinary file, never a bind mount.** Agents rewrite
+a credential atomically, temp file then rename, and rename onto a mountpoint
+returns `EBUSY`. So the file is created, checked and filled through the three
+execs described above, and the image needs a `stat` that answers them.
+
+## A minimal image
+
+Small is fine. Empty is not.
+
+```dockerfile
+FROM alpine:3.20
+
+# The utilities above. busybox already provides most of them; coreutils and
+# util-linux are here so you do not have to know which busybox features your
+# base was compiled with.
+RUN apk add --no-cache bash coreutils util-linux
+
+RUN adduser -D -h /home/mine mine
+COPY mine /usr/local/bin/mine
+
+USER mine
+WORKDIR /home/mine
+```
+
+with a profile that says:
+
+```yaml
+name: mine
+image: docker.io/me/mine:latest
+guestHome: /home/mine
+binary: mine
+genericBoot: true
+```
+
+Then check it rather than trusting this file:
+
+```bash
+script/check-guest-image.sh docker.io/me/mine:latest /home/mine mine
+```
+
+Debian and Ubuntu bases pass as they ship: bash, coreutils and util-linux are
+all in the base. Alpine's busybox provides every name on the list too, but
+whether a given busybox was compiled with the `stat` format flags brig parses
+depends on the build, which is the doubt the two extra packages above remove.
+Run the script rather than taking either sentence on trust.
+
+## What a scratch image is missing
+
+`FROM scratch` with one static binary is missing the entire list, and the
+failure order is the unhelpful part. In rough order of what you would hit:
+
+- **On Linux, the container exits immediately.** brig runs it as
+  `sleep infinity` and there is no `sleep`, so the sandbox is gone before the
+  first probe.
+- **The readiness probe never passes.** No `/bin/true`, so brig waits out
+  `BRIG_READY_TIMEOUT` and reports `sandbox did not become ready`, which says
+  nothing about the image.
+- **The stale-share check cannot run.** No `cat`, so brig cannot read the
+  workspace marker back and treats the guest as not mounting this workspace.
+- **No credential is delivered.** No `sh`, `stat`, `mount`, `mkdir`,
+  `dirname`, `chown`, `chmod` or `rm`, so nothing between the tmpfs and the
+  credential file happens.
+- **`chown` has no name to resolve.** No `/etc/passwd`, so the guest user does
+  not exist even if the binaries did.
+- **`brig shell` cannot get you in to look.** No `bash`.
+
+Distroless is the same story with a tidier base. The `static` and `base`
+variants carry no shell and no coreutils, so every point above applies except
+the last two: they do ship an `/etc/passwd` with a `nonroot` user, and the
+missing `bash` is the least of it. The `:debug` variants add a busybox shell,
+which is closer and still not the whole list.
+
+If a static binary in a tiny image is what you want, put it in a distribution
+base rather than in `scratch`. The difference is a few megabytes of userland
+against a sandbox that fails with `sandbox did not become ready` and no
+further clue.
+
+## Checking an image
+
+```bash
+script/check-guest-image.sh <image> [guest-home] [binary]
+```
+
+It uses the container runtime on your `PATH`, boots the image the way brig
+does, runs each requirement above as a separate exec, and prints one line per
+requirement. It is not part of CI, which has no registry access, so it is
+something you run yourself against an image you are building.

--- a/script/check-guest-image.sh
+++ b/script/check-guest-image.sh
@@ -7,20 +7,41 @@
 # meaninglessness. This is a tool you run yourself, against an image you are
 # building.
 #
-#   script/check-guest-image.sh <image> [guest-home] [binary]
+#   script/check-guest-image.sh <image> [profile]
 #
-#   <image>       the image reference, as you would pass it to `brig --image`
-#   [guest-home]  the profile's guestHome:, default /home/agent. The guest user
-#                 is its last path element, which is how brig derives it too
-#   [binary]      the profile's binary:, checked for if given
+#   <image>    the image reference, as you would pass it to `brig --image`
+#   [profile]  the profile to boot it under, default claude-code. Its
+#              guestHome: is the guest home, and the guest user is that path's
+#              last element, which is how brig derives it too. Its binary: is
+#              the agent CLI, checked for when the profile names one
 #
-# It boots the image the way brig does and runs each requirement as its own
-# exec, so what it reports is behaviour rather than a file being present. An
-# image that will not stay up (no `sleep`, most often) falls back to listing the
-# image filesystem, and says so: those checks are presence only.
+# The boot goes through brig: `BRIG_IMAGE=<image> brig create <profile>`, torn
+# down with `brig rm`. That is the point of the script rather than an
+# implementation detail. An image booted bare as a container -- `hull run
+# <image>` with no profile behind it -- runs with the runtime's default
+# capability set and no CAP_SYS_ADMIN, so `mount -t tmpfs` in it fails with
+# EPERM for images brig mounts a tmpfs in every day. Going through brig gets
+# the profile's hypervisor, rootfs type, generic-boot annotations and guest
+# home, and root in that sandbox holds every capability. It is also the only
+# boot mode brig has, so it is the one the contract describes.
 #
-# Exit status: 0 every requirement met, 1 something is missing, 2 there was no
-# runtime to check with. It never reports a pass it did not perform.
+# The checks run as root through the runtime's own exec against the sandbox
+# brig created, one exec per requirement, so what they report is behaviour
+# rather than a file being present. An image that will not boot falls back to
+# listing the image filesystem, and says so: those checks are presence only.
+#
+# The boot is a real run of a real profile, so whatever credentials that
+# profile delivers reach the image under test. Point this at an image you are
+# building, not at one you have a reason to distrust.
+#
+# BRIG_VERIFY=off is set for the boot, so an image under test that nobody has
+# signed is not refused. BRIG_DRY_RUN=1 prints what would be booted and stops
+# before booting it, which is how the argument handling and the profile lookup
+# can be checked on a machine with no runtime.
+#
+# Exit status: 0 every requirement met, 1 something is missing, 2 there was
+# nothing to check with -- no brig, no runtime, or no such profile. It never
+# reports a pass it did not perform.
 #
 # Not checked here, because neither is a property of the image: that the guest
 # has no swap, and that a tmpfs brig mounted reads back as tmpfs. brig verifies
@@ -28,48 +49,147 @@
 set -uo pipefail
 
 usage() {
-	printf 'usage: %s <image> [guest-home] [binary]\n' "$0" >&2
+	printf 'usage: %s <image> [profile]\n' "$0" >&2
 	exit 2
 }
 
 IMAGE="${1:-}"
 [ -n "$IMAGE" ] || usage
-GUEST_HOME="${2:-/home/agent}"
-BINARY="${3:-}"
+PROFILE="${2:-claude-code}"
+
+dry() { [ -n "${BRIG_DRY_RUN:-}" ] && [ "${BRIG_DRY_RUN}" != 0 ]; }
+
+# --- brig itself ---
+# $BRIG first, then PATH, then the binary a `make build` leaves in the
+# checkout. Which one answered is printed: running a checkout's brig against a
+# profile you edited in your installed one is the confusion worth ruling out
+# before reading any of the lines below.
+BRIG_BIN="${BRIG:-}"
+BRIG_FROM='$BRIG'
+if [ -z "$BRIG_BIN" ]; then
+	if BRIG_BIN="$(command -v brig 2>/dev/null)"; then
+		BRIG_FROM='PATH'
+	else
+		BRIG_BIN="$(cd "$(dirname "$0")/.." && pwd)/brig"
+		BRIG_FROM='this checkout'
+		if [ ! -x "$BRIG_BIN" ]; then
+			printf 'no brig found: put one on PATH, run `make build`, or set BRIG.\n' >&2
+			printf 'Nothing was checked.\n' >&2
+			exit 2
+		fi
+	fi
+fi
+
+# --- the profile ---
+# Read from brig rather than from internal/profile/specs, so a profile of your
+# own and a file that overrides a built-in are read the same way brig will read
+# them at boot. The JSON export is the resolved profile, one field per line.
+if ! SPEC="$("$BRIG_BIN" profile export "$PROFILE" --json 2>&1)"; then
+	printf '%s\n' "$SPEC" >&2
+	printf 'Nothing was checked.\n' >&2
+	exit 2
+fi
+field() {
+	printf '%s\n' "$SPEC" | sed -n 's/^  "'"$1"'": "\(.*\)",*$/\1/p' | head -1
+}
+GUEST_HOME="$(field guestHome)"
+BINARY="$(field binary)"
+PROFILE_RUNTIME_BIN="$(field runtimeBin)"
+if [ -z "$GUEST_HOME" ]; then
+	printf 'the %s profile declares no guestHome:, so there is no guest home to\n' "$PROFILE" >&2
+	printf 'check against. Nothing was checked.\n' >&2
+	exit 2
+fi
+# The last path element, which is how brig derives the account it chowns to.
+# See GuestUser in internal/profile/profile.go.
 GUEST_USER="${GUEST_HOME##*/}"
+# Whether this profile delivers anything as a file or a mount. Everything from
+# sh down to rm in the table is only run for a profile that does, so a missing
+# guest user costs a profile with neither nothing today -- which the line that
+# reports it should say rather than predicting a chown that never happens.
+DELIVERS=no
+if printf '%s\n' "$SPEC" | grep -q '^  "\(files\|volumes\)": \['; then
+	DELIVERS=yes
+fi
 
 # --- the runtime ---
-# The same order brig itself resolves in, plus podman, which takes the same
-# flags and is a reasonable thing to have when you are building an image.
-# BRIG_RUNTIME_BIN wins, as it does for brig.
-RT="${BRIG_RUNTIME_BIN:-}"
+# The checks exec into the sandbox brig booted, which means finding the same
+# runtime brig will find: BRIG_RUNTIME picks the backend, hull on macOS and
+# nerdctl elsewhere by default, and BRIG_RUNTIME_BIN then the profile's
+# runtimeBin pick the binary. See DetectFor in internal/runtime/runtime.go.
+KIND="${BRIG_RUNTIME:-}"
+if [ -z "$KIND" ]; then
+	case "$(uname -s)" in
+	Darwin) KIND=hull ;;
+	*) KIND=nerdctl ;;
+	esac
+fi
+case "$KIND" in
+hull) CANDIDATES='hull' ;;
+nerdctl) CANDIDATES='nerdctl docker' ;;
+*)
+	printf 'unknown BRIG_RUNTIME "%s" (want hull or nerdctl). Nothing was checked.\n' "$KIND" >&2
+	exit 2
+	;;
+esac
+RT="${BRIG_RUNTIME_BIN:-$PROFILE_RUNTIME_BIN}"
+case "$RT" in
+"~/"*) RT="$HOME/${RT#~/}" ;;
+esac
 if [ -z "$RT" ]; then
-	for candidate in nerdctl docker podman hull; do
+	for candidate in $CANDIDATES; do
 		if RT="$(command -v "$candidate" 2>/dev/null)"; then break; fi
 		RT=""
 	done
 fi
+
+printf 'brig guest image contract: %s\n' "$IMAGE"
+printf 'brig: %s (%s)\n' "$BRIG_BIN" "$BRIG_FROM"
+printf 'profile: %s, guest home %s, guest user %s\n' "$PROFILE" "$GUEST_HOME" "$GUEST_USER"
+printf 'runtime: %s (%s)\n' "$KIND" "${RT:-none found}"
+
+if dry; then
+	printf '\nBRIG_DRY_RUN is set, so nothing was booted and nothing was checked.\n'
+	printf 'The boot would be:\n'
+	printf '  BRIG_IMAGE=%s BRIG_VERIFY=off %s create %s --name image-check --workspace <scratch>\n' \
+		"$IMAGE" "$BRIG_BIN" "$PROFILE"
+	printf '  %s rm %s --name image-check --workspace <scratch>\n' "$BRIG_BIN" "$PROFILE"
+	printf 'and each requirement would run as `%s exec -u root <sandbox>`.\n' \
+		"$(basename "${RT:-$KIND}")"
+	exit 0
+fi
+
 if [ -z "$RT" ]; then
-	printf 'no container runtime found: install nerdctl, docker or podman, or set\n' >&2
-	printf 'BRIG_RUNTIME_BIN. Nothing was checked.\n' >&2
+	printf '\nno container runtime found: install %s, or set BRIG_RUNTIME_BIN.\n' \
+		"${CANDIDATES// / or }" >&2
+	printf 'Nothing was checked.\n' >&2
 	exit 2
 fi
-KIND="$(basename "$RT")"
 
-NAME="brig-image-check-$$"
 FAILED=0
-MODE=exec # or "list", when the image would not stay up
+MODE=exec      # or "list", when the image would not boot
+NAME=""        # the sandbox, once brig has named it
+BOOT_FAILED="" # brig's create returned an error, whatever came up
+LISTED=""      # the container the fallback listing was taken from
+
+WORK="$(mktemp -d)"
+# brig suffixes the session slug onto the workspace it is given, so the
+# directory it actually uses is <WORKSPACE>-image-chec. Keeping the base inside
+# a directory of our own means one rm -rf covers whatever it created.
+WORKSPACE="$WORK/workspace"
+LISTING="$WORK/listing"
+BOOTLOG="$WORK/boot.log"
 
 cleanup() {
-	if [ "$KIND" = hull ]; then
-		"$RT" stop "$NAME" >/dev/null 2>&1
-		"$RT" rm "$NAME" >/dev/null 2>&1
-	else
-		"$RT" rm -f "$NAME" >/dev/null 2>&1
+	# Unconditionally, not only when the boot printed a name: a create that
+	# failed after the sandbox was up leaves one behind holding the name, and
+	# `brig rm` on a sandbox that was never created is a no-op.
+	"$BRIG_BIN" rm "$PROFILE" --name image-check --workspace "$WORKSPACE" >/dev/null 2>&1
+	if [ -n "$LISTED" ]; then
+		"$RT" rm -f "$LISTED" >/dev/null 2>&1
 	fi
-	rm -f "$LISTING"
+	rm -rf "$WORK"
 }
-LISTING="$(mktemp)"
 trap cleanup EXIT
 
 # --- reporting ---
@@ -77,34 +197,33 @@ ok()   { printf '  ok   %-22s %s\n' "$1" "$2"; }
 bad()  { printf '  FAIL %-22s %s\n' "$1" "$2"; FAILED=1; }
 skip() { printf '  --   %-22s %s\n' "$1" "$2"; }
 
-printf 'brig guest image contract: %s\n' "$IMAGE"
-printf 'runtime: %s (%s)\n' "$KIND" "$RT"
-printf 'guest home: %s, guest user: %s\n\n' "$GUEST_HOME" "$GUEST_USER"
-
 # --- booting ---
-# Exactly what brig does: no entrypoint override, and `sleep infinity` as the
-# command on a container runtime, because that is the command brig parks the
-# sandbox on. hull takes no command and lets the image's own entrypoint run,
-# which is why `sleep` is not a hull requirement.
-boot() {
-	if [ "$KIND" = hull ]; then
-		"$RT" run --detach --name "$NAME" "$IMAGE" >/dev/null 2>&1
-	else
-		"$RT" run -d --name "$NAME" "$IMAGE" sleep infinity >/dev/null 2>&1
-	fi
-}
+# BRIG_VERIFY=off because the image under test is one you are building, and an
+# unsigned image is the normal case for that; the contract is about what is
+# inside the image, not about who signed it.
+#
+# The sandbox name comes back on brig's stdout rather than being spelled out
+# here. It is brig-<profile>-<slug>, and the slug is the session name cut to
+# ten characters, so `--name image-check` is brig-<profile>-image-chec --
+# taking what brig printed means this does not have to reimplement that.
+export BRIG_IMAGE="$IMAGE"
+export BRIG_VERIFY=off
 
-running() {
-	if [ "$KIND" = hull ]; then
-		"$RT" ps 2>/dev/null | grep -q "^$NAME[[:space:]]\+running"
-	else
-		"$RT" ps --filter "name=^${NAME}$" --format '{{.Names}}' 2>/dev/null |
-			grep -qx "$NAME"
-	fi
-}
+printf '\n'
+if BOOTED="$("$BRIG_BIN" create "$PROFILE" --name image-check --workspace "$WORKSPACE" 2>"$BOOTLOG")"; then
+	NAME="$(printf '%s\n' "$BOOTED" | tail -1 | tr -d '[:space:]')"
+else
+	# A create that fails during credential delivery leaves the sandbox
+	# running, and that is the failure this script exists to explain: the
+	# checks can run in it and name the requirement brig tripped over, which
+	# is more use than brig's one line about the step that hit it. brig names
+	# the sandbox as it starts it, so the name is in what it printed.
+	BOOT_FAILED=1
+	NAME="$(sed -n 's/^brig: starting sandbox \(.*\)\.\.\.$/\1/p' "$BOOTLOG" | tail -1)"
+fi
 
-# guest runs one command inside the sandbox as root, the way every brig setup
-# exec runs. Output on stdout, everything else discarded.
+# guest runs one command inside the sandbox as root, the way every privileged
+# brig exec runs. Output on stdout, everything else discarded.
 guest() {
 	if [ "$KIND" = hull ]; then
 		"$RT" exec -u root "$NAME" -- "$@" 2>/dev/null
@@ -115,23 +234,33 @@ guest() {
 
 # The fallback: create the container without starting it and list its
 # filesystem. This is the only thing that works for an image that cannot run at
-# all, which is exactly the scratch case worth reporting on.
+# all, which is exactly the scratch case worth reporting on. hull has no such
+# verb, so on macOS there is nothing to fall back to.
 build_listing() {
 	if [ "$KIND" = hull ]; then
 		return 1
 	fi
-	"$RT" create --name "$NAME" "$IMAGE" /bin/true >/dev/null 2>&1 || return 1
-	"$RT" export "$NAME" 2>/dev/null | tar -tf - >"$LISTING" 2>/dev/null || return 1
+	LISTED="brig-image-check-list-$$"
+	"$RT" create --name "$LISTED" "$IMAGE" /bin/true >/dev/null 2>&1 || return 1
+	"$RT" export "$LISTED" 2>/dev/null | tar -tf - >"$LISTING" 2>/dev/null || return 1
 	[ -s "$LISTING" ]
 }
 
-if boot && running; then
-	MODE=exec
-else
-	printf 'The image would not stay up, so there is nothing to exec into.\n'
-	if [ "$KIND" != hull ]; then
-		"$RT" rm -f "$NAME" >/dev/null 2>&1
+brig_said() { sed -n '1,10p' "$BOOTLOG" | sed 's/^/  /'; }
+
+if [ -n "$NAME" ] && guest /bin/true >/dev/null; then
+	printf 'sandbox: %s\n' "$NAME"
+	if [ -n "$BOOT_FAILED" ]; then
+		printf '\nbrig did not finish the boot, and said:\n\n'
+		brig_said
+		printf '\nThe sandbox is up, so the checks below ran inside it.\n'
 	fi
+	printf '\n'
+else
+	printf 'brig could not bring this image up as a %s sandbox, so there is nothing\n' "$PROFILE"
+	printf 'to exec into. What brig said:\n\n'
+	brig_said
+	printf '\n'
 	if build_listing; then
 		MODE=list
 		printf 'Falling back to the image filesystem: the checks below are presence\n'
@@ -198,6 +327,33 @@ expect() {
 	fi
 }
 
+# chown is the one check whose failure has two quite different causes, and the
+# useful one is the account rather than the binary. An image that has chown but
+# not the profile's user fails every run of that profile at credential
+# delivery, and the line that says so has to name the user it looked for.
+chown_check() {
+	local label='chown, guest user' note="hands directories to $GUEST_USER and back"
+	if [ "$MODE" = list ]; then
+		if have_binary chown; then ok "$label" "$note"; else bad "$label" "$note"; fi
+		return
+	fi
+	if guest chown "$GUEST_USER" "$SCRATCH/d" >/dev/null; then
+		ok "$label" "$note"
+		return
+	fi
+	# `id root` first: without it, an image with no id at all would be reported
+	# as an image with no guest user, which is a different repair.
+	if guest id -u root >/dev/null && ! guest id -u "$GUEST_USER" >/dev/null; then
+		local msg="the profile's guest home is $GUEST_HOME, so brig will chown to $GUEST_USER, and this image has no such user"
+		if [ "$DELIVERS" = no ]; then
+			msg="$msg (the $PROFILE profile declares no volumes: or files:, so nothing chowns in it today)"
+		fi
+		bad "$label" "$msg"
+		return
+	fi
+	bad "$label" "$note"
+}
+
 SCRATCH=/run/brig-image-check
 
 run '/bin/true' /bin/true 'readiness probe' -- /bin/true
@@ -209,8 +365,7 @@ run 'stat -f -c' stat 'which filesystem a path is on' -- stat -f -c %T /
 run 'mkdir, /run writable' mkdir 'mount targets, pin directory' -- mkdir -p "$SCRATCH/d"
 run 'dirname' dirname 'inside createGuestTarget' -- dirname /a/b
 run 'chmod' chmod 'the mode a files: binding declares' -- chmod 0700 "$SCRATCH/d"
-run 'chown, guest user' chown "hands directories to $GUEST_USER and back" -- \
-	chown "$GUEST_USER" "$SCRATCH/d"
+chown_check
 run 'rm' rm 'removes a planted symlink rather than following it' -- \
 	rm -f "$SCRATCH/absent"
 run 'mount, tmpfs' mount 'covers a directory so a credential stays off disk' -- \
@@ -221,19 +376,29 @@ run 'bash' bash 'brig shell' -- bash -lc 'exit 0'
 if [ -n "$BINARY" ]; then
 	run "$BINARY" "$BINARY" "the profile's binary:" -- "$BINARY" --version
 else
-	skip 'binary:' 'not given, so the agent CLI was not checked'
+	skip 'binary:' "the $PROFILE profile names none, so no agent CLI was checked"
 fi
 
 # The guest home is created by the workspace mount, so its absence is not a
 # failure. Said out loud because an image that ships content there is a mistake
-# worth knowing about: the mount hides all of it.
-if [ "$MODE" = exec ] && guest test -d "$GUEST_HOME"; then
+# worth knowing about: the mount hides all of it. Only visible in list mode --
+# in a booted sandbox the workspace is already over it, which is the whole
+# point.
+if [ "$MODE" = list ] && have_path "$GUEST_HOME"; then
 	printf '\nnote: %s exists in the image. The workspace is mounted over it, so\n' "$GUEST_HOME"
 	printf '      anything the image ships there is invisible in the sandbox.\n'
 fi
 
 printf '\n'
 if [ "$FAILED" -eq 0 ]; then
+	if [ -n "$BOOT_FAILED" ] && [ "$MODE" = exec ]; then
+		# Every requirement passed and brig still could not finish, so whatever
+		# stopped it is outside this list. Not a pass: the run it was asked
+		# about does not work.
+		printf 'Every requirement on the list is met, and brig still could not finish the\n'
+		printf 'boot. What stopped it is above and is not something this list covers.\n'
+		exit 1
+	fi
 	if [ "$MODE" = list ]; then
 		printf 'Every binary is present. Boot the image to check they work.\n'
 	else

--- a/script/check-guest-image.sh
+++ b/script/check-guest-image.sh
@@ -1,0 +1,245 @@
+#!/usr/bin/env bash
+# Check a guest image against the contract in docs/guest-image.md.
+#
+# NOT wired into CI, and should not be. It pulls and boots the image you name,
+# and CI has no registry access and no container runtime to boot one with, so a
+# job running this would either fail on every pull request or be skipped into
+# meaninglessness. This is a tool you run yourself, against an image you are
+# building.
+#
+#   script/check-guest-image.sh <image> [guest-home] [binary]
+#
+#   <image>       the image reference, as you would pass it to `brig --image`
+#   [guest-home]  the profile's guestHome:, default /home/agent. The guest user
+#                 is its last path element, which is how brig derives it too
+#   [binary]      the profile's binary:, checked for if given
+#
+# It boots the image the way brig does and runs each requirement as its own
+# exec, so what it reports is behaviour rather than a file being present. An
+# image that will not stay up (no `sleep`, most often) falls back to listing the
+# image filesystem, and says so: those checks are presence only.
+#
+# Exit status: 0 every requirement met, 1 something is missing, 2 there was no
+# runtime to check with. It never reports a pass it did not perform.
+#
+# Not checked here, because neither is a property of the image: that the guest
+# has no swap, and that a tmpfs brig mounted reads back as tmpfs. brig verifies
+# both inside the running sandbox on every delivery.
+set -uo pipefail
+
+usage() {
+	printf 'usage: %s <image> [guest-home] [binary]\n' "$0" >&2
+	exit 2
+}
+
+IMAGE="${1:-}"
+[ -n "$IMAGE" ] || usage
+GUEST_HOME="${2:-/home/agent}"
+BINARY="${3:-}"
+GUEST_USER="${GUEST_HOME##*/}"
+
+# --- the runtime ---
+# The same order brig itself resolves in, plus podman, which takes the same
+# flags and is a reasonable thing to have when you are building an image.
+# BRIG_RUNTIME_BIN wins, as it does for brig.
+RT="${BRIG_RUNTIME_BIN:-}"
+if [ -z "$RT" ]; then
+	for candidate in nerdctl docker podman hull; do
+		if RT="$(command -v "$candidate" 2>/dev/null)"; then break; fi
+		RT=""
+	done
+fi
+if [ -z "$RT" ]; then
+	printf 'no container runtime found: install nerdctl, docker or podman, or set\n' >&2
+	printf 'BRIG_RUNTIME_BIN. Nothing was checked.\n' >&2
+	exit 2
+fi
+KIND="$(basename "$RT")"
+
+NAME="brig-image-check-$$"
+FAILED=0
+MODE=exec # or "list", when the image would not stay up
+
+cleanup() {
+	if [ "$KIND" = hull ]; then
+		"$RT" stop "$NAME" >/dev/null 2>&1
+		"$RT" rm "$NAME" >/dev/null 2>&1
+	else
+		"$RT" rm -f "$NAME" >/dev/null 2>&1
+	fi
+	rm -f "$LISTING"
+}
+LISTING="$(mktemp)"
+trap cleanup EXIT
+
+# --- reporting ---
+ok()   { printf '  ok   %-22s %s\n' "$1" "$2"; }
+bad()  { printf '  FAIL %-22s %s\n' "$1" "$2"; FAILED=1; }
+skip() { printf '  --   %-22s %s\n' "$1" "$2"; }
+
+printf 'brig guest image contract: %s\n' "$IMAGE"
+printf 'runtime: %s (%s)\n' "$KIND" "$RT"
+printf 'guest home: %s, guest user: %s\n\n' "$GUEST_HOME" "$GUEST_USER"
+
+# --- booting ---
+# Exactly what brig does: no entrypoint override, and `sleep infinity` as the
+# command on a container runtime, because that is the command brig parks the
+# sandbox on. hull takes no command and lets the image's own entrypoint run,
+# which is why `sleep` is not a hull requirement.
+boot() {
+	if [ "$KIND" = hull ]; then
+		"$RT" run --detach --name "$NAME" "$IMAGE" >/dev/null 2>&1
+	else
+		"$RT" run -d --name "$NAME" "$IMAGE" sleep infinity >/dev/null 2>&1
+	fi
+}
+
+running() {
+	if [ "$KIND" = hull ]; then
+		"$RT" ps 2>/dev/null | grep -q "^$NAME[[:space:]]\+running"
+	else
+		"$RT" ps --filter "name=^${NAME}$" --format '{{.Names}}' 2>/dev/null |
+			grep -qx "$NAME"
+	fi
+}
+
+# guest runs one command inside the sandbox as root, the way every brig setup
+# exec runs. Output on stdout, everything else discarded.
+guest() {
+	if [ "$KIND" = hull ]; then
+		"$RT" exec -u root "$NAME" -- "$@" 2>/dev/null
+	else
+		"$RT" exec -u root "$NAME" "$@" 2>/dev/null
+	fi
+}
+
+# The fallback: create the container without starting it and list its
+# filesystem. This is the only thing that works for an image that cannot run at
+# all, which is exactly the scratch case worth reporting on.
+build_listing() {
+	if [ "$KIND" = hull ]; then
+		return 1
+	fi
+	"$RT" create --name "$NAME" "$IMAGE" /bin/true >/dev/null 2>&1 || return 1
+	"$RT" export "$NAME" 2>/dev/null | tar -tf - >"$LISTING" 2>/dev/null || return 1
+	[ -s "$LISTING" ]
+}
+
+if boot && running; then
+	MODE=exec
+else
+	printf 'The image would not stay up, so there is nothing to exec into.\n'
+	if [ "$KIND" != hull ]; then
+		"$RT" rm -f "$NAME" >/dev/null 2>&1
+	fi
+	if build_listing; then
+		MODE=list
+		printf 'Falling back to the image filesystem: the checks below are presence\n'
+		printf 'only, and cannot tell you whether a binary actually works.\n\n'
+	else
+		printf 'The image filesystem could not be listed either, so nothing was checked.\n' >&2
+		exit 2
+	fi
+fi
+
+# --- the checks ---
+# In exec mode each one runs in the guest; in list mode each one looks for the
+# binary on the usual paths. run takes the label, the note, and the argv.
+# tar lists paths without a leading slash, and with or without a ./ prefix
+# depending on how the layer was built. Accept either, and a trailing slash for
+# a directory entry.
+have_path() {
+	local p="${1#/}"
+	grep -qx "\(\./\)\{0,1\}${p}/\{0,1\}" "$LISTING" 2>/dev/null
+}
+
+have_binary() {
+	local b="$1" d
+	case "$b" in
+	/*)
+		have_path "$b"
+		return
+		;;
+	esac
+	for d in /bin /usr/bin /sbin /usr/sbin /usr/local/bin /usr/local/sbin; do
+		have_path "$d/$b" && return 0
+	done
+	return 1
+}
+
+# run <label> <binary-for-list-mode> <note> -- <argv...>
+run() {
+	local label="$1" bin="$2" note="$3"
+	shift 4 # label, bin, note, --
+	if [ "$MODE" = list ]; then
+		if have_binary "$bin"; then ok "$label" "$note"; else bad "$label" "$note"; fi
+		return
+	fi
+	if guest "$@" >/dev/null; then ok "$label" "$note"; else bad "$label" "$note"; fi
+}
+
+# expect <label> <binary-for-list-mode> <note> <wanted> -- <argv...>
+# For the two checks where succeeding is not enough: stat has to answer in the
+# format brig parses, not merely exit 0.
+expect() {
+	local label="$1" bin="$2" note="$3" want="$4"
+	shift 5
+	if [ "$MODE" = list ]; then
+		if have_binary "$bin"; then ok "$label" "$note"; else bad "$label" "$note"; fi
+		return
+	fi
+	local got
+	got="$(guest "$@")"
+	got="${got%%$'\n'*}"
+	if [ "$got" = "$want" ]; then
+		ok "$label" "$note"
+	else
+		bad "$label" "$note (said \"$got\", wanted \"$want\")"
+	fi
+}
+
+SCRATCH=/run/brig-image-check
+
+run '/bin/true' /bin/true 'readiness probe' -- /bin/true
+run 'cat' cat 'workspace marker, mount table' -- cat /proc/self/mountinfo
+run '/proc/swaps' cat 'the swap tripwire' -- cat /proc/swaps
+run 'sh' sh 'the credential write scripts' -- sh -c 'exit 0'
+expect 'stat -c' stat 'file kind, owner and mode' 'directory' -- stat -c %F /
+run 'stat -f -c' stat 'which filesystem a path is on' -- stat -f -c %T /
+run 'mkdir, /run writable' mkdir 'mount targets, pin directory' -- mkdir -p "$SCRATCH/d"
+run 'dirname' dirname 'inside createGuestTarget' -- dirname /a/b
+run 'chmod' chmod 'the mode a files: binding declares' -- chmod 0700 "$SCRATCH/d"
+run 'chown, guest user' chown "hands directories to $GUEST_USER and back" -- \
+	chown "$GUEST_USER" "$SCRATCH/d"
+run 'rm' rm 'removes a planted symlink rather than following it' -- \
+	rm -f "$SCRATCH/absent"
+run 'mount, tmpfs' mount 'covers a directory so a credential stays off disk' -- \
+	mount -t tmpfs -o size=1m,mode=0700,nodev,nosuid tmpfs "$SCRATCH/d"
+run 'sleep' sleep 'the container command on the nerdctl path' -- sleep 0
+run 'bash' bash 'brig shell' -- bash -lc 'exit 0'
+
+if [ -n "$BINARY" ]; then
+	run "$BINARY" "$BINARY" "the profile's binary:" -- "$BINARY" --version
+else
+	skip 'binary:' 'not given, so the agent CLI was not checked'
+fi
+
+# The guest home is created by the workspace mount, so its absence is not a
+# failure. Said out loud because an image that ships content there is a mistake
+# worth knowing about: the mount hides all of it.
+if [ "$MODE" = exec ] && guest test -d "$GUEST_HOME"; then
+	printf '\nnote: %s exists in the image. The workspace is mounted over it, so\n' "$GUEST_HOME"
+	printf '      anything the image ships there is invisible in the sandbox.\n'
+fi
+
+printf '\n'
+if [ "$FAILED" -eq 0 ]; then
+	if [ "$MODE" = list ]; then
+		printf 'Every binary is present. Boot the image to check they work.\n'
+	else
+		printf 'This image satisfies the contract in docs/guest-image.md.\n'
+	fi
+	exit 0
+fi
+printf 'This image does not satisfy the contract. See docs/guest-image.md.\n'
+exit 1


### PR DESCRIPTION
## Summary

The help text and the README said any Linux CLI in an OCI image runs under brig
"as long as it carries the utilities brig invokes", and the README's list of
those utilities was incomplete. There was no page describing what an image must
provide, so someone building one found out by failing, one binary at a time.

`docs/guest-image.md` is the contract, established from the source rather than
from memory: every binary brig runs in the guest with the file and function that
runs it, the paths and kernel interfaces it expects, the user the image runs as,
what `genericBoot` changes, the tmpfs mounts brig creates, and what `volumes:`
and `files:` assume. It names what the old README list got wrong beyond
`sleep`: `chmod`, `rm` and `dirname` (an external command inside a shell
script, so nobody guesses it), that only GNU-style `stat -c` and `stat -f -c`
work, that `sh` and `bash` are not interchangeable, and that most of the list is
conditional on a profile declaring `volumes:` or `files:`.

## Related issues

Closes #44

## Changes

- `docs/guest-image.md`, the contract, 300 lines, each requirement cited.
- The README paragraph now links the contract instead of inlining a list that
  drifts.
- `script/check-guest-image.sh <image> [guest-home] [binary]`, which boots the
  image and checks it line by line. Not wired into CI, by design and by comment:
  it pulls and boots the image you name.

## The script now boots through brig

The first version booted the image bare with `hull run`, which gave a container
capability set without `CAP_SYS_ADMIN`, so the `mount, tmpfs` check was a false
negative for how brig actually uses an image. Review caught it and the script was
reworked to boot through `brig create`, which gets the profile's hypervisor,
rootfs type, generic-boot annotations and guest home, the same as a real run.

Invocation is now `script/check-guest-image.sh <image> [profile]`, profile
default `claude-code`. Home, user and agent binary come from
`brig profile export <profile> --json`, so a file-backed profile or an override
is read the way brig reads it.

Run for real on macOS against `ghcr.io/brig-sh/claude-code-stock:latest`, an
image brig boots every day: all 15 checks pass, exit 0, no sandbox left behind.
The bare-boot version failed `mount, tmpfs` and `chown` on the same image.

```
ok   mount, tmpfs           covers a directory so a credential stays off disk
ok   chown, guest user      hands directories to claude and back
ok   claude                 the profile's binary:
This image satisfies the contract in docs/guest-image.md.
```

It stays out of CI, by design and by header comment: it pulls and boots a real
image, which no CI runner here can do.

## Checklist

- [x] `make all` passes (vet, test, build)
- [x] `script/smoke.sh` passes
- [ ] ~~I have added or updated tests covering the change~~
- [ ] ~~I have run `go test ./... -race`, if the change touches concurrency, subprocesses or the daemon~~
- [x] I have exercised the change against a real runtime (`brig run <agent>`), if it touches the run, exec or credential path
- [x] I have updated the affected docs (README, `docs/security.md`, `docs/profiles.md`, `docs/brigd.md`)

The script was exercised against a real runtime, which is how the boot-mode
problem was found. The box stays unticked until the reworked script passes.

## Credentials and the sandbox boundary

Documentation and a diagnostic script; no behaviour changes. The contract's
tmpfs section is the one that touches the second promise, since it describes
the mount that keeps a delivered credential off host disk.

