### PR TITLE
fix(brigd): hold the socket, bound requests, never prompt, resolve per request

### DIFF
--- a/cmd/brigd/daemon_test.go
+++ b/cmd/brigd/daemon_test.go
@@ -1,0 +1,496 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/brig-sh/brig/internal/profile"
+	"github.com/brig-sh/brig/internal/runtime"
+	"github.com/brig-sh/brig/internal/ttytest"
+)
+
+// stubRuntime points the daemon at a runtime binary that exists and does
+// nothing. The machine running the tests has neither hull nor nerdctl, and a
+// request whose profile names no runtimeBin of its own has to find one.
+func stubRuntime(t *testing.T) string {
+	t.Helper()
+	bin := filepath.Join(shortDir(t), "hull")
+	if err := os.WriteFile(bin, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("BRIG_RUNTIME", "hull")
+	t.Setenv("BRIG_RUNTIME_BIN", bin)
+	return bin
+}
+
+// startDaemon runs a daemon in this process and returns once it answers.
+//
+// It stays up for the rest of the test binary's life: serve has no way to be
+// asked to stop other than a signal, and every test gets a socket path of its
+// own, so there is nothing to collide with.
+func startDaemon(t *testing.T, socket string) {
+	t.Helper()
+	failed := make(chan error, 1)
+	go func() { failed <- serve(socket) }()
+
+	deadline := time.Now().Add(10 * time.Second)
+	for time.Now().Before(deadline) {
+		select {
+		case err := <-failed:
+			t.Fatalf("the daemon exited instead of listening: %v", err)
+		default:
+		}
+		conn, err := net.Dial("unix", socket)
+		if err == nil {
+			_ = conn.Close()
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatal("the daemon never started listening")
+}
+
+// ask sends one request on a connection of its own and returns the response.
+func ask(t *testing.T, socket, request string) Response {
+	t.Helper()
+	conn, err := net.Dial("unix", socket)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = conn.Close() }()
+	if err := conn.SetDeadline(time.Now().Add(30 * time.Second)); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := io.WriteString(conn, request+"\n"); err != nil {
+		t.Fatal(err)
+	}
+	var resp Response
+	if err := json.NewDecoder(conn).Decode(&resp); err != nil {
+		t.Fatalf("no response to %s: %v", request, err)
+	}
+	return resp
+}
+
+// A second daemon must not take a socket path a live one is serving. Binding a
+// unix socket takes no lock, so without one of its own both daemons stay up
+// and the second answers requests the first believes it is handling.
+
+// shortDir is a temporary directory whose path stays under the unix socket
+// limit. t.TempDir puts the test's own name in the path, and on macOS that
+// lands the socket past 104 bytes, where bind fails with "invalid argument"
+// and the daemon looks broken for a reason that has nothing to do with it.
+// See #80 for the daemon-side check that should name this limit.
+func shortDir(t *testing.T) string {
+	t.Helper()
+	dir, err := os.MkdirTemp("", "brigd")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+	return dir
+}
+
+func TestASecondDaemonRefusesTheSocketOfARunningOne(t *testing.T) {
+	stubRuntime(t)
+	socket := filepath.Join(shortDir(t), "brigd.sock")
+	startDaemon(t, socket)
+
+	// Bounded, because the failure this asserts against is a second daemon
+	// that starts and serves forever rather than one that exits.
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+	second := exec.CommandContext(ctx, os.Args[0], "-test.run=TestServeInAHelperProcess")
+	second.Env = append(os.Environ(), "BRIGD_HELPER_SOCKET="+socket)
+	out, err := second.CombinedOutput()
+
+	if err == nil {
+		t.Fatalf("a second daemon started on a socket already being served: %s", out)
+	}
+	if !strings.Contains(string(out), strconv.Itoa(os.Getpid())) {
+		t.Errorf("the refusal does not name the running daemon (pid %d): %s", os.Getpid(), out)
+	}
+	// The first one is the whole point: refusing is only right if the daemon
+	// that was already there is still serving.
+	if resp := ask(t, socket, `{"op":"version"}`); !resp.OK {
+		t.Errorf("the running daemon stopped serving: %+v", resp)
+	}
+}
+
+// The socket is unlinked by closing the listener, and net does that unlink
+// before it closes the descriptor -- which is what makes the unlink ordered
+// before Accept returns and therefore before serve releases the flock. That
+// ordering is the entire argument that a daemon on its way out cannot unlink
+// the socket of the one that replaces it, and it is a property of the standard
+// library rather than of anything here, so it is asserted rather than assumed.
+func TestClosingTheListenerUnlinksTheSocket(t *testing.T) {
+	socket := filepath.Join(shortDir(t), "brigd.sock")
+	ln, err := net.Listen("unix", socket)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(socket); err != nil {
+		t.Fatalf("the listener bound but left nothing at %s: %v", socket, err)
+	}
+	if err := ln.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(socket); !os.IsNotExist(err) {
+		t.Fatalf("closing the listener left the socket at %s (%v), so shutdown "+
+			"would need a removal of its own, outside the lock", socket, err)
+	}
+}
+
+// A signalled daemon cleans up after itself and leaves the path free for the
+// next one. This is the half of the removal's job that had to survive dropping
+// it: the shutdown no longer names the path, so if closing the listener did not
+// unlink it, a successor would find a stale socket in the way.
+func TestASignalledDaemonLeavesThePathFreeForItsSuccessor(t *testing.T) {
+	stubRuntime(t)
+	socket := filepath.Join(shortDir(t), "brigd.sock")
+
+	// In a process of its own, because a signal is process-wide: delivering
+	// SIGTERM to this one would take the test binary with it.
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+	first := exec.CommandContext(ctx, os.Args[0], "-test.run=TestServeInAHelperProcess")
+	first.Env = append(os.Environ(), "BRIGD_HELPER_SOCKET="+socket)
+	if err := first.Start(); err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = first.Process.Kill() }()
+	waitUntilServing(t, socket)
+
+	if err := first.Process.Signal(syscall.SIGTERM); err != nil {
+		t.Fatal(err)
+	}
+	if err := first.Wait(); err != nil {
+		t.Fatalf("the daemon did not exit cleanly on SIGTERM: %v", err)
+	}
+	if _, err := os.Stat(socket); !os.IsNotExist(err) {
+		t.Errorf("a signalled daemon left its socket behind at %s (%v)", socket, err)
+	}
+
+	// The successor is what the removal was for. It has to bind the same path
+	// and answer on it.
+	startDaemon(t, socket)
+	if resp := ask(t, socket, `{"op":"version"}`); !resp.OK {
+		t.Errorf("the successor is not serving: %+v", resp)
+	}
+}
+
+// waitUntilServing returns once something answers on socket.
+func waitUntilServing(t *testing.T, socket string) {
+	t.Helper()
+	deadline := time.Now().Add(30 * time.Second)
+	for time.Now().Before(deadline) {
+		conn, err := net.Dial("unix", socket)
+		if err == nil {
+			_ = conn.Close()
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("nothing ever started serving %s", socket)
+}
+
+// A request past the limit is answered rather than dropped. The scanner used
+// to end the scan on one, which closed the connection with nothing written to
+// the client and nothing written to the log: a client that sent too much saw
+// exactly what a crashed daemon looks like.
+func TestAnOverlongRequestIsAnswered(t *testing.T) {
+	stubRuntime(t)
+	socket := filepath.Join(shortDir(t), "brigd.sock")
+	startDaemon(t, socket)
+
+	// A request of exactly the limit is still served. Without this the test
+	// below would pass against a daemon that refused everything.
+	atTheLimit := `{"op":"version"}`
+	atTheLimit += strings.Repeat(" ", maxRequestBytes-len(atTheLimit))
+	if resp := ask(t, socket, atTheLimit); !resp.OK {
+		t.Errorf("a request of exactly the limit was refused: %+v", resp)
+	}
+
+	conn, err := net.Dial("unix", socket)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = conn.Close() }()
+	if err := conn.SetDeadline(time.Now().Add(30 * time.Second)); err != nil {
+		t.Fatal(err)
+	}
+	// One byte over, written from a goroutine: the daemon answers and closes
+	// as soon as it knows the request is too long, so the tail of the write
+	// may well have nowhere to go.
+	go func() {
+		_, _ = io.WriteString(conn, strings.Repeat("a", maxRequestBytes+1)+"\n")
+	}()
+
+	var resp Response
+	if err := json.NewDecoder(conn).Decode(&resp); err != nil {
+		t.Fatalf("an over-length request got no response at all: %v", err)
+	}
+	if resp.OK {
+		t.Errorf("an over-length request was reported as served: %+v", resp)
+	}
+	if !strings.Contains(resp.Error, strconv.Itoa(maxRequestBytes)) {
+		t.Errorf("the error does not say what the limit is: %q", resp.Error)
+	}
+}
+
+// A request that arrives in pieces is served. The deadline was set once per
+// scan and a scan reads a whole line, so what it bounded was how long the
+// request took to arrive: a client trickling one across the window was cut off
+// however recently its last byte had landed, which is not what an idle timeout
+// means and not what the daemon is protecting itself against.
+//
+// net.Pipe rather than a socket, because it is unbuffered: every byte written
+// here is a read on the daemon's side, which is what makes the reset per read
+// the thing under test.
+func TestARequestThatArrivesInPiecesIsServed(t *testing.T) {
+	d := newDaemon()
+	d.idle = 100 * time.Millisecond
+	client, server := net.Pipe()
+	defer func() { _ = client.Close() }()
+	go d.handle(server)
+
+	// Longer than the timeout in total, with every gap well inside it.
+	req := []byte(`{"op":"version"}` + "\n")
+	for i := range req {
+		if err := client.SetWriteDeadline(time.Now().Add(30 * time.Second)); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := client.Write(req[i : i+1]); err != nil {
+			t.Fatalf("the daemon stopped reading after byte %d of %d: %v", i, len(req), err)
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	if err := client.SetReadDeadline(time.Now().Add(30 * time.Second)); err != nil {
+		t.Fatal(err)
+	}
+	var resp Response
+	if err := json.NewDecoder(client).Decode(&resp); err != nil {
+		t.Fatalf("a request that arrived in pieces got no response: %v", err)
+	}
+	if !resp.OK {
+		t.Errorf("a request that arrived in pieces was refused: %+v", resp)
+	}
+}
+
+// The other side of the same timeout: a client that opens a connection and then
+// says nothing must not hold a goroutine and a descriptor for as long as it
+// likes. Dropping the timeout entirely would pass the test above.
+func TestAConnectionThatSaysNothingIsClosed(t *testing.T) {
+	d := newDaemon()
+	d.idle = 100 * time.Millisecond
+	client, server := net.Pipe()
+	defer func() { _ = client.Close() }()
+	done := make(chan struct{})
+	go func() {
+		d.handle(server)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(30 * time.Second):
+		t.Fatal("a connection that sent nothing was held open past the idle timeout")
+	}
+}
+
+// A client that asks and then stops reading must not park the handler in a
+// write forever. Nothing bounded a write: the read deadline says nothing about
+// one, so once the socket buffer filled, Encode blocked for as long as the
+// client left the connection sitting there, holding a goroutine and a
+// descriptor apiece.
+//
+// net.Pipe is unbuffered, so the fill is immediate and the test does not have
+// to guess how much a socket takes before it blocks.
+func TestAClientThatStopsReadingDoesNotPinTheHandler(t *testing.T) {
+	d := newDaemon()
+	// Generous next to the write deadline, so a handler that comes back does so
+	// because the write gave up and not because the read did.
+	d.idle = 30 * time.Second
+	d.write = 100 * time.Millisecond
+	client, server := net.Pipe()
+	defer func() { _ = client.Close() }()
+	done := make(chan struct{})
+	go func() {
+		d.handle(server)
+		close(done)
+	}()
+
+	if err := client.SetWriteDeadline(time.Now().Add(30 * time.Second)); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := io.WriteString(client, `{"op":"version"}`+"\n"); err != nil {
+		t.Fatal(err)
+	}
+	// Deliberately no read of the response.
+
+	select {
+	case <-done:
+	case <-time.After(30 * time.Second):
+		t.Fatal("the handler is still blocked writing to a client that never read")
+	}
+}
+
+// testProfile registers one profile of the test's own and returns its name.
+// The registry is global and built from files, exactly as it is in main.
+func testProfile(t *testing.T, name string, extra ...string) string {
+	t.Helper()
+	dir := shortDir(t)
+	spec := "name: " + name + "\n" +
+		"image: ghcr.io/brig-sh/claude-code:arm64\n" +
+		"guestHome: /home/agent\n" +
+		"binary: agent\n" +
+		"mem: 1024\ncpus: 1\n" +
+		strings.Join(extra, "\n")
+	if err := os.WriteFile(filepath.Join(dir, name+".yaml"), []byte(spec+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("BRIG_PROFILE_DIR", dir)
+	if err := profile.Load(dir); err != nil {
+		t.Fatal(err)
+	}
+	return name
+}
+
+// A daemon never prompts. The image check is the one thing in a run that stops
+// to ask, and asking on the daemon's own terminal puts the question where the
+// client cannot see it, holds the sandbox's lock across the wait, and times
+// the client out. The refusal comes back as a request's answer instead.
+func TestARequestThatWouldPromptIsRefusedRatherThanAsked(t *testing.T) {
+	stubRuntime(t)
+	agent := testProfile(t, "promptcheck")
+	t.Setenv("BRIG_WORKSPACE", filepath.Join(shortDir(t), "ws"))
+	// A real terminal on the daemon's stdin, the way starting brigd from a
+	// shell leaves one, and nothing written to it. This is what makes the test
+	// about the fix rather than about `go test` running without a terminal: a
+	// daemon that still asks reads from here, blocks, and the request below
+	// times out instead of being answered.
+	ttytest.AsStdin(t)
+	// An image under our own registry whose signature does not check out: the
+	// one case that stops to ask.
+	t.Setenv("BRIG_VERIFY", "warn")
+	t.Setenv("BRIG_COSIGN_BIN", "false")
+
+	socket := filepath.Join(shortDir(t), "brigd.sock")
+	startDaemon(t, socket)
+
+	resp := ask(t, socket, `{"op":"ensure","agent":"`+agent+`"}`)
+	if resp.OK {
+		t.Fatalf("an image that failed verification was booted: %+v", resp)
+	}
+	// Named, not merely refused: a client that gets "aborted" with no reason
+	// has nothing to act on.
+	if !strings.Contains(resp.Error, "failed verification") {
+		t.Errorf("the error does not say what went wrong: %q", resp.Error)
+	}
+	if !strings.Contains(resp.Error, "BRIG_VERIFY=off") {
+		t.Errorf("the error does not name the setting that overrides it: %q", resp.Error)
+	}
+	said := strings.Join(resp.Warnings, "\n")
+	if !strings.Contains(said, "DID NOT VERIFY") {
+		t.Errorf("the client was not told what the check concluded: %q", said)
+	}
+	if strings.Contains(said, "Boot it anyway?") || strings.Contains(resp.Error, "Boot it anyway?") {
+		t.Errorf("the daemon asked a question: %q %q", said, resp.Error)
+	}
+}
+
+// A boot that went well warns about nothing. The daemon collects what a run
+// says and returns it to the client as warnings, and the line narrating that
+// the boot has started went into the same buffer -- so a cold boot with nothing
+// wrong with it answered {"ok":true} carrying a complaint about itself, and a
+// client with any rule about a non-empty warnings list acted on it.
+//
+// The counterpart, that a real warning still travels, is
+// TestARequestThatWouldPromptIsRefusedRatherThanAsked: the image check's verdict
+// reaches the client in the same field.
+func TestACleanColdBootWarnsAboutNothing(t *testing.T) {
+	stubRuntime(t)
+	agent := testProfile(t, "cleanboot")
+	t.Setenv("BRIG_WORKSPACE", filepath.Join(shortDir(t), "ws"))
+	// The image check is the other thing that speaks on a cold boot, and with
+	// no cosign on this machine it has something true to say. Off, so what is
+	// left in the buffer is the narration this test is about.
+	t.Setenv("BRIG_VERIFY", "off")
+
+	socket := filepath.Join(shortDir(t), "brigd.sock")
+	startDaemon(t, socket)
+
+	resp := ask(t, socket, `{"op":"ensure","agent":"`+agent+`"}`)
+	if !resp.OK {
+		t.Fatalf("the sandbox did not come up: %+v", resp)
+	}
+	if len(resp.Warnings) != 0 {
+		t.Errorf("a boot with nothing wrong with it warned anyway: %q", resp.Warnings)
+	}
+}
+
+// A profile's runtimeBin has to reach the same binary through the daemon as it
+// does through the CLI. It did not: the daemon detected a runtime once at
+// startup, with no profile in hand to take a preference from, so a profile
+// pinning a build was honoured when you typed `brig run` and ignored when a
+// client asked brigd for the same sandbox.
+func TestAProfilesRuntimeBinReachesTheSameBinaryThroughTheDaemon(t *testing.T) {
+	// Nothing in the environment: BRIG_RUNTIME_BIN beats the profile, which is
+	// the usual order, and would answer this question for the wrong reason.
+	t.Setenv("BRIG_RUNTIME", "hull")
+	t.Setenv("BRIG_RUNTIME_BIN", "")
+	pinned := filepath.Join(shortDir(t), "hull-of-my-own")
+	if err := os.WriteFile(pinned, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	agent := testProfile(t, "pinnedruntime", "runtimeBin: "+pinned)
+
+	cfg, _, err := newDaemon().config(Request{Agent: agent})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Runtime.Bin() != pinned {
+		t.Errorf("the daemon drives %q, want the profile's %q", cfg.Runtime.Bin(), pinned)
+	}
+
+	// The CLI's own resolution, spelled as cmd/brig spells it. The two paths
+	// agreeing is the property; either one being right on its own is not.
+	p, ok := profile.Lookup(agent)
+	if !ok {
+		t.Fatalf("profile %q did not register", agent)
+	}
+	rt, err := runtime.DetectFor(runtime.Preference{Bin: p.RuntimeBin})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rt.Bin() != cfg.Runtime.Bin() {
+		t.Errorf("the CLI drives %q and the daemon %q", rt.Bin(), cfg.Runtime.Bin())
+	}
+}
+
+// TestServeInAHelperProcess is not a test. It is how the test above starts a
+// second daemon in a second process, which is the only honest way to ask the
+// question: a lock is held against other processes, and this one already holds
+// it.
+func TestServeInAHelperProcess(t *testing.T) {
+	socket := os.Getenv("BRIGD_HELPER_SOCKET")
+	if socket == "" {
+		t.Skip("not the helper process; see TestASecondDaemonRefusesTheSocketOfARunningOne")
+	}
+	// main's own exit path, so the test above asserts on what a user would see.
+	if err := serve(socket); err != nil {
+		_, _ = os.Stderr.WriteString("brigd: " + err.Error() + "\n")
+		os.Exit(1)
+	}
+	os.Exit(0)
+}

--- a/cmd/brigd/daemon_test.go
+++ b/cmd/brigd/daemon_test.go
@@ -394,14 +394,20 @@ func TestARequestThatWouldPromptIsRefusedRatherThanAsked(t *testing.T) {
 	}
 	// Named, not merely refused: a client that gets "aborted" with no reason
 	// has nothing to act on.
-	if !strings.Contains(resp.Error, "failed verification") {
+	//
+	// Which check stopped it is not this test's business. A cosign that exits
+	// non-zero fails the digest resolve before it reaches the signature, so on
+	// a runtime that pins the digest this is "could not check" rather than
+	// "failed", and the wording differs. What has to hold either way is that
+	// the response says the image was not verified and names the way past it.
+	if !strings.Contains(resp.Error, "verif") {
 		t.Errorf("the error does not say what went wrong: %q", resp.Error)
 	}
 	if !strings.Contains(resp.Error, "BRIG_VERIFY=off") {
 		t.Errorf("the error does not name the setting that overrides it: %q", resp.Error)
 	}
 	said := strings.Join(resp.Warnings, "\n")
-	if !strings.Contains(said, "DID NOT VERIFY") {
+	if !strings.Contains(said, "could not be checked") && !strings.Contains(said, "DID NOT VERIFY") {
 		t.Errorf("the client was not told what the check concluded: %q", said)
 	}
 	if strings.Contains(said, "Boot it anyway?") || strings.Contains(resp.Error, "Boot it anyway?") {

--- a/cmd/brigd/main.go
+++ b/cmd/brigd/main.go
@@ -15,15 +15,20 @@ package main
 
 import (
 	"bufio"
+	"bytes"
 	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
 	"net"
 	"os"
 	"os/signal"
 	"path/filepath"
+	"strconv"
+	"strings"
 	"sync"
 	"syscall"
+	"time"
 
 	"github.com/brig-sh/brig/internal/profile"
 	"github.com/brig-sh/brig/internal/runtime"
@@ -31,6 +36,37 @@ import (
 )
 
 var version = "dev"
+
+// maxRequestBytes is the longest request line brigd reads, newline excluded.
+//
+// A request is an op, a profile name and a session name, so a megabyte is far
+// more than one can honestly need; the limit is there so a client that never
+// sends a newline cannot make the daemon buffer without bound. It is a raised
+// bufio.Scanner default rather than an invented number, and it is a documented
+// part of the protocol precisely because exceeding it used to be invisible:
+// the scan ended, the connection closed, and neither the client nor the log
+// was told anything.
+const maxRequestBytes = 1 << 20
+
+// idleTimeout is how long a connection may sit silent before the daemon closes
+// it.
+//
+// It bounds the silence, not the work: the deadline is reset on every read of
+// the connection, so an ensure that spends a minute booting a sandbox is not
+// racing it, and neither is a request that arrives in pieces. A client that
+// opens a connection and then says nothing costs a goroutine and a descriptor
+// until this runs out.
+const idleTimeout = 5 * time.Minute
+
+// writeTimeout is how long the daemon will spend delivering one response.
+//
+// A response is a line of JSON, so it fits the socket buffer and this never
+// comes near being reached by a client that reads its answers. One that does
+// not read them is the case it exists for: once the buffer fills, the write
+// blocks, and with no deadline it blocks for as long as that client cares to
+// leave it there, holding a goroutine and a descriptor the read deadline says
+// nothing about.
+const writeTimeout = 30 * time.Second
 
 // Request is one line of JSON on the socket.
 type Request struct {
@@ -41,8 +77,19 @@ type Request struct {
 
 // Response is one line of JSON back.
 type Response struct {
-	OK       bool      `json:"ok"`
-	Error    string    `json:"error,omitempty"`
+	OK    bool   `json:"ok"`
+	Error string `json:"error,omitempty"`
+	// Warnings is what the run said about itself: a credential that was not
+	// forwarded and why, an expiring secret, an image that could not be
+	// verified. The CLI prints these on the terminal of the person who typed
+	// the command; a daemon has no such terminal, and its own is nobody's, so
+	// they travel back to the client that asked instead. One line each, in the
+	// order they were said.
+	//
+	// Only things to act on. What the run narrated about its own progress is
+	// not among them, so an ensure that went entirely well comes back with no
+	// warnings at all and a client can treat any at all as worth showing.
+	Warnings []string  `json:"warnings,omitempty"`
 	Version  string    `json:"version,omitempty"`
 	Sessions []Session `json:"sessions,omitempty"`
 }
@@ -85,12 +132,97 @@ func defaultSocket() string {
 	return filepath.Join(home, ".brig", "brigd.sock")
 }
 
-type daemon struct {
-	rt runtime.Runtime
+// lockSocket takes the exclusive lock that makes this process the daemon for
+// one socket path, and returns the file holding it.
+//
+// The lock lives on a sidecar file rather than on the socket, because a unix
+// socket cannot carry one: the kernel drops the socket's inode from the
+// filesystem the moment somebody unlinks the path, and the listener keeps
+// working, so there is nothing there for a second daemon to test. flock on a
+// plain file is dropped when the process dies however it dies, which is what
+// makes a crashed daemon leave nothing behind to clean up and no stale pid to
+// second-guess.
+//
+// The pid goes into the file as well. Nothing reads it to decide anything --
+// the lock decides -- but a refusal that names the process in the way is the
+// difference between "it is already running" and a hunt through ps.
+//
+// The file is deliberately not removed on shutdown. Unlinking it would let a
+// daemon starting at that moment hold a lock on a file that no longer has a
+// name, while a third one creates a new file at the same path and locks that:
+// two daemons, two locks, one socket, which is the bug this exists to stop.
+func lockSocket(socket string) (*os.File, error) {
+	path := socket + ".lock"
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		return nil, err
+	}
+	if err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX|syscall.LOCK_NB); err != nil {
+		holder := lockHolder(path)
+		_ = f.Close()
+		return nil, fmt.Errorf("another brigd%s is already serving %s. Stop it, or "+
+			"start this one on a socket of its own with --socket", holder, socket)
+	}
+	// Truncated before the pid is written, so a shorter pid than the last one
+	// cannot leave the tail of the old one behind for the next reader.
+	if err := f.Truncate(0); err != nil {
+		_ = f.Close()
+		return nil, err
+	}
+	if _, err := f.WriteAt([]byte(strconv.Itoa(os.Getpid())+"\n"), 0); err != nil {
+		_ = f.Close()
+		return nil, err
+	}
+	return f, nil
+}
 
+// lockHolder names the process holding the lock, as " (pid 123)", or says
+// nothing at all when the file has no readable pid in it. It is only ever part
+// of a message, so an unreadable file is not worth an error of its own.
+func lockHolder(path string) string {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return ""
+	}
+	pid := strings.TrimSpace(string(b))
+	if pid == "" {
+		return ""
+	}
+	return " (pid " + pid + ")"
+}
+
+type daemon struct {
 	mu       sync.Mutex
-	sessions map[string]Session     // keyed by VM name
+	sessions map[string]entry       // keyed by VM name
 	locks    map[string]*sync.Mutex // one per VM name, see lockFor
+
+	// idle is how long a connection may sit silent and write is how long one
+	// response may take to deliver. Fields rather than the constants so a test
+	// can ask what happens on either side of them without waiting minutes for
+	// the answer.
+	idle  time.Duration
+	write time.Duration
+}
+
+// entry is one remembered sandbox and the runtime that booted it.
+//
+// The runtime is per sandbox because it is per profile: two profiles can name
+// two different runtime binaries, and asking the wrong one whether a sandbox is
+// running gets a truthful answer to a different question. It is kept beside the
+// Session rather than in it because Session is the wire type, and which binary
+// brig drove is the daemon's business.
+type entry struct {
+	Session
+	rt runtime.Runtime
+}
+
+func newDaemon() *daemon {
+	return &daemon{
+		sessions: map[string]entry{},
+		locks:    map[string]*sync.Mutex{},
+		idle:     idleTimeout,
+		write:    writeTimeout,
+	}
 }
 
 // lockFor serialises work on one sandbox.
@@ -111,16 +243,24 @@ func (d *daemon) lockFor(vm string) *sync.Mutex {
 }
 
 func serve(socket string) error {
-	rt, err := runtime.Detect()
-	if err != nil {
-		return err
-	}
 	if err := os.MkdirAll(filepath.Dir(socket), 0o700); err != nil {
 		return err
 	}
-	// A socket left behind by a crashed daemon would block the bind. Removing
-	// it is safe only because a live daemon holds a lock on it, which the
-	// bind below re-establishes.
+	// One daemon per socket path, and the lock is what decides it. Binding a
+	// unix socket takes no lock of any kind, so nothing in the listen below
+	// keeps a second daemon out: both stay up, both report listening, and the
+	// second one answers -- which leaves the first holding an inventory that no
+	// longer matches reality and a per-VM mutex that serialises nothing,
+	// because the two processes do not share it.
+	lock, err := lockSocket(socket)
+	if err != nil {
+		return err
+	}
+	defer lock.Close()
+
+	// Only now that the lock is held. A socket left behind by a crashed daemon
+	// would block the bind and has to go; one that a live daemon is serving
+	// must not, and holding the lock is the difference between the two.
 	_ = os.Remove(socket)
 
 	ln, err := net.Listen("unix", socket)
@@ -134,17 +274,35 @@ func serve(socket string) error {
 		return err
 	}
 
-	d := &daemon{rt: rt, sessions: map[string]Session{}, locks: map[string]*sync.Mutex{}}
+	d := newDaemon()
 
 	stop := make(chan os.Signal, 1)
 	signal.Notify(stop, syscall.SIGINT, syscall.SIGTERM)
 	go func() {
 		<-stop
+		// Closing the listener is the whole of the shutdown, and the socket is
+		// unlinked by that close rather than by a removal of our own. The
+		// removal used to be here, one statement later, and one statement later
+		// is outside the lock: this goroutine could be descheduled between the
+		// two, the accept loop return, the deferred Close release the flock, a
+		// second daemon start and bind a socket of its own at the same path, and
+		// the removal then unlink the successor's live socket. The successor
+		// keeps serving a socket with no name, and every client that dials the
+		// path gets a connection refused to a daemon that is running.
+		//
+		// A close cannot do that, because the unlink is what net does before it
+		// closes the descriptor -- and it is that descriptor closing which makes
+		// Accept return. So the unlink is ordered before the accept loop returns
+		// and therefore before the lock is released, which is the same rule the
+		// stale-socket removal above follows. See
+		// TestClosingTheListenerUnlinksTheSocket for the assertion that this
+		// ordering is real.
 		ln.Close()
-		os.Remove(socket)
 	}()
 
-	fmt.Fprintf(os.Stderr, "brigd %s listening on %s (runtime %s)\n", version, socket, rt.Kind())
+	// No runtime named here any more: there is one per request, resolved from
+	// the profile the request names, so there is no single answer to give.
+	fmt.Fprintf(os.Stderr, "brigd %s listening on %s\n", version, socket)
 	for {
 		conn, err := ln.Accept()
 		if err != nil {
@@ -154,17 +312,95 @@ func serve(socket string) error {
 	}
 }
 
+// idleConn arms the read deadline afresh before every read of the connection.
+//
+// The deadline used to be set once per scan, and a scan reads a whole line, so
+// what it bounded was how long a request took to arrive rather than how long
+// the client was silent: a client trickling one request across the window was
+// cut off however recently its last byte had landed. The daemon has no quarrel
+// with a slow writer -- what costs it a goroutine and a descriptor is a
+// connection nobody is using -- so the deadline belongs on each read.
+type idleConn struct {
+	conn net.Conn
+	idle time.Duration
+}
+
+func (c idleConn) Read(p []byte) (int, error) {
+	if err := c.conn.SetReadDeadline(time.Now().Add(c.idle)); err != nil {
+		return 0, err
+	}
+	return c.conn.Read(p)
+}
+
+// replier writes one response per call, each bounded by a deadline of its own.
+//
+// Nothing bounded a write before this. A client that sends a request and then
+// stops reading fills the socket buffer, and Encode then blocks in a write that
+// no read deadline covers, holding a goroutine and a descriptor for as long as
+// that client leaves the connection there.
+//
+// A failed write ends the connection rather than being retried: part of the
+// answer is already on the wire with no way to say where it stopped, so a
+// client reading again would find the tail of one response where the next one
+// should start.
+type replier struct {
+	conn net.Conn
+	enc  *json.Encoder
+	d    time.Duration
+}
+
+func (r replier) reply(resp Response) error {
+	if err := r.conn.SetWriteDeadline(time.Now().Add(r.d)); err != nil {
+		return err
+	}
+	return r.enc.Encode(resp)
+}
+
 func (d *daemon) handle(conn net.Conn) {
 	defer conn.Close()
-	scan := bufio.NewScanner(conn)
-	enc := json.NewEncoder(conn)
-	for scan.Scan() {
+	scan := bufio.NewScanner(idleConn{conn: conn, idle: d.idle})
+	// One byte more than the limit, for the newline. The scanner's cap is on
+	// what it buffers rather than on the token it hands back, and a request of
+	// exactly the limit is only buffered whole if its terminator fits too.
+	scan.Buffer(make([]byte, 0, 64*1024), maxRequestBytes+1)
+	out := replier{conn: conn, enc: json.NewEncoder(conn), d: d.write}
+	for {
+		if !scan.Scan() {
+			break
+		}
 		var req Request
 		if err := json.Unmarshal(scan.Bytes(), &req); err != nil {
-			_ = enc.Encode(Response{Error: "bad request: " + err.Error()})
+			if err := out.reply(Response{Error: "bad request: " + err.Error()}); err != nil {
+				return
+			}
 			continue
 		}
-		_ = enc.Encode(d.dispatch(req))
+		if err := out.reply(d.dispatch(req)); err != nil {
+			return
+		}
+	}
+	// A scan that stops on an error rather than on end of input is the one case
+	// a client cannot see for itself: it wrote a request and the connection
+	// closed, with nothing said here and nothing said in the daemon's log
+	// either. Say both.
+	//
+	// The connection is not read any further after this. What follows an
+	// over-length request in the stream is the tail of that request, and there
+	// is no way to tell where it ends and the next one begins, so answering and
+	// closing is the only honest thing to do with it.
+	switch err := scan.Err(); {
+	case err == nil:
+	case errors.Is(err, os.ErrDeadlineExceeded):
+		// An idle client is not a failure and has nothing to be told: it is
+		// still holding its end of a connection nobody is using.
+	case errors.Is(err, bufio.ErrTooLong):
+		tooLong := fmt.Errorf("request is longer than the %d byte limit, so it was "+
+			"not read", maxRequestBytes)
+		_ = out.reply(Response{Error: tooLong.Error()})
+		fmt.Fprintln(os.Stderr, "brigd: "+tooLong.Error())
+	default:
+		_ = out.reply(Response{Error: err.Error()})
+		fmt.Fprintln(os.Stderr, "brigd: "+err.Error())
 	}
 }
 
@@ -183,19 +419,72 @@ func (d *daemon) dispatch(req Request) Response {
 	}
 }
 
-func (d *daemon) config(req Request) (*wrap.Config, error) {
+// config resolves one request into a run, and hands back the buffer that run
+// says things into.
+//
+// The runtime is resolved here, per request and from the profile, in the same
+// call the CLI makes for the same reason: a profile that names a runtimeBin is
+// asking for that binary, and detecting once at startup with no profile in hand
+// meant the daemon honoured it for nobody and bound one runtime for its whole
+// life. Doing it per request also means a daemon can serve a profile that names
+// a binary installed after it started.
+//
+// Two things separate a daemon's run from the CLI's, and both are settings on
+// the Config rather than behaviour of their own. It has no terminal to put a
+// question to, so it declares that up front and the image check takes the path
+// it already has for having nobody to ask: refuse, and say which setting lets
+// a caller proceed deliberately. And what it says belongs to the client that
+// asked rather than to whatever terminal brigd was started from, so both
+// writers go to a buffer this request owns; concurrent requests each get their
+// own. Progress narration is the exception and stays on the daemon's stderr,
+// for the reason given where it is set.
+func (d *daemon) config(req Request) (*wrap.Config, *bytes.Buffer, error) {
 	t, ok := profile.Lookup(req.Agent)
 	if !ok {
-		return nil, fmt.Errorf("unknown agent %q", req.Agent)
+		return nil, nil, fmt.Errorf("unknown agent %q", req.Agent)
 	}
-	return wrap.Load(t, wrap.Options{Name: req.Name}, d.rt)
+	rt, err := runtime.DetectFor(runtime.Preference{Bin: t.RuntimeBin})
+	if err != nil {
+		return nil, nil, err
+	}
+	cfg, err := wrap.Load(t, wrap.Options{Name: req.Name}, rt)
+	if err != nil {
+		return nil, nil, err
+	}
+	said := &bytes.Buffer{}
+	cfg.Out = said
+	cfg.Err = said
+	// Not into that buffer. What the run narrates about its own progress is not
+	// a warning, and the buffer is delivered to the client as the request's
+	// warnings: with the narration in it, an ensure that did everything right
+	// answered {"ok":true} carrying "starting sandbox ..." as a complaint about
+	// itself, and a client with any rule about a non-empty warnings list acted
+	// on it. It goes to the daemon's stderr instead, which is its log and the
+	// one place a line saying a boot has started is worth having.
+	cfg.Progress = os.Stderr
+	cfg.NoTerminal = true
+	return cfg, said, nil
+}
+
+// warnings turns what a run wrote into the response's warnings, one line each.
+func warnings(buf *bytes.Buffer) []string {
+	if buf == nil {
+		return nil
+	}
+	var out []string
+	for _, line := range strings.Split(buf.String(), "\n") {
+		if strings.TrimSpace(line) != "" {
+			out = append(out, line)
+		}
+	}
+	return out
 }
 
 // ensure boots the sandbox if it is not already up, using exactly the CLI's
 // path: same workspace preparation, same credential resolution, same
 // stale-share check.
 func (d *daemon) ensure(req Request) Response {
-	cfg, err := d.config(req)
+	cfg, said, err := d.config(req)
 	if err != nil {
 		return Response{Error: err.Error()}
 	}
@@ -211,17 +500,17 @@ func (d *daemon) ensure(req Request) Response {
 	// Response.Error next must not collapse those newlines onto one line.
 	set, err := cfg.BuildEnv()
 	if err != nil {
-		return Response{Error: err.Error()}
+		return Response{Error: err.Error(), Warnings: warnings(said)}
 	}
 	if err := cfg.EnsureRunning(set); err != nil {
-		return Response{Error: err.Error()}
+		return Response{Error: err.Error(), Warnings: warnings(said)}
 	}
 	d.remember(cfg)
-	return Response{OK: true, Sessions: d.status()}
+	return Response{OK: true, Warnings: warnings(said), Sessions: d.status()}
 }
 
 func (d *daemon) stop(req Request) Response {
-	cfg, err := d.config(req)
+	cfg, said, err := d.config(req)
 	if err != nil {
 		return Response{Error: err.Error()}
 	}
@@ -230,22 +519,27 @@ func (d *daemon) stop(req Request) Response {
 	defer lock.Unlock()
 
 	if err := cfg.Stop(); err != nil {
-		return Response{Error: err.Error()}
+		return Response{Error: err.Error(), Warnings: warnings(said)}
 	}
 	d.mu.Lock()
 	delete(d.sessions, cfg.VMName)
 	d.mu.Unlock()
-	return Response{OK: true, Sessions: d.status()}
+	return Response{OK: true, Warnings: warnings(said), Sessions: d.status()}
 }
 
 func (d *daemon) remember(cfg *wrap.Config) {
 	d.mu.Lock()
 	defer d.mu.Unlock()
-	d.sessions[cfg.VMName] = Session{
-		Agent:     cfg.Profile.Name,
-		Name:      cfg.RawName,
-		VM:        cfg.VMName,
-		Workspace: cfg.Workspace,
+	d.sessions[cfg.VMName] = entry{
+		Session: Session{
+			Agent:     cfg.Profile.Name,
+			Name:      cfg.RawName,
+			VM:        cfg.VMName,
+			Workspace: cfg.Workspace,
+		},
+		// The runtime this sandbox was booted with, so asking whether it is
+		// still running asks the binary that booted it.
+		rt: cfg.Runtime,
 	}
 }
 
@@ -256,9 +550,9 @@ func (d *daemon) status() []Session {
 	d.mu.Lock()
 	defer d.mu.Unlock()
 	out := make([]Session, 0, len(d.sessions))
-	for vm, s := range d.sessions {
-		s.Running = d.rt.Running(vm)
-		out = append(out, s)
+	for vm, e := range d.sessions {
+		e.Running = e.rt.Running(vm)
+		out = append(out, e.Session)
 	}
 	return out
 }

--- a/docs/brigd.md
+++ b/docs/brigd.md
@@ -24,6 +24,12 @@ brigd --socket /tmp/brigd.sock
 The socket is created 0600. It carries lifecycle control over sandboxes
 holding live credentials, so it belongs to the invoking user alone.
 
+One daemon serves one socket path. Starting a second on a path that is already
+being served exits non-zero and names the process in the way, rather than
+taking the path over: two daemons on one socket would each keep an inventory
+of half the sandboxes. The lock is a `brigd.sock.lock` file beside the socket,
+held for as long as the daemon runs and released by the kernel if it dies.
+
 ## Protocol
 
 Line-delimited JSON, one request per line, one response per line.
@@ -49,6 +55,41 @@ A response looks like:
 Errors come back as `{"ok":false,"error":"..."}` rather than as a closed
 connection.
 
+Anything the run says about itself comes back with it, as `warnings`, one line
+each: a credential that was not forwarded and why, a secret about to expire, an
+image that could not be verified. The CLI prints these on the terminal of the
+person who typed the command, and the daemon has no such terminal, so they
+travel to the client that asked rather than to whatever terminal brigd happens
+to have been started from.
+
+Only things to act on. What a run narrates about its own progress, such as the
+line saying a boot has started, goes to brigd's stderr and not to the client, so
+an `ensure` that went entirely well comes back with no `warnings` at all.
+
+A connection that sends nothing for five minutes is closed. The deadline is
+reset on every read, so it bounds the silence and not the work: an `ensure`
+that spends a minute booting is not racing it, and neither is a request that
+arrives in pieces.
+
+A response has thirty seconds to be delivered. A response is a line of JSON and
+fits the socket buffer, so a client that reads its answers never comes near
+this; one that asks and then stops reading would hold a goroutine and a
+descriptor open indefinitely once the buffer filled, and has its connection
+closed instead.
+
+A request line is at most 1 MiB, newline excluded. That is far more than an op,
+a profile name and a session name need; the limit exists so a client that never
+sends a newline cannot make the daemon buffer without bound. A longer one gets
+an error saying so written to it, and the connection is then closed, because
+what follows an over-length request in the stream cannot be told apart from the
+tail of it.
+
+Whether that error is read is another matter. It goes out the moment the limit
+is reached, which is while the client is usually still writing, so a client that
+does not read until its write returns sees the broken pipe rather than the
+error. The error is there for one that reads as it writes; the closed connection
+is what everybody else gets.
+
 For instance, with `socat`:
 
 ```bash
@@ -61,6 +102,18 @@ echo '{"op":"ensure","agent":"claude"}' | socat - UNIX-CONNECT:$HOME/.brig/brigd
 credentials, verifies the image and checks the share, then boots only if
 needed. Work on one sandbox is serialised, so two clients asking for the same
 one at the same moment get one boot rather than two.
+
+The daemon never asks a question. The image check stops to ask when an image
+claiming to be ours fails verification, and there is nobody on the other end of
+brigd's terminal to answer: the client is somewhere else and the sandbox's lock
+would be held across the wait. So a request that would have prompted is refused
+instead, with the reason and the setting that overrides it in `error`. Setting
+`BRIG_VERIFY=off`, or fixing the image, is how such a request goes through.
+
+The runtime is resolved per request, from the profile the request names, so a
+profile carrying `runtimeBin` drives the same binary through the daemon as it
+does through the CLI. A profile naming a binary that is not there fails that
+request and no other.
 
 `status` re-reads liveness from the runtime instead of trusting the inventory.
 A sandbox can be stopped by anything, including a `brig stop` that never went

--- a/internal/wrap/config.go
+++ b/internal/wrap/config.go
@@ -119,8 +119,27 @@ type Config struct {
 	// paying for a second keychain read.
 	HostCred *creds.HostCredential
 
+	// NoTerminal declares that this run has no terminal to put a question to,
+	// whatever this process's own stdin happens to be. brigd sets it: started
+	// from a shell its stdin is a terminal, but it is the daemon's terminal and
+	// not the client's, so a question asked there is asked of nobody while the
+	// caller waits for an answer that cannot arrive. See confirm.
+	NoTerminal bool
+
 	Out io.Writer
 	Err io.Writer
+
+	// Progress is where the run narrates what it is doing -- the line that says
+	// a boot has started, and nothing that anybody has to act on.
+	//
+	// Separate from Err because a caller that collects what a run said and
+	// hands it to somebody else has to be able to tell the two apart. brigd is
+	// that caller: it returns Err to the client as the request's warnings, and
+	// with the narration in there a boot that went perfectly came back carrying
+	// "starting sandbox ..." as a warning about itself. On a terminal the
+	// distinction does not arise, both being lines on the same stderr, which is
+	// why it went unnoticed for as long as the CLI was the only caller.
+	Progress io.Writer
 
 	env Env
 }
@@ -306,6 +325,7 @@ func Load(t profile.Profile, o Options, rt runtime.Runtime) (*Config, error) {
 		Cwd:            cwd,
 		Out:            os.Stdout,
 		Err:            os.Stderr,
+		Progress:       os.Stderr,
 		env:            env,
 	}
 	if strictErr != nil {

--- a/internal/wrap/run.go
+++ b/internal/wrap/run.go
@@ -257,7 +257,7 @@ func (c *Config) EnsureRunning(set creds.Set) error {
 		return err
 	}
 
-	fmt.Fprintf(c.Err, "brig: starting sandbox %s...\n", c.VMName)
+	c.progressf("starting sandbox %s...", c.VMName)
 	// What a runtime that cannot mount after boot needs handed to it now
 	// instead. Empty for hull, which execs as root and does the three-phase
 	// mount itself; see createTimeVolumes.

--- a/internal/wrap/verify.go
+++ b/internal/wrap/verify.go
@@ -131,7 +131,8 @@ func (c *Config) verifyDigest() error {
 		}
 		if !c.confirm("Boot the cached copy unverified?") {
 			return errors.New("aborted: the registry could not be reached, so the image " +
-				"could not be verified. Try again with the registry reachable")
+				"could not be verified. Try again with the registry reachable, or set " +
+				"BRIG_VERIFY=off to boot the cached copy unchecked")
 		}
 		return nil
 

--- a/internal/wrap/verify.go
+++ b/internal/wrap/verify.go
@@ -181,8 +181,14 @@ func (c *Config) verifyDigest() error {
 // one check that stops into one that does not. So it answers no and says
 // which setting overrides it -- a scripted run that genuinely wants to
 // proceed can say so in advance.
+//
+// A caller that has no terminal of its own says so with NoTerminal rather than
+// leaving it to be guessed from this process's stdin. The two are not the same
+// question for a daemon: brigd's stdin may well be a terminal, it is simply
+// not the one the request came from, and asking there puts the question in
+// front of nobody while the client waits.
 func (c *Config) confirm(question string) bool {
-	if !IsTerminal(os.Stdin) {
+	if c.NoTerminal || !IsTerminal(os.Stdin) {
 		c.warnf("not a terminal, so there is nobody to ask: refusing. " +
 			"Set BRIG_VERIFY=off to boot it regardless.")
 		return false

--- a/internal/wrap/verify_test.go
+++ b/internal/wrap/verify_test.go
@@ -277,6 +277,39 @@ func TestVerifyRefusesAFailedSignatureWithStdinOnDevNull(t *testing.T) {
 	}
 }
 
+// A caller with no terminal of its own is taken at its word, even sitting on a
+// real one. This is brigd's case: its stdin may well be a terminal, because it
+// was started from a shell, but that terminal belongs to whoever started the
+// daemon and not to the client whose request raised the question -- so asking
+// there puts a question in front of nobody while the client waits for an
+// answer that cannot come.
+func TestVerifyDoesNotAskWhenTheCallerHasNoTerminal(t *testing.T) {
+	// A real terminal on stdin, with an answer already waiting on it: the
+	// point is that neither is looked at.
+	master := ttytest.AsStdin(t)
+	if _, err := master.WriteString("y\n"); err != nil {
+		t.Fatal(err)
+	}
+	c := verifyConfig(t, "ghcr.io/brig-sh/claude-code:arm64", verify.Warn)
+	c.VerifyPolicy.Cosign = "false" // present, and always exits non-zero
+	c.NoTerminal = true
+
+	err := c.verifyImage()
+	if err == nil {
+		t.Fatal("a failed signature was booted on a terminal the caller does not have")
+	}
+	if !strings.Contains(err.Error(), "BRIG_VERIFY=off") {
+		t.Errorf("the refusal did not name the override: %v", err)
+	}
+	said := c.Err.(*bytes.Buffer).String()
+	if strings.Contains(said, "Boot it anyway?") {
+		t.Errorf("the question was asked anyway: %q", said)
+	}
+	if !strings.Contains(said, "nobody to ask") {
+		t.Errorf("the refusal did not say why nobody was asked: %q", said)
+	}
+}
+
 // And with a real terminal the question is actually asked and the answer
 // actually read. This is the half the no-terminal tests cannot prove: a
 // confirm() that always refused would satisfy every assertion above.

--- a/internal/wrap/verify_test.go
+++ b/internal/wrap/verify_test.go
@@ -347,3 +347,35 @@ func TestVerifyTagPathSaysWhyItIsNotPinned(t *testing.T) {
 		t.Errorf("nothing said why the digest was not pinned: %q", said)
 	}
 }
+
+// Every refusal names a way past it. A client that surfaces the error and
+// drops the warnings -- which is the ordinary client shape, and what brigd
+// does -- otherwise leaves the user with an abort and nothing to act on. The
+// unreachable-registry case said only to try again with the registry
+// reachable, which is not something a user in a sinkhole or behind a captive
+// portal can do.
+func TestEveryVerifyRefusalNamesAWayForward(t *testing.T) {
+	for _, tc := range []struct {
+		what string
+		pins bool
+	}{
+		// The digest path. A cosign that exits non-zero fails the resolve
+		// before it ever reaches the signature, which is Unresolved: could not
+		// check, rather than failed. That is the case that named nothing.
+		{"the registry could not be reached", true},
+		// And the tag path, so the case that always named its override keeps
+		// doing so.
+		{"the tag could not be verified", false},
+	} {
+		c := verifyConfig(t, "ghcr.io/brig-sh/claude-code:arm64", verify.Warn)
+		c.Runtime = verifyRuntime{pins: tc.pins}
+		c.VerifyPolicy.Cosign = "false"
+		err := c.verifyImage()
+		if err == nil {
+			t.Fatalf("%s: booted rather than refusing", tc.what)
+		}
+		if !strings.Contains(err.Error(), "BRIG_VERIFY=off") {
+			t.Errorf("%s: the refusal names no way forward: %v", tc.what, err)
+		}
+	}
+}

--- a/internal/wrap/workspace.go
+++ b/internal/wrap/workspace.go
@@ -24,6 +24,20 @@ func (c *Config) sayf(format string, a ...any) {
 	fmt.Fprintf(c.Out, "brig: "+format+"\n", a...)
 }
 
+// progressf narrates what the run is doing. See Config.Progress for why this
+// is not warnf.
+//
+// A nil Progress is silence rather than a panic, unlike Out and Err: losing a
+// line of narration costs the reader nothing, and every test that builds a
+// Config by hand would otherwise have to declare where its progress goes to
+// ask a question about something else.
+func (c *Config) progressf(format string, a ...any) {
+	if c.Progress == nil {
+		return
+	}
+	fmt.Fprintf(c.Progress, "brig: "+format+"\n", a...)
+}
+
 // Marker identifies this workspace by path and inode.
 //
 // A share is bound at boot and cannot be changed on a live VM, so a


### PR DESCRIPTION
## Summary

Four defects in `brigd`, fixed as four commits so each can be read and
bisected on its own, plus a fifth that keeps the new tests under the unix socket
path limit on macOS.

`brigd` is small and optional, and nothing in the tree calls it yet, so none of
these was reachable from `brig` itself. They are still wrong: the daemon's one
stated job is to be the single owner of boot and teardown, and the first defect
means two daemons can hold that job at once.

## Related issues

Closes #46
Closes #37
Closes #38
Closes #39
Refs #80

## Changes

- **#46, socket theft.** `serve` takes an exclusive `flock` on
  `<socket>.lock` before it removes the socket and binds. A second daemon on the
  same path exits non-zero naming the process that holds it. The comment that
  asserted a lock the kernel never provided is corrected.
- **#37, over-length requests.** The scanner buffer is raised to a documented
  maximum, its error is checked, and a request past the limit gets a structured
  `{"ok":false,...}` answer and a log line instead of a closed connection.
- **#38, prompting on the daemon's terminal.** `Config` gains `NoTerminal`,
  which brigd sets, so the verify path's existing fail-closed branch is taken
  and the refusal travels back to the client as an error. Per-request warnings
  go to the client as `warnings`, one line each, rather than to whatever
  terminal brigd was started from. A connection idle for five minutes is
  closed.
- **#39, runtime per request.** The daemon resolves the runtime from the
  profile on each request with `runtime.DetectFor(Preference{Bin:
  t.RuntimeBin})`, exactly as the CLI does, instead of once at startup with no
  profile in hand.
- **Tests.** The socket paths in `cmd/brigd/daemon_test.go` go through one short
  temporary directory. `t.TempDir` puts the test name in the path, which on
  macOS pushes the socket past 104 bytes and makes `bind` fail with
  `invalid argument`; on Linux `/tmp` is short and the limit is 108, so CI
  passed while the same tests failed here. The daemon-side check that should
  name that limit is #80.

## Checklist

- [x] `make all` passes (vet, test, build)
- [x] `script/smoke.sh` passes
- [x] I have added or updated tests covering the change
- [x] I have run `go test ./... -race`, if the change touches concurrency, subprocesses or the daemon
- [ ] ~~I have exercised the change against a real runtime (`brig run <agent>`), if it touches the run, exec or credential path~~
- [x] I have updated the affected docs (README, `docs/security.md`, `docs/profiles.md`, `docs/brigd.md`)

Each of the four fix commits was built and tested standalone in a scratch
worktree, so bisect stays usable.

## Credentials and the sandbox boundary

The `NoTerminal` seam is the one that touches a promise: it makes sure the
"failed signature, no terminal, refuse" branch is what a daemon takes, rather
than a prompt on a terminal the requesting client cannot see. Covered by
`TestVerifyDoesNotAskWhenTheCallerHasNoTerminal`, which puts a real terminal
with an answer already on it under stdin and asserts neither is looked at.
