### PR TITLE
chore(creds)!: remove BRIG_CREDENTIALS_CMD

### DIFF
--- a/README.md
+++ b/README.md
@@ -623,11 +623,12 @@ Booleans are shell-style: anything except `0` is on.
 | variable | default | what it does |
 | --- | --- | --- |
 | `BRIG_FORWARD_ENV` | per profile | Space-separated list of variables to forward. Replaces the profile's list rather than adding to it |
-| `BRIG_CREDENTIALS_CMD` | unset | **Deprecated, removed next release.** Command printing the host credential JSON on stdout, for a profile still using `hostCredential:`. `brig secret import <profile> --from-command '<command>'` does the same job once, instead of on every run |
 | `BRIG_ALLOW_REFS` | `0` | Forward a value that looks like an unresolved `scheme://` secret reference |
 | `BRIG_ALLOW_DENIED` | `0` | Forward a variable on the profile's billing denylist |
 | `BRIG_ALLOW_EXPIRED` | `0` | Forward the host credential even though it reports as expired. brig withholds one by default, because a dead token turns into a confusing failure inside the guest rather than a clear one on the host. Set this if your clock is the thing that is wrong. Scoped to the deprecated `hostCredential:` path, and goes with it: an imported credential that has expired warns and is still delivered, so there is nothing to override |
 | `GIT_TERMINAL_PROMPT` | `0` | Forwarded as-is; set it to `1` on the host to let git prompt in the guest |
+
+Removed: `BRIG_CREDENTIALS_CMD` ran a command of yours on every boot to read the host credential. brig now refuses to start when it is set, and names the replacement, which reads your command once instead: `brig secret import <profile> <name> --from-command '<command>'`.
 
 ### Guest git
 

--- a/cmd/brig/main.go
+++ b/cmd/brig/main.go
@@ -87,9 +87,6 @@ settings (BRIG_<AGENT>_<KEY> wins over BRIG_<KEY>; see the README for all):
   BRIG_PULL            missing (default) | always | never
   BRIG_SKILLS          1 to project your ~/.claude skills and plugins read-only
   BRIG_FORWARD_ENV     replaces the env-sourced bindings, space-separated
-  BRIG_CREDENTIALS_CMD deprecated, goes next release: declare the credential
-                       under secrets:, then brig secret import <profile> <name>
-                       --from-command does the same job once instead of per run
   BRIG_GIT_CONFIG      1 to write the guest git-over-HTTPS files
   BRIG_VERIFY          warn (default) | require | off -- guest image signature
   BRIG_PROFILE_DIR     where your own profiles live (BRIG_TEMPLATE_DIR still works)

--- a/docs/profiles.md
+++ b/docs/profiles.md
@@ -618,9 +618,9 @@ brig secret import mytool
 
 The difference is when the host is read: at import, once, when you asked --
 rather than on every boot. `BRIG_CREDENTIALS_CMD`, which pointed the old
-machinery at any command printing equivalent JSON, is replaced by
-`brig secret import <profile> --from-command '<command>'` and goes in the same
-release.
+machinery at any command printing equivalent JSON, is gone; brig refuses to
+start when it is set and names what replaces it,
+`brig secret import <profile> <name> --from-command '<command>'`.
 
 ## A worked example
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -45,13 +45,16 @@ brig secret import claude-code     # carry the host login in, once
 
 That is a change from earlier releases, which read Claude Code's own keychain
 item on every invocation as a fallback. The profile key that did it,
-`hostCredential:`, is deprecated and leaves the shipped profiles in this
-release; brig removes the field and `BRIG_CREDENTIALS_CMD` in the next.
+`hostCredential:`, is deprecated and has left the shipped profiles; brig
+removes the field in the next release. `BRIG_CREDENTIALS_CMD`, which pointed
+that read at a host command of your own, is already gone: a run that sets it
+fails, naming `brig secret import <profile> <name> --from-command '<command>'`.
 
-Until it does, the sentence above is about the profiles brig ships. A profile
-of your own still carrying `hostCredential:` keeps the old behaviour, because
-that is what deprecating rather than deleting the key means: every run reads
-the host item it names, and raises the approval dialog that comes with it.
+Until the field goes too, the sentence above is about the profiles brig ships.
+A profile of your own still carrying `hostCredential:` keeps the old
+behaviour, because that is what deprecating rather than deleting the key
+means: every run reads the host item it names, and raises the approval dialog
+that comes with it.
 `brig run` warns when it finds one. Moving it to `secrets:` with `sources:` is
 what makes the promise above true for your profile too.
 

--- a/internal/creds/creds.go
+++ b/internal/creds/creds.go
@@ -45,11 +45,10 @@ func (s *Set) Add(name, value, reportAs string) {
 }
 
 // AddSecret appends a variable whose value brig resolved on the user's behalf:
-// from the store it owns, or from the host credential -- however that was
-// obtained, keychain or BRIG_CREDENTIALS_CMD. It is reported like any other
-// credential, but it never travels in argv: the host durably logs every exec's
-// argv, so such a value there would outlive the sandbox in a file the user
-// never sees.
+// from the store it owns, or from the host credential it read out of the
+// keychain. It is reported like any other credential, but it never travels in
+// argv: the host durably logs every exec's argv, so such a value there would
+// outlive the sandbox in a file the user never sees.
 func (s *Set) AddSecret(name, value, reportAs string) {
 	s.Vars = append(s.Vars, runtime.Var{Name: name, Value: value, Secret: true})
 	if reportAs == "" {
@@ -122,16 +121,15 @@ func admit(t profile.Profile, name, value string, fromEnv bool, opt Options) (st
 // exported because that one is resolved in wrap rather than in Bind.
 //
 // It was the one value that reached the guest without passing either guard:
-// the keychain read and BRIG_CREDENTIALS_CMD called AddSecret directly, so a
-// profile that denies its own target variable did not deny this path, and a
-// credentials command that printed "op://vault/item" -- which is exactly what
-// a secret-manager helper prints when it is not logged in -- forwarded that
-// string as the login and left the guest failing to authenticate for a reason
-// nothing said out loud.
+// the keychain read called AddSecret directly, so a profile that denies its own
+// target variable did not deny this path, and a blob whose token field held
+// "op://vault/item" -- a secret-manager reference rather than a token -- was
+// forwarded as the login and left the guest failing to authenticate for a
+// reason nothing said out loud.
 //
 // Treated as ambient, like an environment-sourced value, because that is what
-// it is: brig did not write this blob, it read whatever the keychain or the
-// user's own command handed back.
+// it is: brig did not write this blob, it read whatever the keychain handed
+// back.
 func AdmitHost(p profile.Profile, name, value string, opt Options) (string, bool) {
 	return admit(p, name, value, true, opt)
 }
@@ -163,49 +161,51 @@ type HostCredential struct {
 	Source string
 }
 
+// KeychainRead reads the raw credential blob a host keychain holds for one
+// service. Only ReadHost calls it, and only a test supplies one of its own:
+// the real read talks to the login keychain of whoever is running brig.
+type KeychainRead func(service string) ([]byte, error)
+
 // ReadHost resolves the profile's host credential.
 //
-// The default backend is the macOS keychain, which is where the host's own
-// login already lives -- that is what lets a fresh sandbox work without
-// anyone minting a token. Any other backend is a command that prints the same
-// JSON on stdout:
+// The backend is the macOS keychain, which is where the host's own login
+// already lives -- that is what lets a fresh sandbox work without anyone
+// minting a token. Any other backend is imported once, into brig's own store,
+// rather than read on every run:
 //
-//	BRIG_CREDENTIALS_CMD='your-secret-tool read claude/credentials'
+//	brig secret import <profile> <name> --from-command '<command>'
 //
-// Absence is ordinary: nobody has run the agent on this host. It is reported
-// as (nil, nil), not as an error. A failing custom command IS an error,
-// because its stderr is the only explanation the caller will ever get.
-func ReadHost(hc *profile.HostCredential, command string) (*HostCredential, error) {
+// That import is what replaced BRIG_CREDENTIALS_CMD, which used to point this
+// read at a command of the user's own and ran it on every boot.
+//
+// read is nil everywhere but in tests, where it stands in for the keychain: a
+// suite must not read, or depend on, the keychain of whoever runs it.
+//
+// Absence is ordinary: nobody has run the agent on this host, or this is not a
+// Mac. It is reported as a nil credential rather than as a failure, and there
+// is nothing else left to report: the keychain's own stderr is noise rather
+// than an explanation when the common case is an item that was never created.
+func ReadHost(hc *profile.HostCredential, read KeychainRead) *HostCredential {
 	if hc == nil {
-		return nil, nil
+		return nil
 	}
-	var blob []byte
-	source := ""
-	if command != "" {
-		out, err := runShell(command)
-		if err != nil {
-			return nil, fmt.Errorf("BRIG_CREDENTIALS_CMD failed: %w", err)
-		}
-		blob, source = out, "BRIG_CREDENTIALS_CMD"
-	} else {
-		out, err := keychain(hc.KeychainService)
-		if err != nil {
-			// The keychain's own stderr is noise rather than an explanation
-			// here: not having run the agent on this host is the common case.
-			return nil, nil
-		}
-		blob, source = out, "the host keychain"
+	if read == nil {
+		read = keychain
 	}
-	blob = bytes.TrimSpace(blob)
+	out, err := read(hc.KeychainService)
+	if err != nil {
+		return nil
+	}
+	blob := bytes.TrimSpace(out)
 	if len(blob) == 0 {
-		return nil, nil
+		return nil
 	}
 	token, _ := findString(blob, hc.TokenField)
 	if token == "" {
-		return nil, nil
+		return nil
 	}
 	expiry, _ := findNumber(blob, hc.ExpiryField)
-	return &HostCredential{Token: token, ExpiresAt: expiry, Source: source}, nil
+	return &HostCredential{Token: token, ExpiresAt: expiry, Source: "the host keychain"}
 }
 
 // Expired reports whether the credential is past its expiry. A blob carrying
@@ -231,29 +231,6 @@ func keychain(service string) ([]byte, error) {
 		return nil, err
 	}
 	return out.Bytes(), nil
-}
-
-func runShell(command string) ([]byte, error) {
-	cmd := exec.Command("sh", "-c", command)
-	var out, errb bytes.Buffer
-	cmd.Stdout = &out
-	cmd.Stderr = &errb
-	if err := cmd.Run(); err != nil {
-		msg := strings.TrimSpace(errb.String())
-		if msg != "" {
-			return nil, fmt.Errorf("%w: %s", err, firstLines(msg, 3))
-		}
-		return nil, err
-	}
-	return out.Bytes(), nil
-}
-
-func firstLines(s string, n int) string {
-	lines := strings.Split(s, "\n")
-	if len(lines) > n {
-		lines = lines[:n]
-	}
-	return strings.Join(lines, " ")
 }
 
 // findString and findNumber are jsonfind under the names ReadHost already

--- a/internal/wrap/config.go
+++ b/internal/wrap/config.go
@@ -57,6 +57,12 @@ type Config struct {
 	// declares secrets -- opening it unconditionally would raise a keychain
 	// prompt for runs that read nothing. Replaced in tests.
 	OpenStore func() (creds.SecretReader, error)
+	// ReadKeychain reads the blob behind a profile's deprecated
+	// hostCredential:, and is nil outside tests, where nil means the host's own
+	// keychain. It exists because a test must not read the login keychain of
+	// whoever runs the suite, and because the blob a test wants is one it wrote
+	// itself. BRIG_CREDENTIALS_CMD used to serve that purpose by accident.
+	ReadKeychain creds.KeychainRead
 	// envWarnings are what building Env decided to drop, held until BuildEnv
 	// has somewhere to print them: Load has no writer yet.
 	envWarnings []string
@@ -84,10 +90,9 @@ type Config struct {
 	// runtime so the object that boots is the object that verified; empty means
 	// boot the tag as given, which is every hull run and any path that could not
 	// resolve a digest.
-	BootDigest     string
-	AllowRefs      bool
-	AllowDenied    bool
-	CredentialsCmd string
+	BootDigest  string
+	AllowRefs   bool
+	AllowDenied bool
 
 	// Cwd is the host directory the command was invoked from, and GuestCwd is
 	// where that lands inside the guest.
@@ -122,6 +127,24 @@ type Options struct {
 // Load resolves the configuration for one invocation.
 func Load(t profile.Profile, o Options, rt runtime.Runtime) (*Config, error) {
 	env := NewEnv(t.Name, os.LookupEnv)
+
+	// BRIG_CREDENTIALS_CMD is gone, and a run that still sets it fails here
+	// rather than proceeding. The variable named a command brig ran on every
+	// boot to read the host credential, so a run that ignored it would boot a
+	// sandbox with no login and no explanation -- the failure would surface
+	// inside the guest, as a prompt to authenticate, which is the last place
+	// anyone would connect back to a setting on the host.
+	//
+	// The replacement is two steps, and naming only the second sends the reader
+	// into an error: --from-command fills one secret so it needs a name, and a
+	// profile still on hostCredential: has no secrets: list for that name to be
+	// in. Say both, in order.
+	if cmd, ok := env.Get("CREDENTIALS_CMD"); ok && cmd != "" {
+		return nil, fmt.Errorf("BRIG_CREDENTIALS_CMD has been removed. Declare the "+
+			"credential under secrets: in %s, then store it once: brig secret import "+
+			"%s <name> --from-command '<command>'", t.Name, t.Name)
+	}
+
 	rawName := o.Name
 
 	slug := ""
@@ -225,7 +248,6 @@ func Load(t profile.Profile, o Options, rt runtime.Runtime) (*Config, error) {
 		VerifyPolicy:   verifyPolicy(env),
 		AllowRefs:      env.Bool("ALLOW_REFS", false),
 		AllowDenied:    env.Bool("ALLOW_DENIED", false),
-		CredentialsCmd: env.String("CREDENTIALS_CMD", ""),
 		Cwd:            cwd,
 		Out:            os.Stdout,
 		Err:            os.Stderr,

--- a/internal/wrap/config_test.go
+++ b/internal/wrap/config_test.go
@@ -230,8 +230,7 @@ func TestBuildEnvBindsAResolvedSecret(t *testing.T) {
 // host durably logs every exec's argv -- a token in there outlives the sandbox
 // in a file nobody thinks to look at.
 func TestBuildEnvKeepsTheHostCredentialOutOfArgv(t *testing.T) {
-	c := bindingConfig(t, credentialProfile)
-	c.CredentialsCmd = `printf '{"accessToken":"tok"}'`
+	c := hostCredConfig(t, "", `{"accessToken":"tok"}`)
 
 	set, err := c.BuildEnv()
 	if err != nil {
@@ -301,37 +300,49 @@ func mustMkdir(t *testing.T, path string) {
 	}
 }
 
-// BRIG_CREDENTIALS_CMD is ReadHost's only consumer and would otherwise stop
-// doing anything silently: it is reachable only through hostCredential:, which
-// no shipped profile declares any more. It warns when set and names
-// --from-command, which is the verb that does the same job once instead of on
-// every run.
-func TestCredentialsCmdWarnsAndNamesFromCommand(t *testing.T) {
-	c := bindingConfig(t, credentialProfile)
-	c.CredentialsCmd = `printf '{"accessToken":"tok"}'`
+// BRIG_CREDENTIALS_CMD is removed, and a run that still sets it fails rather
+// than ignoring it: the variable named the command that read the host
+// credential, so a run that carried on would boot a sandbox without the login
+// the user believes they configured, and the only symptom would be the guest
+// asking them to authenticate.
+//
+// Both spellings, because the per-profile prefix is how a shell carries a
+// setting for one profile and the removal has to reach the same names the
+// setting did.
+func TestCredentialsCmdFailsTheRunAndNamesTheImport(t *testing.T) {
+	p, ok := profile.Lookup("claude-code")
+	if !ok {
+		t.Fatal("no claude-code profile")
+	}
+	for _, name := range []string{"BRIG_CREDENTIALS_CMD", "BRIG_CLAUDE_CODE_CREDENTIALS_CMD"} {
+		t.Run(name, func(t *testing.T) {
+			t.Setenv(name, "your-secret-tool read claude/credentials")
 
-	if _, err := c.BuildEnv(); err != nil {
-		t.Fatal(err)
-	}
-	warning := c.Err.(*bytes.Buffer).String()
-	if !strings.Contains(warning, "BRIG_CREDENTIALS_CMD is deprecated") {
-		t.Errorf("nothing said BRIG_CREDENTIALS_CMD is going:\n%s", warning)
-	}
-	if !strings.Contains(warning, "--from-command") {
-		t.Errorf("the warning does not name what replaces it:\n%s", warning)
+			_, err := Load(p, Options{}, nil)
+			if err == nil {
+				t.Fatal("a run with BRIG_CREDENTIALS_CMD set was loaded anyway")
+			}
+			for _, want := range []string{"BRIG_CREDENTIALS_CMD", "removed",
+				"brig secret import claude-code <name> --from-command"} {
+				if !strings.Contains(err.Error(), want) {
+					t.Errorf("the error does not carry %q: %v", want, err)
+				}
+			}
+		})
 	}
 }
 
-// And it says nothing when it is not set. A deprecation warning on every run
-// of a setting nobody uses is the kind of noise that trains people to stop
-// reading brig's stderr.
-func TestCredentialsCmdIsSilentWhenUnset(t *testing.T) {
-	c := bindingConfig(t, credentialProfile)
-
-	if _, err := c.BuildEnv(); err != nil {
-		t.Fatal(err)
+// And an unset one loads, including the empty spelling: `export
+// BRIG_CREDENTIALS_CMD=` is how a shell profile turns the setting off, and
+// failing on it would refuse the very state the user moved to.
+func TestLoadAcceptsAnEmptyCredentialsCmd(t *testing.T) {
+	p, ok := profile.Lookup("claude-code")
+	if !ok {
+		t.Fatal("no claude-code profile")
 	}
-	if warning := c.Err.(*bytes.Buffer).String(); strings.Contains(warning, "BRIG_CREDENTIALS_CMD") {
-		t.Errorf("warned about a setting that is not set:\n%s", warning)
+	t.Setenv("BRIG_CREDENTIALS_CMD", "")
+
+	if _, err := Load(p, Options{}, nil); err != nil {
+		t.Fatalf("an empty BRIG_CREDENTIALS_CMD failed the run: %v", err)
 	}
 }

--- a/internal/wrap/hostcred_test.go
+++ b/internal/wrap/hostcred_test.go
@@ -8,20 +8,23 @@ import (
 	"time"
 )
 
-// hostCredConfig builds a run whose host credential comes from a command
-// printing the blob given, which is the BRIG_CREDENTIALS_CMD path a user with
-// any other secret backend takes. The keychain path resolves the same value
-// through the same code.
+// hostCredConfig builds a run whose host credential is the blob given. The
+// keychain read is replaced rather than performed: these cases are about what
+// BuildEnv does with a blob, and a suite must not read, or depend on, the login
+// keychain of whoever is running it.
 func hostCredConfig(t *testing.T, body, blob string) *Config {
 	t.Helper()
 	c := bindingConfig(t, "hostCredential:\n  keychainService: s\n  tokenField: accessToken\n"+
 		"  expiryField: expiresAt\n  targetVar: TOK\n  renewHint: run it once\n"+body)
-	c.CredentialsCmd = "printf %s " + shellQuote(blob)
+	c.ReadKeychain = func(service string) ([]byte, error) {
+		if service != "s" {
+			t.Errorf("the keychain was read for %q, not the service the profile names", service)
+		}
+		return []byte(blob), nil
+	}
 	c.Err = &bytes.Buffer{}
 	return c
 }
-
-func shellQuote(s string) string { return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'" }
 
 func warnings(t *testing.T, c *Config) string {
 	t.Helper()

--- a/internal/wrap/run.go
+++ b/internal/wrap/run.go
@@ -25,23 +25,6 @@ func (c *Config) BuildEnv() (creds.Set, error) {
 		c.warnf("%s", w)
 	}
 
-	// BRIG_CREDENTIALS_CMD is ReadHost's only consumer, and ReadHost is only
-	// reached through hostCredential:, which no built-in declares any more --
-	// so on a shipped profile this variable already does nothing. Said out
-	// loud rather than left to be discovered: it is documented in the
-	// top-level usage and the README, and a setting that silently stopped
-	// working is worse than one that is going away.
-	// The replacement is two steps, and naming only the second sends the
-	// reader into an error: --from-command fills one secret so it needs a
-	// name, and a profile still on hostCredential: has no secrets: list for
-	// that name to be in. Say both, in order.
-	if c.CredentialsCmd != "" {
-		c.warnf("BRIG_CREDENTIALS_CMD is deprecated and goes in the next release. "+
-			"Declare the credential under secrets: in %s, then store it once: "+
-			"brig secret import %s <name> --from-command '<command>'",
-			c.Profile.Name, c.Profile.Name)
-	}
-
 	// Resolved before anything else touches the sandbox, and returned as an
 	// error rather than a warning: a run whose secret cannot be resolved must
 	// fail, saying which secret is missing and how to create it, instead of
@@ -73,11 +56,14 @@ func (c *Config) BuildEnv() (creds.Set, error) {
 	// mint one. Read fresh every invocation: the token is short-lived, the
 	// host renews it as a matter of course, and nothing in the guest has to
 	// refresh anything.
+	//
+	// Only a profile still carrying the deprecated hostCredential: gets here,
+	// and no built-in carries one any more. The keychain is the only backend
+	// this reads: BRIG_CREDENTIALS_CMD, which used to point it at a command of
+	// the user's own, is gone, and Load fails a run that still sets it rather
+	// than booting a sandbox without the login the variable used to supply.
 	if hc := c.Profile.HostCredential; hc != nil && !set.Has(hc.TargetVar) {
-		host, err := creds.ReadHost(hc, c.CredentialsCmd)
-		if err != nil {
-			c.warnf("%s", err)
-		} else if host != nil {
+		if host := creds.ReadHost(hc, c.ReadKeychain); host != nil {
 			c.HostCred = host
 			c.admitHostCredential(hc, host, &set)
 		}

--- a/script/smoke.sh
+++ b/script/smoke.sh
@@ -157,8 +157,10 @@ export BRIG_BOOT_ASSETS="$WORK/assets"
 export BRIG_HYPERVISOR=vz
 # Your own profiles go in a scratch directory, never the caller's own.
 export BRIG_PROFILE_DIR="$WORK/profiles"
-# Never touch the real keychain from a test.
-export BRIG_CREDENTIALS_CMD='printf {"claudeAiOauth":{"accessToken":"host-token","expiresAt":99999999999999}}'
+# The keychain is never read here, and nothing below arranges for it to be: no
+# shipped profile declares hostCredential:, which is the only thing that reads
+# it. BRIG_CREDENTIALS_CMD used to stand in for that read from this script; it
+# is removed, and the case below is what is left to assert about it.
 
 echo "== run =="
 CLAUDE_CODE_OAUTH_TOKEN=env-token-secret GH_TOKEN=gh-secret \
@@ -168,8 +170,8 @@ rc=$?
 
 # The whole reason brig builds the command line itself: a forwarded value
 # must never be readable in `ps`.
-if grep -q 'env-token-secret\|gh-secret\|host-token' "$STUB_LOG"; then
-  if grep '^argv:' "$STUB_LOG" | grep -q 'env-token-secret\|gh-secret\|host-token'; then
+if grep -q 'env-token-secret\|gh-secret' "$STUB_LOG"; then
+  if grep '^argv:' "$STUB_LOG" | grep -q 'env-token-secret\|gh-secret'; then
     bad "a credential value reached argv"
   else
     ok "credential values reach the runtime, but never through argv"
@@ -229,6 +231,20 @@ out="$(GH_TOKEN='op://vault/item/field' "$WORK/brig" env claude 2>&1)"
 case "$out" in
   *"unresolved secret reference"*) ok "a secret-manager reference is not forwarded" ;;
   *) bad "a secret-manager reference is not forwarded -- got: $out" ;;
+esac
+
+echo "== removed settings =="
+# BRIG_CREDENTIALS_CMD named a command brig ran on every boot to read the host
+# credential. It is removed, and a run that still sets it fails here rather
+# than booting a sandbox without the login its user believes they configured --
+# a failure that would otherwise surface as the guest asking them to log in.
+out="$(BRIG_CREDENTIALS_CMD='printf {}' "$WORK/brig" env claude 2>&1)"; rc=$?
+[ "$rc" != 0 ] && ok "a run still setting BRIG_CREDENTIALS_CMD fails" \
+  || bad "a run still setting BRIG_CREDENTIALS_CMD started anyway"
+case "$out" in
+  *"brig secret import claude-code <name> --from-command"*)
+    ok "the failure names the import that replaces it" ;;
+  *) bad "the failure names the import that replaces it -- got: $out" ;;
 esac
 
 echo "== named session =="


### PR DESCRIPTION
## Summary

`BRIG_CREDENTIALS_CMD` was deprecated in the help text and warned on every run
that it "goes in the next release". The replacement has existed for a while:
`brig secret import <profile> <name> --from-command` does the same job once, at
import, instead of running a credential command on every boot, which is the
reason it was deprecated. A deprecation with a deadline in it that outlives the
deadline makes the next notice worth less.

It is removed. A run that still sets it exits non-zero and names the
replacement, rather than ignoring the variable silently.

## Related issues

Closes #23

## Changes

- The read of `BRIG_CREDENTIALS_CMD` in `internal/wrap/config.go`, the
  `Config.CredentialsCmd` field, the per-run warning in `run.go`, and in
  `internal/creds` the command branch of `ReadHost` with its shell runner and
  the error return that existed only to carry a failing command's stderr.
- Help text, the README settings row, and the sentences in `docs/profiles.md`
  and `docs/security.md` that still promised the removal "next release".
- What stays, because `hostCredential:` in a profile still reaches it and is a
  separate deprecation: `ReadHost` itself, the keychain read, expiry, the
  denylist and unresolved-reference guards, `BRIG_ALLOW_EXPIRED`.
- One addition, not a removal: `ReadHost` now takes the keychain read as a
  parameter, surfaced as `Config.ReadKeychain`. The removed variable was what
  let the wrap tests and `script/smoke.sh` feed in a credential blob without
  touching the tester's login keychain, so that seam had to become explicit
  rather than disappear with it.
- Tests: the two deprecation tests are replaced, not skipped, covering both the
  bare and the per-profile spellings of the variable. Smoke gains a
  `removed settings` case asserting the exit status and the named replacement.

The commit carries a `BREAKING CHANGE:` footer, which is where the generated
changelog reads it from.

## What a user sees

```
brig: BRIG_CREDENTIALS_CMD has been removed. Declare the credential under secrets: in claude-code, then store it once: brig secret import claude-code <name> --from-command '<command>'
```

## Checklist

- [x] `make all` passes (vet, test, build)
- [x] `script/smoke.sh` passes
- [x] I have added or updated tests covering the change
- [x] I have run `go test ./... -race`, if the change touches concurrency, subprocesses or the daemon
- [x] I have exercised the change against a real runtime (`brig run <agent>`), if it touches the run, exec or credential path
- [x] I have updated the affected docs (README, `docs/security.md`, `docs/profiles.md`, `docs/brigd.md`)

## Credentials and the sandbox boundary

This narrows the second promise's exceptions: one of the two ways a run could
execute a host-side command that returns a credential is gone. The other,
`hostCredential:` in a user profile, remains and is deprecated separately. The
tests that matter are the ones asserting the host credential path still keeps
its value out of argv after the refactor, which were converted rather than
dropped.
