### PR TITLE
feat(telemetry): disclose telemetry and gate the boot on consent

### DIFF
--- a/README.md
+++ b/README.md
@@ -425,7 +425,7 @@ rather than letting a default stand in for consent.
 An event carries the product name and version, the OS version and CPU
 architecture, an install identifier generated on your machine (delete
 `~/.hull/telemetry.json` to rotate it), a timestamp and a checksum. On top of
-that envelope: which brig subcommand ran and whether it succeeded, with
+that envelope: which runtime operation ran and whether it succeeded, with
 failures bucketed into coarse classes such as `network` or `permission` and
 never the error text; which hypervisor backend booted and whether the boot
 worked; how long a sandbox lived; sampled memory and CPU of the VM process

--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ separate Linux re-implementation of it.
 | `brig profile ls\|export\|import\|edit\|rm` | manage profiles (`brig export` is the short form of `brig profile export`). `export --json` for JSON instead of YAML |
 | `brig secret create\|read\|update\|delete\|ls` | keep secrets in your keyring. macOS only for now |
 | `brig secret import <profile>` | fill that profile's secrets from your host, once. macOS only for now |
+| `brig telemetry status\|on\|off` | report what is counted, or turn the counting on or off. See [Telemetry](#telemetry) |
 | `brig version` | |
 
 `brig template …` and `brig agents` are the older spellings and still work
@@ -398,6 +399,62 @@ brig run claude --image ghcr.io/brig-sh/claude-code:arm64-98f4739
 `cursor` is built by community-images but deliberately not published, pending
 a terms check. `brig run cursor` says so rather than failing on a registry
 404; build the image yourself and pass `--image`.
+
+## Telemetry
+
+brig counts usage, and this section says so plainly because nothing else about
+the tool would lead you to expect it. There is no account and no server of
+brig's own, but the runtime brig drives on macOS reports a handful of events to
+a collector run by NOFire AI, tagged with brig's name because brig is the
+product you installed. On Linux, where the backend is `nerdctl`, nothing is
+sent at all.
+
+Turning it off is one line, and it is durable rather than per-shell:
+
+```bash
+brig telemetry off      # or: DO_NOT_TRACK=1 in your environment
+brig telemetry status   # what the current answer is, and what decided it
+```
+
+It is on by default once you answer yes, and the question is asked on the
+first command that hands your terminal to an agent. Until it has been
+answered, brig sends nothing: a sandbox boot happens with no terminal
+attached, so nobody could have been asked, and brig suppresses counting for it
+rather than letting a default stand in for consent.
+
+An event carries the product name and version, the OS version and CPU
+architecture, an install identifier generated on your machine (delete
+`~/.hull/telemetry.json` to rotate it), a timestamp and a checksum. On top of
+that envelope: which brig subcommand ran and whether it succeeded, with
+failures bucketed into coarse classes such as `network` or `permission` and
+never the error text; which hypervisor backend booted and whether the boot
+worked; how long a sandbox lived; sampled memory and CPU of the VM process
+while a command is attached; and, if brig or the runtime panics, the panic
+type with a stack trace whose paths are trimmed. Crash reports queue in
+`~/.hull/crashes/`, where you can read or delete them before they go anywhere.
+
+What is never collected, as a commitment rather than a description of the
+current build:
+
+- workspace paths, or any host path
+- repository names, branches or remotes
+- command arguments, including the agent's own
+- agent prompts, or anything the agent read or wrote
+- secret names, secret values, or which credentials were forwarded
+- image names and registry references
+- network destinations the guest reached
+- file metadata: names, sizes, timestamps, counts
+
+Your IP address is not stored: it is discarded at ingestion. Raw events are
+kept for a year. If a future version widens what it collects, the question is
+asked again with the new list, and nothing from the wider set is sent until
+you answer it.
+
+The full field-by-field description is
+[hull's telemetry documentation](https://github.com/brig-sh/hull/blob/main/docs/telemetry.md),
+since hull is what does the sending. `HULL_TELEMETRY_DISABLED=1` and
+`DO_NOT_TRACK=1` both reach it untouched and both win over anything recorded on
+disk.
 
 ## Documentation
 

--- a/cmd/brig/main.go
+++ b/cmd/brig/main.go
@@ -55,6 +55,8 @@ usage:
   brig secret create|read|update|delete|ls       keep secrets in your keyring
   brig secret import <profile>                   fill a profile's secrets from
                                                  your host, once
+  brig telemetry status|on|off                   report what is counted, or
+                                                 turn the counting on or off
   brig version
 
 flags (before the agent's own arguments; -- ends brig's parsing):
@@ -155,6 +157,8 @@ func run(args []string) error {
 		return profileCmd(rest)
 	case "secret":
 		return secretCmd(os.Stdout, rest)
+	case "telemetry":
+		return telemetryCmd(os.Stdout, rest)
 	case "import":
 		return importProfile(rest)
 	case "export":

--- a/cmd/brig/telemetry.go
+++ b/cmd/brig/telemetry.go
@@ -1,0 +1,113 @@
+package main
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/brig-sh/brig/internal/runtime"
+)
+
+// detectRuntime is the seam the CLI tests replace. Everything else goes
+// through runtime.Detect, which picks the backend for this host.
+var detectRuntime = runtime.Detect
+
+// telemetryUsage is what `brig telemetry --help` prints.
+const telemetryUsage = `brig telemetry -- what is counted, and how to stop it
+
+usage:
+  brig telemetry status   report whether usage data is being sent
+  brig telemetry on       start sending it
+  brig telemetry off      stop sending it, on this machine, for good
+
+brig has no collector and no account. The counting is done by the sandbox
+runtime underneath, and these verbs set the answer it keeps, so an opt-out
+holds whether brig is the caller or not. DO_NOT_TRACK=1 in your environment
+turns it off without recording anything, and beats both.
+
+The telemetry section of the README lists every field an event carries, who
+receives it, and what is never collected.
+`
+
+// telemetryCmd reports and sets the telemetry answer.
+//
+// The whole point of the command is that you do not have to know what brig
+// drives underneath to opt out, so neither the report nor the help names the
+// runtime: a user who reads "local-first, no account" and then wants the
+// network call to stop should find the switch under brig's own name. The state
+// is the runtime's, though, not a second store of brig's -- see SetTelemetry.
+func telemetryCmd(out io.Writer, args []string) error {
+	verb := "status"
+	if len(args) > 0 {
+		verb = args[0]
+	}
+	if len(args) > 1 {
+		return fmt.Errorf("telemetry takes one word: status, on or off")
+	}
+	switch verb {
+	case "--help", "-h", "help":
+		_, err := io.WriteString(out, telemetryUsage)
+		return err
+	case "status", "on", "off":
+	default:
+		return fmt.Errorf("unknown telemetry subcommand %q (status, on or off)", verb)
+	}
+
+	rt, err := detectRuntime()
+	if err != nil {
+		return err
+	}
+	reporter, ok := rt.(runtime.TelemetryReporter)
+	if !ok {
+		// A backend that collects nothing has nothing to report and nothing to
+		// turn off, and saying so is more use than an error: the question the
+		// user asked -- is anything being sent -- has an answer here, and it is
+		// no.
+		_, err := io.WriteString(out, "telemetry: off\n"+
+			"The sandbox runtime on this host sends nothing, so there is nothing\n"+
+			"to turn off.\n")
+		return err
+	}
+	if verb != "status" {
+		if err := reporter.SetTelemetry(verb == "on"); err != nil {
+			return err
+		}
+	}
+	// Report the state after setting it rather than echoing what was asked
+	// for. They differ whenever DO_NOT_TRACK is set: the answer is recorded,
+	// and the variable still wins, which is exactly the case a confident
+	// "telemetry: on" would misreport.
+	state, err := reporter.TelemetryStatus()
+	if err != nil {
+		return err
+	}
+	_, err = io.WriteString(out, telemetryReport(state))
+	return err
+}
+
+// telemetryReport is the state in brig's words, with the sentence that tells
+// the reader what to do about it.
+func telemetryReport(state runtime.Telemetry) string {
+	switch state.State {
+	case runtime.TelemetryOn:
+		return "telemetry: on\n" +
+			"A sandbox boot and the command that takes your terminal each count\n" +
+			"once. `brig telemetry off` stops it.\n"
+	case runtime.TelemetryOff:
+		if state.Setting != "" {
+			return "telemetry: off\n" +
+				state.Setting + " in this environment turns it off, and beats any\n" +
+				"answer recorded on this machine.\n"
+		}
+		return "telemetry: off\n" +
+			"The answer is recorded on this machine. `brig telemetry on` reverses it.\n"
+	case runtime.TelemetryUnanswered:
+		return "telemetry: not answered yet\n" +
+			"Nothing goes out for a sandbox boot until you answer, and the first\n" +
+			"command that hands your terminal to an agent asks the question.\n" +
+			"`brig telemetry on` or `brig telemetry off` answers it now.\n"
+	default:
+		return "telemetry: cannot tell\n" +
+			"The sandbox runtime did not report a state this version of brig\n" +
+			"recognises. Boots are not counted while that is true.\n"
+	}
+}

--- a/cmd/brig/telemetry_test.go
+++ b/cmd/brig/telemetry_test.go
@@ -1,0 +1,148 @@
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/brig-sh/brig/internal/runtime"
+)
+
+// fakeRuntime is a runtime that reports telemetry and nothing else. The
+// embedded interface supplies the sandbox methods, which this command never
+// calls: a nil method that panics if it is ever reached is a better test than
+// a dozen stubs that quietly do nothing.
+type fakeRuntime struct {
+	runtime.Runtime
+	state runtime.Telemetry
+	set   []bool
+	// sticky is a state a recorded answer does not move, which is what a
+	// variable in the environment is.
+	sticky bool
+}
+
+func (f *fakeRuntime) TelemetryStatus() (runtime.Telemetry, error) { return f.state, nil }
+
+func (f *fakeRuntime) SetTelemetry(on bool) error {
+	f.set = append(f.set, on)
+	if f.sticky {
+		return nil
+	}
+	f.state = runtime.Telemetry{State: runtime.TelemetryOff}
+	if on {
+		f.state = runtime.Telemetry{State: runtime.TelemetryOn}
+	}
+	return nil
+}
+
+// quiet is a runtime that collects nothing, which is what nerdctl is.
+type quietRuntime struct{ runtime.Runtime }
+
+func withRuntime(t *testing.T, rt runtime.Runtime) {
+	t.Helper()
+	prev := detectRuntime
+	detectRuntime = func() (runtime.Runtime, error) { return rt, nil }
+	t.Cleanup(func() { detectRuntime = prev })
+}
+
+func telemetryOutput(t *testing.T, rt runtime.Runtime, args ...string) string {
+	t.Helper()
+	withRuntime(t, rt)
+	var out bytes.Buffer
+	if err := telemetryCmd(&out, args); err != nil {
+		t.Fatalf("telemetry %v: %v", args, err)
+	}
+	return out.String()
+}
+
+// The command exists so that opting out does not require knowing what brig
+// drives underneath. A report that named it would defeat that: the user would
+// still be looking up another tool's documentation to understand their own
+// answer.
+func TestTelemetryStatusDoesNotNameTheRuntime(t *testing.T) {
+	for _, state := range []runtime.Telemetry{
+		{State: runtime.TelemetryOn},
+		{State: runtime.TelemetryOff},
+		{State: runtime.TelemetryOff, Setting: "DO_NOT_TRACK=1"},
+		{State: runtime.TelemetryUnanswered},
+		{State: runtime.TelemetryUnknown},
+	} {
+		got := telemetryOutput(t, &fakeRuntime{state: state}, "status")
+		if !strings.HasPrefix(got, "telemetry: ") {
+			t.Errorf("%q does not start with the state", got)
+		}
+		if strings.Contains(strings.ToLower(got), "hull") {
+			t.Errorf("the report names the runtime: %q", got)
+		}
+	}
+	if strings.Contains(strings.ToLower(telemetryUsage), "hull") {
+		t.Errorf("the help names the runtime:\n%s", telemetryUsage)
+	}
+}
+
+// status is the default verb, because `brig telemetry` on its own is a
+// question, not a change.
+func TestTelemetryDefaultsToStatus(t *testing.T) {
+	rt := &fakeRuntime{state: runtime.Telemetry{State: runtime.TelemetryUnanswered}}
+
+	got := telemetryOutput(t, rt)
+
+	if len(rt.set) != 0 {
+		t.Errorf("a bare `brig telemetry` changed the answer: %v", rt.set)
+	}
+	if !strings.Contains(got, "not answered yet") {
+		t.Errorf("state not reported: %q", got)
+	}
+}
+
+func TestTelemetryOnAndOffRecordTheAnswer(t *testing.T) {
+	rt := &fakeRuntime{state: runtime.Telemetry{State: runtime.TelemetryUnanswered}}
+
+	if got := telemetryOutput(t, rt, "off"); !strings.Contains(got, "telemetry: off") {
+		t.Errorf("off did not report off: %q", got)
+	}
+	if got := telemetryOutput(t, rt, "on"); !strings.Contains(got, "telemetry: on") {
+		t.Errorf("on did not report on: %q", got)
+	}
+	if len(rt.set) != 2 || rt.set[0] || !rt.set[1] {
+		t.Errorf("answers recorded = %v, want [false true]", rt.set)
+	}
+}
+
+// The report is the effective state, not an echo of the verb. Recording a yes
+// while DO_NOT_TRACK is set leaves telemetry off, and saying "on" there would
+// be a plain lie about what the machine will do.
+func TestTelemetryOnReportsTheVariableThatStillWins(t *testing.T) {
+	rt := &fakeRuntime{
+		state:  runtime.Telemetry{State: runtime.TelemetryOff, Setting: "DO_NOT_TRACK=1"},
+		sticky: true,
+	}
+
+	got := telemetryOutput(t, rt, "on")
+
+	if !strings.Contains(got, "telemetry: off") {
+		t.Errorf("a recorded yes was reported as on while DO_NOT_TRACK was set: %q", got)
+	}
+	if !strings.Contains(got, "DO_NOT_TRACK=1") {
+		t.Errorf("the variable that decided the state was not named: %q", got)
+	}
+}
+
+// A backend that sends nothing answers the question the user actually asked
+// rather than failing, because "is anything being sent" has an answer on Linux
+// too, and it is no.
+func TestTelemetryOnARuntimeThatCollectsNothing(t *testing.T) {
+	got := telemetryOutput(t, quietRuntime{}, "status")
+
+	if !strings.Contains(got, "telemetry: off") {
+		t.Errorf("a runtime that collects nothing reported %q", got)
+	}
+}
+
+func TestTelemetryRejectsAnUnknownVerb(t *testing.T) {
+	withRuntime(t, &fakeRuntime{})
+	var out bytes.Buffer
+	if err := telemetryCmd(&out, []string{"enable"}); err == nil {
+		t.Fatal("an unknown verb was accepted")
+	}
+}

--- a/docs/security.md
+++ b/docs/security.md
@@ -481,6 +481,74 @@ xattr -l "$(which brig)"                 # com.apple.quarantine, still there
 A from-source build is neither signed nor notarized, so it is yours to trust
 by having built it.
 
+## Telemetry
+
+brig is local-first and asks you to create no account, and a reader who takes
+that at face value will not expect a network call to a collector. There is
+one, on macOS, so here is what it is.
+
+The runtime brig drives reports usage events over OTLP to an OpenTelemetry
+collector run by NOFire AI, with no third-party analytics service in the path.
+brig tags those events with its own name, because brig is what you installed
+and hull is an implementation detail of it. On Linux the backend is `nerdctl`,
+which has no telemetry of any kind, and nothing is sent.
+
+The switch is `brig telemetry off`, which records the answer where the runtime
+keeps it, so it holds for every later invocation whether brig is the caller or
+not. `DO_NOT_TRACK=1` or `HULL_TELEMETRY_DISABLED=1` in the environment does
+the same for one shell without writing anything down, and beats a recorded
+yes. `brig telemetry status` reports which of those is currently deciding.
+
+**Nothing is sent before you have answered.** The runtime defaults telemetry
+on when it cannot put the question to anyone, and brig's boot invocation gives
+it no terminal, so left alone a fresh install would report its first boot
+before anyone had been asked. brig suppresses counting for every operation
+that runs without a terminal until an answer is on file: the boot, the stop,
+the plumbing. The one invocation that does inherit your terminal -- the exec
+that hands the sandbox to the agent -- is left able to ask, which is where the
+question appears. A default is not consent, but neither is a prompt nobody can
+ever see.
+
+An event carries a fixed envelope -- schema version, event type, product name
+and version, OS version, CPU architecture, an install identifier generated
+locally, a timestamp, a checksum -- plus, depending on the event: the brig
+subcommand and whether it succeeded, with failures reduced to coarse classes
+and never the error text; the hypervisor backend and whether the boot worked;
+how long a sandbox lived; sampled RSS and CPU of the VM process while a
+command is attached; and a panic type with a path-trimmed stack trace when
+something crashes. The install identifier is a random value in
+`~/.hull/telemetry.json`; deleting the file rotates it. Crash reports queue in
+`~/.hull/crashes/` and can be read or deleted before they are uploaded. IP
+addresses are dropped at ingestion, raw events are kept for a year, and
+widening what is collected re-asks the question rather than proceeding on the
+old answer. Field by field, that is
+[hull's telemetry documentation](https://github.com/brig-sh/hull/blob/main/docs/telemetry.md).
+
+These are never collected, and this is a commitment about what brig will send
+rather than a note about what it happens to send today:
+
+- workspace paths, and host paths generally
+- repository names, branches or remotes
+- command arguments, brig's own and the agent's
+- agent prompts, and anything the agent read or wrote
+- secret names, secret values, and which credentials a run forwarded
+- image names and registry references
+- network destinations the guest reached
+- file metadata: names, sizes, timestamps, counts
+
+The list is the one that matters for this page, because each entry is
+something the sandbox boundary above exists to keep private. A workspace path
+names the project; an image reference names what you are building; a forwarded
+credential name says which vendor you have an account with. Telemetry that
+carried any of them would leak across the boundary the rest of this document
+describes, out of a channel the user did not think was there. If you find one
+of them in a payload, that is a bug and
+[SECURITY.md](../SECURITY.md) is how to report it.
+
+`HULL_TELEMETRY_DEBUG=1` prints payloads to stderr instead of sending them,
+which is how to check any of this for yourself rather than taking our word for
+it.
+
 ## Things brig does not claim
 
 It does not sandbox the agent from the network. Outbound traffic from the

--- a/docs/security.md
+++ b/docs/security.md
@@ -503,11 +503,11 @@ yes. `brig telemetry status` reports which of those is currently deciding.
 on when it cannot put the question to anyone, and brig's boot invocation gives
 it no terminal, so left alone a fresh install would report its first boot
 before anyone had been asked. brig suppresses counting for every operation
-that runs without a terminal until an answer is on file: the boot, the stop,
-the plumbing. The one invocation that does inherit your terminal -- the exec
-that hands the sandbox to the agent -- is left able to ask, which is where the
-question appears. A default is not consent, but neither is a prompt nobody can
-ever see.
+that runs without a terminal: the boot and the stop until an answer is on
+file, and the plumbing always. The one invocation that does inherit your
+terminal -- the exec that hands the sandbox to the agent -- is left able to
+ask, which is where the question appears. A default is not consent, but
+neither is a prompt nobody can ever see.
 
 An event carries a fixed envelope -- schema version, event type, product name
 and version, OS version, CPU architecture, an install identifier generated

--- a/internal/runtime/hull.go
+++ b/internal/runtime/hull.go
@@ -21,6 +21,13 @@ type hull struct {
 	// while brig is running.
 	pinsOnce sync.Once
 	pins     bool
+	// consent caches whether hull has an answer on file about telemetry, which
+	// decides whether an operation the user asked for may be counted. See
+	// consentRecorded.
+	consent struct {
+		once sync.Once
+		on   bool
+	}
 }
 
 func newHull(bin string) (Runtime, error) {
@@ -272,7 +279,9 @@ func (h *hull) Run(spec RunSpec) error {
 	}
 
 	cmd := exec.Command(h.bin, args...)
-	cmd.Env = mergeEnv(telemetryEnv(spec.Counted), envVals)
+	// The boot gets no terminal, so hull cannot ask anyone anything here: it
+	// is counted only once an answer is already on file. See telemetryEnvFor.
+	cmd.Env = mergeEnv(h.telemetryEnvFor(spec.Counted, false), envVals)
 	cmd.Stdout = nil // the instance id is not interesting; failures explain themselves
 	cmd.Stderr = os.Stderr
 	return cmd.Run()
@@ -419,7 +428,7 @@ func (h *hull) Output(spec ExecSpec) (string, error) {
 	// as "cannot say" rather than waiting on it.
 	cmd, cancel, envVals := h.agentCall(spec)
 	defer cancel()
-	cmd.Env = mergeEnv(telemetryEnv(spec.Counted), envVals)
+	cmd.Env = mergeEnv(h.telemetryEnvFor(spec.Counted, false), envVals)
 	var out bytes.Buffer
 	cmd.Stdout = &out
 	if err := cmd.Run(); err != nil {
@@ -436,7 +445,7 @@ func (h *hull) Output(spec ExecSpec) (string, error) {
 func (h *hull) Feed(spec ExecSpec) error {
 	cmd, cancel, envVals := h.agentCall(spec)
 	defer cancel()
-	cmd.Env = mergeEnv(telemetryEnv(spec.Counted), envVals)
+	cmd.Env = mergeEnv(h.telemetryEnvFor(spec.Counted, false), envVals)
 	cmd.Stdin = spec.Stdin
 	var errb bytes.Buffer
 	cmd.Stderr = &errb
@@ -455,7 +464,12 @@ func (h *hull) Feed(spec ExecSpec) error {
 func (h *hull) Replace(spec ExecSpec) error {
 	args, envVals := h.execArgs(spec)
 	argv := append([]string{h.bin}, args...)
-	return syscall.Exec(h.bin, argv, mergeEnv(telemetryEnv(spec.Counted), envVals))
+	// This is the one invocation that inherits the user's terminal, and TTY is
+	// set from whether brig's own stdin is one. When it is, hull can put its
+	// consent question to a person before it sends anything, so brig leaves it
+	// unsuppressed and lets that happen; when it is not, the same rule as the
+	// boot applies. See telemetryEnvFor.
+	return syscall.Exec(h.bin, argv, mergeEnv(h.telemetryEnvFor(spec.Counted, spec.TTY), envVals))
 }
 
 func (h *hull) Stop(name string) error { return h.quiet("stop", name, true) }
@@ -480,7 +494,9 @@ func (h *hull) Remove(name string) error {
 // failed `brig stop` will look.
 func (h *hull) quiet(verb, name string, counted bool) error {
 	cmd := exec.Command(h.bin, verb, name)
-	cmd.Env = mergeEnv(telemetryEnv(counted))
+	// Counted like the boot, and gated like it for the same reason: this runs
+	// with no terminal, so nothing can be asked here either.
+	cmd.Env = mergeEnv(h.telemetryEnvFor(counted, false))
 	var out bytes.Buffer
 	cmd.Stdout, cmd.Stderr = &out, &out
 	if err := cmd.Run(); err != nil {

--- a/internal/runtime/hull.go
+++ b/internal/runtime/hull.go
@@ -462,14 +462,28 @@ func (h *hull) Feed(spec ExecSpec) error {
 // TUI gets the real terminal, ^C reaches it rather than brig, and its exit
 // status is brig's exit status without any relaying.
 func (h *hull) Replace(spec ExecSpec) error {
+	argv, env := h.replaceCmd(spec)
+	return syscall.Exec(h.bin, argv, env)
+}
+
+// replaceCmd builds the handover argv and environment in one place, so a test
+// can assert both what a shell handover runs (`-t` for the guest pty) and
+// whether the boot gate lets it be counted, neither of which survives the
+// syscall.Exec in Replace itself.
+//
+// canAsk is spec.CanAsk, not spec.TTY. This is the one invocation that inherits
+// the user's terminal, but only a real terminal on brig's own stdin means there
+// is anyone to answer hull's consent question. A login shell wants a pty even
+// when brig is driven from a script, so TTY is true there while CanAsk is not;
+// reading TTY for both left a scripted `brig shell` looking askable and let
+// hull's on-by-default send the first-boot event. When CanAsk is false and no
+// answer is on file the boot rule applies and the exec is suppressed. See
+// telemetryEnvFor.
+func (h *hull) replaceCmd(spec ExecSpec) (argv, env []string) {
 	args, envVals := h.execArgs(spec)
-	argv := append([]string{h.bin}, args...)
-	// This is the one invocation that inherits the user's terminal, and TTY is
-	// set from whether brig's own stdin is one. When it is, hull can put its
-	// consent question to a person before it sends anything, so brig leaves it
-	// unsuppressed and lets that happen; when it is not, the same rule as the
-	// boot applies. See telemetryEnvFor.
-	return syscall.Exec(h.bin, argv, mergeEnv(h.telemetryEnvFor(spec.Counted, spec.TTY), envVals))
+	argv = append([]string{h.bin}, args...)
+	env = mergeEnv(h.telemetryEnvFor(spec.Counted, spec.CanAsk), envVals)
+	return argv, env
 }
 
 func (h *hull) Stop(name string) error { return h.quiet("stop", name, true) }

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -109,6 +109,14 @@ type ExecSpec struct {
 	TTY     bool
 	Env     []Var
 	Counted bool
+	// CanAsk reports whether brig's own stdin is a terminal, so hull can put
+	// its consent question to a person before anything is sent. Kept apart from
+	// TTY on purpose: TTY gives the guest a pseudo-terminal, which a login shell
+	// wants even when brig is driven from a script, whereas the question can
+	// only be answered on a real terminal. Reading TTY for both jobs counted a
+	// scripted `brig shell` as askable and let hull's on-by-default send the
+	// first-boot event. Only Replace reads it; see telemetryEnvFor.
+	CanAsk bool
 	// Stdin, when set, is fed to the command inside the guest. It is how a
 	// credential reaches the guest without appearing in argv: hull durably
 	// logs every exec's argv to a host file, so a value there outlives the

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -289,6 +289,12 @@ func withDigest(image, digest string) string {
 // plumbing -- reachability probes, ps lookups, cleanup -- so one brig command
 // counts once. Only the operations a user asked for are counted. DO_NOT_TRACK
 // and the runtime's own opt-out pass through untouched and always win.
+//
+// Being an operation the user asked for is necessary but not sufficient: an
+// operation that runs with no terminal is also not counted until an answer
+// about telemetry is on file, because a question nobody can be asked is not a
+// question anyone has answered. That second rule is telemetryEnvFor, in
+// telemetry.go, and every counted hull call goes through it.
 func telemetryEnv(counted bool) []string {
 	suppress := "1"
 	if counted {

--- a/internal/runtime/telemetry.go
+++ b/internal/runtime/telemetry.go
@@ -1,0 +1,196 @@
+package runtime
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+// TelemetryState is a runtime's telemetry setting, in brig's own words.
+//
+// The words are brig's rather than the runtime's on purpose. hull phrases its
+// state for someone who installed hull, and a brig user has not necessarily
+// heard of it: the point of `brig telemetry` is that opting out does not
+// require knowing which binary underneath does the sending. The mapping from
+// what a runtime says to one of these lives in this file, so the CLI above
+// never parses another tool's sentences.
+type TelemetryState string
+
+const (
+	// TelemetryOn means someone answered yes and events go out.
+	TelemetryOn TelemetryState = "on"
+	// TelemetryOff means events do not go out, whether that is a recorded no
+	// or a variable in this shell.
+	TelemetryOff TelemetryState = "off"
+	// TelemetryUnanswered means no answer has been recorded that covers what
+	// would be collected today. Nothing has been agreed to, so brig treats a
+	// boot as not countable; see telemetryEnvFor.
+	TelemetryUnanswered TelemetryState = "unanswered"
+	// TelemetryUnknown means the runtime did not say. An older build with no
+	// telemetry command at all lands here, and so does a build that answered
+	// something this version has never seen.
+	TelemetryUnknown TelemetryState = "unknown"
+)
+
+// Telemetry is what a runtime reports about its own collection.
+type Telemetry struct {
+	State TelemetryState
+	// Setting names the environment variable that decided the state, as
+	// NAME=VALUE, when a variable in this shell decided it rather than a
+	// recorded answer. Empty otherwise. Worth carrying because "off" with no
+	// explanation is the state people then cannot turn back on: the answer is
+	// in their shell, not on their disk, and only naming the variable says so.
+	Setting string
+}
+
+// TelemetryReporter is a runtime whose collection brig can report and change.
+//
+// Optional on purpose: it is not part of Runtime because it is not part of
+// running a sandbox, and a backend that collects nothing should not have to
+// grow two stub methods to say so. The CLI type-asserts for it and treats a
+// runtime that does not implement it as one that sends nothing, which is what
+// nerdctl is.
+type TelemetryReporter interface {
+	// TelemetryStatus reports the effective state, including a variable in
+	// the environment that overrides whatever is on disk.
+	TelemetryStatus() (Telemetry, error)
+	// SetTelemetry records an answer durably, for every later invocation.
+	SetTelemetry(on bool) error
+}
+
+// telemetryCallTimeout bounds the extra invocation a boot pays to find out
+// whether it may be counted.
+//
+// It reads a small file in the runtime's own store, so it is fast or it is
+// broken. Bounding it keeps a wedged runtime binary from turning a question
+// about telemetry into a `brig run` that never boots: the answer this call
+// exists to fetch decides one environment variable, and having no answer is
+// already handled -- it suppresses.
+const telemetryCallTimeout = 3 * time.Second
+
+// TelemetryStatus asks hull what its effective state is.
+func (h *hull) TelemetryStatus() (Telemetry, error) {
+	out, err := h.telemetryCmd("status")
+	if err != nil {
+		return Telemetry{State: TelemetryUnknown}, err
+	}
+	return parseTelemetry(out), nil
+}
+
+// SetTelemetry records the answer where hull keeps it.
+//
+// Deliberately not a store of brig's own. Two files answering the same
+// question drift, and the one that would lose is brig's: hull is what actually
+// decides whether to send, so an answer it cannot see is not an answer at all.
+// This is also why `brig telemetry off` is durable rather than a variable brig
+// sets per invocation -- an opt-out that only holds while brig is the caller
+// is not the opt-out anyone means.
+func (h *hull) SetTelemetry(on bool) error {
+	verb := "off"
+	if on {
+		verb = "on"
+	}
+	_, err := h.telemetryCmd(verb)
+	return err
+}
+
+// telemetryCmd runs one hull telemetry verb and returns its stdout.
+//
+// Suppressed like every other question brig asks on its own account: asking
+// what the setting is, or changing it, must not itself become an event.
+func (h *hull) telemetryCmd(verb string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), telemetryCallTimeout)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, h.bin, "telemetry", verb)
+	cmd.WaitDelay = time.Second
+	cmd.Env = mergeEnv(telemetryEnv(false))
+	var out, errb bytes.Buffer
+	cmd.Stdout, cmd.Stderr = &out, &errb
+	if err := cmd.Run(); err != nil {
+		if said := strings.TrimSpace(errb.String()); said != "" {
+			return "", fmt.Errorf("%s telemetry %s: %w: %s", h.bin, verb, err, firstLines(said, 2))
+		}
+		return "", fmt.Errorf("%s telemetry %s: %w", h.bin, verb, err)
+	}
+	return out.String(), nil
+}
+
+// parseTelemetry turns hull's one line into a state brig can report.
+//
+// hull prints "telemetry: <state>", where the state is one of a handful of
+// phrases documented in its docs/telemetry.md. Anything else is read as
+// unknown rather than guessed at: a phrase this version has not seen is a
+// version that collects something this version cannot describe, and reporting
+// that as "on" would put brig's name on a claim it cannot support.
+func parseTelemetry(out string) Telemetry {
+	state := strings.TrimSpace(out)
+	state = strings.TrimSpace(strings.TrimPrefix(state, "telemetry:"))
+	switch {
+	case state == "enabled":
+		return Telemetry{State: TelemetryOn}
+	case state == "disabled":
+		return Telemetry{State: TelemetryOff}
+	case strings.HasPrefix(state, "disabled ("):
+		return Telemetry{State: TelemetryOff, Setting: insideParens(state)}
+	case strings.HasPrefix(state, "not configured"):
+		return Telemetry{State: TelemetryUnanswered}
+	case strings.HasPrefix(state, "enabled "):
+		// "enabled for an older schema": there is an answer on disk, but it
+		// covers a smaller list of fields than this build would send, so hull
+		// will ask again. An answer to a question that has since changed is
+		// not an answer to this one, which is exactly the case brig must not
+		// count a boot for.
+		return Telemetry{State: TelemetryUnanswered}
+	default:
+		return Telemetry{State: TelemetryUnknown}
+	}
+}
+
+// insideParens lifts the "DO_NOT_TRACK=1" out of "disabled (DO_NOT_TRACK=1)".
+func insideParens(s string) string {
+	open := strings.Index(s, "(")
+	closing := strings.LastIndex(s, ")")
+	if open < 0 || closing < open {
+		return ""
+	}
+	return strings.TrimSpace(s[open+1 : closing])
+}
+
+// consentRecorded reports whether an answer covering today's collection is on
+// file, and caches it for the rest of the process.
+//
+// One brig command boots at most one sandbox, so the cache saves a second
+// invocation rather than many; it is here because the answer cannot change
+// underneath a single command in any way brig would want to act on. A runtime
+// that will not answer counts as no answer, which suppresses.
+func (h *hull) consentRecorded() bool {
+	h.consent.once.Do(func() {
+		st, err := h.TelemetryStatus()
+		h.consent.on = err == nil && st.State == TelemetryOn
+	})
+	return h.consent.on
+}
+
+// telemetryEnvFor decides whether an operation the user asked for is actually
+// counted, on top of telemetryEnv's plumbing rule.
+//
+// hull defaults telemetry on when it cannot prompt, and brig's boot invocation
+// gives it no terminal: left alone, a fresh install sends events for its first
+// boot before anyone has been asked anything, and the prompt then appears
+// later on an interactive step wearing brig's name. So brig suppresses the
+// boot until hull reports a recorded answer. The alternative -- brig asking
+// the question itself, on its own terminal, before the first boot -- would put
+// the disclosure in brig's hands, but it also means brig owning a consent
+// prompt whose wording has to track what hull collects, and it cannot run at
+// all for `brig run` from a script.
+//
+// canAsk is for the one invocation that hands hull the terminal. There the
+// question can be put to a human before anything is sent, which is hull's own
+// design, so suppressing would only prevent the prompt from ever appearing --
+// and with it any chance of an answer.
+func (h *hull) telemetryEnvFor(counted, canAsk bool) []string {
+	return telemetryEnv(counted && (canAsk || h.consentRecorded()))
+}

--- a/internal/runtime/telemetry.go
+++ b/internal/runtime/telemetry.go
@@ -135,6 +135,12 @@ func parseTelemetry(out string) Telemetry {
 		return Telemetry{State: TelemetryOff}
 	case strings.HasPrefix(state, "disabled ("):
 		return Telemetry{State: TelemetryOff, Setting: insideParens(state)}
+	case strings.HasPrefix(state, "enabled ("):
+		// The mirror of "disabled (...)": the parens name the setting that
+		// turned it on (a variable, say), and the state is definite. Read it as
+		// on and carry the setting, rather than folding it into the older-schema
+		// case below and reporting a definite answer as unanswered.
+		return Telemetry{State: TelemetryOn, Setting: insideParens(state)}
 	case strings.HasPrefix(state, "not configured"):
 		return Telemetry{State: TelemetryUnanswered}
 	case strings.HasPrefix(state, "enabled "):

--- a/internal/runtime/telemetry_test.go
+++ b/internal/runtime/telemetry_test.go
@@ -145,6 +145,34 @@ func TestTerminalHandoverStaysAskable(t *testing.T) {
 	}
 }
 
+// A shell handover always gives the guest a pty, but only a real terminal on
+// brig's own stdin means hull has someone to answer its consent question. The
+// two are separate signals: TTY drives `hull exec -t`, CanAsk drives the boot
+// gate. A scripted `brig shell -- cmd` sets TTY (a login shell wants a pty)
+// without CanAsk, and on a fresh install that must still suppress -- the exact
+// case the boot gate closes and which reading TTY for both jobs had left open.
+func TestShellHandoverSeparatesPtyFromConsent(t *testing.T) {
+	h, _ := stubTelemetryHull(t, "not configured (on by default; interactive runs will be asked)")
+
+	argv, env := h.replaceCmd(ExecSpec{Name: "vm", Cmd: []string{"bash", "-lc", "ls"}, Counted: true, TTY: true, CanAsk: false})
+	if line := strings.Join(argv, " "); !strings.Contains(line, "exec -t") {
+		t.Errorf("the guest lost its pty when brig's stdin was not a terminal: %s", line)
+	}
+	if got := strings.Join(env, " "); !strings.Contains(got, "HULL_TELEMETRY_SUPPRESS=1") {
+		t.Errorf("a scripted shell on a fresh install was counted: %s", got)
+	}
+
+	// Same handover with a terminal on brig's stdin: hull can put the question
+	// to a person, so the gate leaves it unsuppressed, and the pty is unchanged.
+	argv, env = h.replaceCmd(ExecSpec{Name: "vm", Cmd: []string{"bash", "-l"}, Counted: true, TTY: true, CanAsk: true})
+	if got := strings.Join(env, " "); strings.Contains(got, "HULL_TELEMETRY_SUPPRESS=1") {
+		t.Errorf("an interactive shell could not be asked the consent question: %s", got)
+	}
+	if line := strings.Join(argv, " "); !strings.Contains(line, "exec -t") {
+		t.Errorf("an interactive shell lost its pty: %s", line)
+	}
+}
+
 // Plumbing stays suppressed whatever the answer is: one user command counts
 // once, which is the rule that predates the gate.
 func TestPlumbingStaysSuppressedWithConsent(t *testing.T) {

--- a/internal/runtime/telemetry_test.go
+++ b/internal/runtime/telemetry_test.go
@@ -214,6 +214,7 @@ func TestParseTelemetry(t *testing.T) {
 		{"telemetry: disabled\n", TelemetryOff, ""},
 		{"telemetry: disabled (DO_NOT_TRACK=1)\n", TelemetryOff, "DO_NOT_TRACK=1"},
 		{"telemetry: disabled (HULL_TELEMETRY_DISABLED=1)\n", TelemetryOff, "HULL_TELEMETRY_DISABLED=1"},
+		{"telemetry: enabled (HULL_TELEMETRY_ENABLED=1)\n", TelemetryOn, "HULL_TELEMETRY_ENABLED=1"},
 		{"telemetry: not configured (on by default; interactive runs will be asked)\n", TelemetryUnanswered, ""},
 		{"telemetry: enabled for an older schema (interactive runs will be re-asked)\n", TelemetryUnanswered, ""},
 		{"", TelemetryUnknown, ""},

--- a/internal/runtime/telemetry_test.go
+++ b/internal/runtime/telemetry_test.go
@@ -1,0 +1,214 @@
+package runtime
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// stubTelemetryHull writes a stand-in for the hull binary that answers `telemetry
+// status` with the state a test names, and records the telemetry environment
+// every other invocation was given.
+//
+// Recording the environment is the whole point: what decides whether a fresh
+// install sends anything is one variable in the child's environment, and the
+// only honest way to assert on it is to be the child and write it down.
+func stubTelemetryHull(t *testing.T, state string) (*hull, func() string) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("shell stand-in is not portable to windows")
+	}
+	dir := t.TempDir()
+	log := filepath.Join(dir, "env.log")
+	script := `#!/bin/sh
+if [ "$1" = telemetry ]; then
+  printf 'telemetry-verb=%s\n' "$2" >> "$STUB_LOG"
+  [ "$2" = status ] && printf 'telemetry: %s\n' "$STUB_TELEMETRY"
+  exit 0
+fi
+{
+  printf 'verb=%s\n' "$1"
+  printf 'HULL_TELEMETRY_SUPPRESS=%s\n' "${HULL_TELEMETRY_SUPPRESS-<unset>}"
+  printf 'HULL_TELEMETRY_PRODUCT=%s\n' "${HULL_TELEMETRY_PRODUCT-<unset>}"
+  printf 'DO_NOT_TRACK=%s\n' "${DO_NOT_TRACK-<unset>}"
+} >> "$STUB_LOG"
+exit 0
+`
+	bin := filepath.Join(dir, "hull")
+	if err := os.WriteFile(bin, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("STUB_LOG", log)
+	t.Setenv("STUB_TELEMETRY", state)
+	return &hull{bin: bin}, func() string {
+		b, err := os.ReadFile(log)
+		if err != nil {
+			return ""
+		}
+		return string(b)
+	}
+}
+
+func boot(t *testing.T, h *hull) {
+	t.Helper()
+	if err := h.Run(RunSpec{Name: "vm", Image: "img", Mem: 2048, CPUs: 2, Counted: true}); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+}
+
+// The gap this closes: hull defaults telemetry on when it cannot prompt, and
+// the boot hands it no terminal, so a fresh install used to send events for
+// its first boot before anyone had been asked anything -- with brig's name on
+// them. Nothing may go out until an answer exists.
+func TestFreshInstallDoesNotCountTheBoot(t *testing.T) {
+	h, logged := stubTelemetryHull(t, "not configured (on by default; interactive runs will be asked)")
+
+	boot(t, h)
+	if err := h.Stop("vm"); err != nil {
+		t.Fatalf("stop: %v", err)
+	}
+
+	got := logged()
+	if strings.Count(got, "HULL_TELEMETRY_SUPPRESS=1") != 2 {
+		t.Errorf("an unanswered install counted an operation:\n%s", got)
+	}
+	// Attribution still travels, so that whatever is eventually sent says brig
+	// rather than reading as hull's own usage.
+	if !strings.Contains(got, "HULL_TELEMETRY_PRODUCT=brig") {
+		t.Errorf("attribution missing:\n%s", got)
+	}
+}
+
+// The other half of the same rule: once there is an answer, the operations the
+// user asked for count again. A gate that never opens is not a consent gate,
+// it is an opt-out brig imposed on the user's behalf.
+func TestRecordedConsentCountsTheBoot(t *testing.T) {
+	h, logged := stubTelemetryHull(t, "enabled")
+
+	boot(t, h)
+
+	if got := logged(); !strings.Contains(got, "HULL_TELEMETRY_SUPPRESS=\n") {
+		t.Errorf("a recorded yes did not count the boot:\n%s", got)
+	}
+}
+
+// DO_NOT_TRACK is the cross-tool opt-out, and it wins over everything: over
+// the boot gate, over an answer recorded on this machine, over brig's own
+// attribution. It also has to reach the child untouched, because the tool that
+// honours it is the one brig spawns.
+func TestDoNotTrackWins(t *testing.T) {
+	t.Setenv("DO_NOT_TRACK", "1")
+	h, logged := stubTelemetryHull(t, "disabled (DO_NOT_TRACK=1)")
+
+	boot(t, h)
+
+	got := logged()
+	if !strings.Contains(got, "DO_NOT_TRACK=1") {
+		t.Errorf("DO_NOT_TRACK did not reach the runtime:\n%s", got)
+	}
+	if !strings.Contains(got, "HULL_TELEMETRY_SUPPRESS=1") {
+		t.Errorf("DO_NOT_TRACK was set and the boot was still counted:\n%s", got)
+	}
+	state, err := h.TelemetryStatus()
+	if err != nil {
+		t.Fatalf("status: %v", err)
+	}
+	if state.State != TelemetryOff {
+		t.Errorf("state = %q, want off", state.State)
+	}
+	// Reported, because "off" with no explanation is the state a user cannot
+	// then turn back on: the answer is in the shell, not on the disk.
+	if state.Setting != "DO_NOT_TRACK=1" {
+		t.Errorf("setting = %q, want DO_NOT_TRACK=1", state.Setting)
+	}
+}
+
+// The exception, and the reason the gate does not simply suppress everything:
+// the exec that hands over the terminal is where hull can ask the question.
+// Suppressing there would mean the prompt never appears and the answer is
+// never recorded, so telemetry would be off for good with nobody having
+// chosen that.
+func TestTerminalHandoverStaysAskable(t *testing.T) {
+	h, _ := stubTelemetryHull(t, "not configured (on by default; interactive runs will be asked)")
+
+	withTerminal := strings.Join(h.telemetryEnvFor(true, true), " ")
+	if strings.Contains(withTerminal, "HULL_TELEMETRY_SUPPRESS=1") {
+		t.Errorf("the invocation that can ask was suppressed: %s", withTerminal)
+	}
+	// Same invocation without a terminal on stdin: nobody to ask, so the boot
+	// rule applies.
+	withoutTerminal := strings.Join(h.telemetryEnvFor(true, false), " ")
+	if !strings.Contains(withoutTerminal, "HULL_TELEMETRY_SUPPRESS=1") {
+		t.Errorf("a non-interactive handover was counted: %s", withoutTerminal)
+	}
+}
+
+// Plumbing stays suppressed whatever the answer is: one user command counts
+// once, which is the rule that predates the gate.
+func TestPlumbingStaysSuppressedWithConsent(t *testing.T) {
+	h, _ := stubTelemetryHull(t, "enabled")
+
+	if got := strings.Join(h.telemetryEnvFor(false, true), " "); !strings.Contains(got, "HULL_TELEMETRY_SUPPRESS=1") {
+		t.Errorf("plumbing counted: %s", got)
+	}
+}
+
+func TestSetTelemetryRecordsTheAnswer(t *testing.T) {
+	h, logged := stubTelemetryHull(t, "disabled")
+
+	if err := h.SetTelemetry(false); err != nil {
+		t.Fatalf("off: %v", err)
+	}
+	if err := h.SetTelemetry(true); err != nil {
+		t.Fatalf("on: %v", err)
+	}
+
+	got := logged()
+	for _, want := range []string{"telemetry-verb=off", "telemetry-verb=on"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("%s not driven:\n%s", want, got)
+		}
+	}
+}
+
+// Every phrase hull documents, plus the two that matter most: a state this
+// version has not seen must not read as "on", and an answer given to a
+// narrower disclosure than today's is not an answer to today's.
+func TestParseTelemetry(t *testing.T) {
+	for _, tt := range []struct {
+		out     string
+		want    TelemetryState
+		setting string
+	}{
+		{"telemetry: enabled\n", TelemetryOn, ""},
+		{"telemetry: disabled\n", TelemetryOff, ""},
+		{"telemetry: disabled (DO_NOT_TRACK=1)\n", TelemetryOff, "DO_NOT_TRACK=1"},
+		{"telemetry: disabled (HULL_TELEMETRY_DISABLED=1)\n", TelemetryOff, "HULL_TELEMETRY_DISABLED=1"},
+		{"telemetry: not configured (on by default; interactive runs will be asked)\n", TelemetryUnanswered, ""},
+		{"telemetry: enabled for an older schema (interactive runs will be re-asked)\n", TelemetryUnanswered, ""},
+		{"", TelemetryUnknown, ""},
+		{"telemetry: something this version has never heard of\n", TelemetryUnknown, ""},
+	} {
+		got := parseTelemetry(tt.out)
+		if got.State != tt.want || got.Setting != tt.setting {
+			t.Errorf("parseTelemetry(%q) = (%q, %q), want (%q, %q)",
+				tt.out, got.State, got.Setting, tt.want, tt.setting)
+		}
+	}
+}
+
+// An older runtime with no telemetry command at all, or one that will not
+// answer, is not an answer either. The gate must close, not open, and asking
+// must not take the whole run down with it.
+func TestUnansweredRuntimeSuppresses(t *testing.T) {
+	h := &hull{bin: filepath.Join(t.TempDir(), "not-there")}
+
+	if _, err := h.TelemetryStatus(); err == nil {
+		t.Fatal("a missing runtime reported a telemetry state")
+	}
+	if got := strings.Join(h.telemetryEnvFor(true, false), " "); !strings.Contains(got, "HULL_TELEMETRY_SUPPRESS=1") {
+		t.Errorf("a runtime that would not answer counted the operation: %s", got)
+	}
+}

--- a/internal/wrap/exec_test.go
+++ b/internal/wrap/exec_test.go
@@ -1,0 +1,58 @@
+package wrap
+
+import (
+	"os"
+	"testing"
+
+	"github.com/brig-sh/brig/internal/creds"
+	"github.com/brig-sh/brig/internal/runtime"
+)
+
+// recordingRuntime captures the spec handed to Replace instead of exec'ing it,
+// so a test can see what the guest pty and the consent gate were told.
+type recordingRuntime struct {
+	runtime.Runtime
+	spec runtime.ExecSpec
+}
+
+func (r *recordingRuntime) Replace(spec runtime.ExecSpec) error {
+	r.spec = spec
+	return nil
+}
+
+// Shell forces a pty on because a login shell wants one, but whether hull may
+// ask its consent question is a fact about brig's own stdin, not the guest's
+// pty. Under test, stdin is not a terminal (a script or CI is the same), so a
+// `brig shell -- cmd` must record TTY on and CanAsk off: the split the boot
+// gate reads to leave a fresh install suppressed rather than send its first
+// event before anyone was asked.
+func TestShellSeparatesPtyFromConsent(t *testing.T) {
+	rec := &recordingRuntime{}
+	c := &Config{VMName: "vm", Runtime: rec}
+
+	if err := c.Shell(creds.Set{}, []string{"ls"}); err != nil {
+		t.Fatalf("shell: %v", err)
+	}
+	if !rec.spec.TTY {
+		t.Error("shell dropped the guest pty")
+	}
+	if rec.spec.CanAsk {
+		t.Error("a non-terminal stdin was treated as askable")
+	}
+}
+
+// The Run path already fed the terminal check to both jobs by passing it as the
+// tty argument, and that stays true: CanAsk tracks the same signal TTY does
+// when the caller computed tty from stdin. This pins that the field is set from
+// the real stdin, not left to default, so the Run path's behaviour is unchanged.
+func TestExecCanAskTracksStdin(t *testing.T) {
+	rec := &recordingRuntime{}
+	c := &Config{VMName: "vm", Runtime: rec}
+
+	if err := c.Exec(creds.Set{}, []string{"ls"}, false); err != nil {
+		t.Fatalf("exec: %v", err)
+	}
+	if rec.spec.CanAsk != IsTerminal(os.Stdin) {
+		t.Errorf("CanAsk = %v, want the real stdin terminal check", rec.spec.CanAsk)
+	}
+}

--- a/internal/wrap/run.go
+++ b/internal/wrap/run.go
@@ -399,10 +399,16 @@ func (c *Config) Remove() error {
 // on success.
 func (c *Config) Exec(set creds.Set, argv []string, tty bool) error {
 	return c.Runtime.Replace(runtime.ExecSpec{
-		Name:    c.VMName,
-		Cmd:     argv,
-		Cwd:     c.GuestCwd,
-		TTY:     tty,
+		Name: c.VMName,
+		Cmd:  argv,
+		Cwd:  c.GuestCwd,
+		TTY:  tty,
+		// Whether hull may ask its consent question is a fact about brig's own
+		// stdin, not about the guest's pty. Shell forces TTY on so a login shell
+		// gets its terminal, but a `brig shell -- cmd` from a script still has
+		// no one to answer, so it must not read as askable. Compute it here,
+		// once, from the real stdin rather than reusing tty. See telemetryEnvFor.
+		CanAsk:  IsTerminal(os.Stdin),
 		Env:     set.Vars,
 		Counted: true,
 	})


### PR DESCRIPTION
## Summary

brig tags hull's telemetry with its own product name and leaves it unsuppressed
for the boot and for the exec that takes the terminal. hull defaults telemetry
on when it cannot prompt, and brig's boot gives hull no terminal on stdin, so a
fresh install sent events for its first boot before any consent prompt could
appear, and the prompt that appeared later carried brig's name. brig's own
documentation never said telemetry existed; the one mention was a settings row
listing two pass-through variables.

hull's telemetry documentation is good and its payload is small. The defect was
brig's silence, and the boot that ran ahead of the question.

## Related issues

Closes #31

## Changes

- **Nothing is sent before an answer is recorded.** Every hull invocation now
  passes through a consent gate: the boot, stop and rm stay suppressed until
  hull reports a recorded yes. The one exec that hands over a real terminal is
  left unsuppressed, on purpose, because that is the only place hull's own
  prompt can appear; without it the question is never asked, no answer is ever
  recorded, and the gate never opens. A scripted `brig run -p` therefore never
  sends anything, which is stricter than hull's own unattended default.
- **`brig telemetry status|on|off`.** Drives hull's own `telemetry`
  subcommand and persisted state rather than inventing a second store, and
  reports in brig's words without hull appearing in the command line. A runtime
  with no telemetry (nerdctl) reports `off` rather than erroring.
- **Disclosure.** A telemetry section in the README and in `docs/security.md`:
  what is collected, who receives it, that it defaults to on once answered, the
  one-line opt-out, and a commitment list of what is never collected: workspace
  paths, repository names, command arguments, agent prompts, secret names, image
  names, network destinations, file metadata.
- `DO_NOT_TRACK=1` continues to win, untouched, and is tested.

The gate reads hull's recorded state through `hull telemetry status`, bounded
at three seconds and cached per process. hull's page does not specify what that
prints, so the phrases were taken from hull's source; an unrecognised phrase
from a future hull maps to "cannot tell" and suppresses rather than guesses.

## Checklist

- [x] `make all` passes (vet, test, build)
- [x] `script/smoke.sh` passes
- [x] I have added or updated tests covering the change
- [x] I have run `go test ./... -race`, if the change touches concurrency, subprocesses or the daemon
- [x] I have exercised the change against a real runtime (`brig run <agent>`), if it touches the run, exec or credential path
- [x] I have updated the affected docs (README, `docs/security.md`, `docs/profiles.md`, `docs/brigd.md`)

`brig telemetry status` was run against the hull on this machine from a build
of this branch and reported the recorded state in brig's words. A full first
boot on a fresh install, to watch the prompt appear on the exec and the next
boot be counted, has not been done and should be once before merge.

## Credentials and the sandbox boundary

No change to either promise. This is about a third thing the docs did not name:
what leaves the machine. The tests pin that a fresh install's boot and stop
carry `HULL_TELEMETRY_SUPPRESS=1`, that a recorded yes lifts it, and that
`DO_NOT_TRACK` reaches the child untouched.

