### PR TITLE
feat(wrap): refuse hvi below macOS 15, and publish the support matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -469,6 +469,7 @@ The README is the overview. The details live in [docs/](docs/):
   and what would reopen each one
 - [brigd.md](docs/brigd.md) -- the session daemon and its protocol
 - [runtimes.md](docs/runtimes.md) -- hull, nerdctl and urunc: what each one is, its licence, and every command brig runs against it
+- [support.md](docs/support.md) -- which computers brig runs on
 
 Found a security problem? [SECURITY.md](SECURITY.md) is how to report it
 privately, rather than in a public issue.

--- a/docs/support.md
+++ b/docs/support.md
@@ -1,0 +1,15 @@
+# What brig runs on
+
+brig boots each coding agent inside its own lightweight virtual machine. That
+needs a Mac with Apple Silicon, or a Linux machine.
+
+| Your computer | Does brig run? |
+| --- | --- |
+| Mac with Apple Silicon (M1 or newer), macOS 15 or later | Yes |
+| Mac with Apple Silicon (M1 or newer), macOS 14 | Yes, if you start it with `BRIG_HYPERVISOR=vz` |
+| Intel Mac | No, brig needs Apple Silicon |
+| Linux, x86-64 or ARM64 | Yes, with `nerdctl` or Docker installed |
+
+On macOS, brig boots the virtual machine itself, so there is nothing else to
+install. On Linux it uses nerdctl and containerd, and Docker works in their
+place.

--- a/internal/wrap/config.go
+++ b/internal/wrap/config.go
@@ -63,6 +63,12 @@ type Config struct {
 	// whoever runs the suite, and because the blob a test wants is one it wrote
 	// itself. BRIG_CREDENTIALS_CMD used to serve that purpose by accident.
 	ReadKeychain creds.KeychainRead
+
+	// MacOSVersion reports the host's macOS version like "14.5", or "" off
+	// macOS. A field so a test can pin the version the hypervisor preflight
+	// sees without running on the OS in question; Load sets it to the real
+	// host reader. See preflightHypervisor.
+	MacOSVersion func() string
 	// envWarnings are what building Env decided to drop, held until BuildEnv
 	// has somewhere to print them: Load has no writer yet.
 	envWarnings []string
@@ -239,6 +245,7 @@ func Load(t profile.Profile, o Options, rt runtime.Runtime) (*Config, error) {
 		Env:            bindings,
 		envWarnings:    envWarnings,
 		OpenStore:      openStore,
+		MacOSVersion:   macOSVersion,
 		GitConfig:      env.Bool("GIT_CONFIG", false),
 		HostConfig:     hostProjections(t, o.Skills || env.Bool("SKILLS", false)),
 		GitHosts:       env.Fields("GIT_HOSTS", []string{"github.com"}),

--- a/internal/wrap/macos_darwin.go
+++ b/internal/wrap/macos_darwin.go
@@ -1,0 +1,23 @@
+package wrap
+
+import "syscall"
+
+// macOSVersion reports the host's macOS product version, like "14.5".
+//
+// Read from the kern.osproductversion sysctl rather than by shelling out to
+// sw_vers: it is one standard-library call with no subprocess, and brig keeps
+// the number of external commands it runs small on purpose. The value drives
+// one decision, preflightHypervisor, which compares only the major component,
+// so the SYSTEM_VERSION_COMPAT shim that can report "10.16" to a binary linked
+// against an old SDK does not reach a modern Go build like this one.
+//
+// An error is reported as "" -- the same as being off macOS -- so a host that
+// will not answer for its own version lets the run proceed rather than being
+// refused over a reading brig could not take.
+func macOSVersion() string {
+	v, err := syscall.Sysctl("kern.osproductversion")
+	if err != nil {
+		return ""
+	}
+	return v
+}

--- a/internal/wrap/macos_other.go
+++ b/internal/wrap/macos_other.go
@@ -1,0 +1,8 @@
+//go:build !darwin
+
+package wrap
+
+// macOSVersion reports nothing off macOS: the hvi floor is a macOS fact, and
+// the container runtime brig drives elsewhere ignores the hypervisor field
+// entirely, so there is no version here to gate a run on.
+func macOSVersion() string { return "" }

--- a/internal/wrap/run.go
+++ b/internal/wrap/run.go
@@ -3,6 +3,7 @@ package wrap
 import (
 	"fmt"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 
@@ -168,6 +169,18 @@ func (c *Config) resolveSecrets() (creds.Resolution, error) {
 // EnsureRunning brings the sandbox up if it is not already, and makes sure
 // the one that is up is mounting this workspace.
 func (c *Config) EnsureRunning(set creds.Set) error {
+	// BRIG_HYPERVISOR (or BRIG_<PROFILE>_HYPERVISOR) beats what the profile
+	// asked for, which is the same order every other setting follows. Resolved
+	// once here so the preflight below and the spec built later cannot disagree
+	// about which backend this run wants.
+	hypervisor := c.env.String("HYPERVISOR", c.Profile.Hypervisor)
+	// Refuse a backend the host cannot boot before the workspace is prepared or
+	// an image is pulled, so the floor lands as one sentence that names the way
+	// past it rather than as the runtime dying at boot with no name. See
+	// preflightHypervisor.
+	if err := c.preflightHypervisor(hypervisor); err != nil {
+		return err
+	}
 	if err := c.PrepareWorkspace(); err != nil {
 		return err
 	}
@@ -265,10 +278,9 @@ func (c *Config) EnsureRunning(set creds.Set) error {
 		// decided in the runtime adapter.
 		RootfsType:  c.env.String("ROOTFS_TYPE", c.Profile.RootfsType),
 		GenericBoot: c.Profile.GenericBoot,
-		// BRIG_HYPERVISOR (or BRIG_<PROFILE>_HYPERVISOR) beats what the
-		// profile asked for, which is the same order every other setting
-		// follows.
-		Hypervisor: c.env.String("HYPERVISOR", c.Profile.Hypervisor),
+		// Resolved once at the top of EnsureRunning, where the preflight also
+		// read it, so the backend this spec boots is the one that was checked.
+		Hypervisor: hypervisor,
 		Counted:    true,
 	}
 	if err := c.Runtime.Run(spec); err != nil {
@@ -288,6 +300,66 @@ func (c *Config) EnsureRunning(set creds.Set) error {
 		focusWindow()
 	}
 	return c.deliverSecretFiles()
+}
+
+// preflightHypervisor refuses a run whose hypervisor the host cannot boot,
+// before the runtime is asked to start anything. It is the host-version
+// sibling of runtime.supports, which refuses a graphical profile on a
+// console-less backend: same idea, a floor turned into a sentence that names
+// the way past it, moved ahead of the runtime so the refusal lands before a
+// workspace is prepared or an image is pulled.
+//
+// It is not the first thing the command does. BuildEnv has already resolved
+// credentials by the time EnsureRunning runs, so a keychain prompt, or a
+// managed-gitconfig write under BRIG_GIT_CONFIG, can happen before this. What
+// it stays ahead of is the runtime's own work, where the unnamed crash lived.
+//
+// The one floor that exists today is hvi on macOS. The hvi backend drives
+// Apple's in-kernel interrupt controller, the hv_gic_* family, which Apple
+// shipped first in macOS 15. On macOS 14 those symbols are absent and the VMM
+// dies at start with `dyld: missing symbol called` -- a failure with no name
+// on it, which reads like a brig bug rather than an OS floor. That is the
+// report in #4, seen on 14.5. Six of the eight shipped profiles ask for hvi,
+// so the default first run on macOS 14 hits this, and it is worth catching
+// here rather than leaving to an unnamed crash.
+//
+// It refuses rather than quietly falling back to vz. The profile named hvi for
+// a reason, and a downgrade nobody chose is its own surprise; naming
+// BRIG_HYPERVISOR=vz leaves that choice with the person who can weigh it.
+//
+// The version is read through c.MacOSVersion, a seam a test can pin. Off macOS
+// it reports "", and there is nothing to refuse: hvi is a macOS backend, and
+// the Linux runtime ignores the field entirely. A version brig cannot parse
+// also proceeds -- blocking a run over a version string we could not read
+// would trade the boot crash for a refusal that is just as opaque.
+func (c *Config) preflightHypervisor(hv string) error {
+	if hv != "hvi" {
+		return nil
+	}
+	version := ""
+	if c.MacOSVersion != nil {
+		version = c.MacOSVersion()
+	}
+	if version == "" {
+		return nil
+	}
+	if major, ok := majorVersion(version); !ok || major >= 15 {
+		return nil
+	}
+	return fmt.Errorf("the hvi hypervisor needs macOS 15 or newer (this is %s): "+
+		"its in-kernel interrupt controller does not exist here. "+
+		"Set BRIG_HYPERVISOR=vz for this run, or upgrade macOS", version)
+}
+
+// majorVersion pulls the major number out of a "15.4.1"-style version string,
+// reporting false when there is no number to read.
+func majorVersion(v string) (int, bool) {
+	major, _, _ := strings.Cut(v, ".")
+	n, err := strconv.Atoi(strings.TrimSpace(major))
+	if err != nil {
+		return 0, false
+	}
+	return n, true
 }
 
 // waitReady waits for the in-guest agent.

--- a/internal/wrap/run_test.go
+++ b/internal/wrap/run_test.go
@@ -1,0 +1,80 @@
+package wrap
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/brig-sh/brig/internal/creds"
+)
+
+// The hvi backend needs Apple's in-kernel interrupt controller, which exists
+// only on macOS 15 and newer. A host below that floor is refused here, before
+// anything is started, with a message that names the version and the bypass --
+// rather than the VMM dying at boot with an unnamed dyld failure (#4).
+func TestPreflightHypervisorRefusesHVIBelowMacOS15(t *testing.T) {
+	old := &Config{MacOSVersion: func() string { return "14.5" }}
+
+	err := old.preflightHypervisor("hvi")
+	if err == nil {
+		t.Fatal("hvi on macOS 14.5 must be refused")
+	}
+	if !strings.Contains(err.Error(), "BRIG_HYPERVISOR=vz") {
+		t.Errorf("message does not name the bypass: %v", err)
+	}
+	if !strings.Contains(err.Error(), "14.5") {
+		t.Errorf("message does not name the host version: %v", err)
+	}
+	if !strings.Contains(err.Error(), "macOS 15") {
+		t.Errorf("message does not name the floor: %v", err)
+	}
+
+	// vz has a console and no dependency on the in-kernel controller, so it is
+	// the working bypass and must proceed on the same host.
+	if err := old.preflightHypervisor("vz"); err != nil {
+		t.Errorf("vz must proceed on macOS 14.5: %v", err)
+	}
+
+	// Once the host is new enough, hvi is exactly what the profile asked for.
+	newHost := &Config{MacOSVersion: func() string { return "15.0" }}
+	if err := newHost.preflightHypervisor("hvi"); err != nil {
+		t.Errorf("hvi must proceed on macOS 15.0: %v", err)
+	}
+
+	// Off macOS the version reader says "", and there is nothing to refuse: the
+	// Linux runtime ignores the hypervisor field a profile still carries.
+	off := &Config{MacOSVersion: func() string { return "" }}
+	if err := off.preflightHypervisor("hvi"); err != nil {
+		t.Errorf("hvi must proceed off macOS: %v", err)
+	}
+
+	// A version brig cannot parse is not grounds to block the run: that would
+	// swap the boot crash for a refusal just as opaque.
+	garbled := &Config{MacOSVersion: func() string { return "sonoma" }}
+	if err := garbled.preflightHypervisor("hvi"); err != nil {
+		t.Errorf("hvi must proceed on an unparseable version: %v", err)
+	}
+}
+
+// EnsureRunning must refuse an unbootable hypervisor before it prepares the
+// workspace, so a macOS 14 host is turned away without a marker or a seeded
+// state file left behind. This pins the ordering the message promises: move
+// the preflight below PrepareWorkspace and the marker appears, failing here.
+func TestEnsureRunningRefusesBeforePreparingTheWorkspace(t *testing.T) {
+	ws := t.TempDir()
+	c := testConfig(t, ws, ws)
+	c.Profile.Hypervisor = "hvi"
+	c.MacOSVersion = func() string { return "14.5" }
+
+	err := c.EnsureRunning(creds.Set{})
+	if err == nil {
+		t.Fatal("hvi on macOS 14.5 must be refused")
+	}
+	if !strings.Contains(err.Error(), "macOS 15") {
+		t.Errorf("refusal is not the hypervisor floor: %v", err)
+	}
+	if _, statErr := os.Stat(filepath.Join(ws, markerFile)); !os.IsNotExist(statErr) {
+		t.Errorf("the workspace was prepared before the refusal: marker present (%v)", statErr)
+	}
+}


### PR DESCRIPTION
## Summary

The README named no minimum OS, no tested runtime versions and no architectures.
#4 is what that costs: a macOS 14.5 host, a sandbox that never became ready, and
`dyld: missing symbol called` from the VMM, with nothing to say why.

The floor is per backend, not per OS. hull's `vz-runner` targets macOS 14. The
`hvi` backend uses Apple's in-kernel interrupt controller, the `hv_gic_*` calls,
which shipped in macOS 15, and six of the eight shipped profiles ask for `hvi`.
So the default first run on macOS 14 dies at boot with an unnamed missing
symbol.

Two commits: a preflight that turns that crash into a sentence, and the matrix.

## Related issues

Closes #20
Closes #4

## Changes

- **Preflight.** At the top of `EnsureRunning`, before the workspace is prepared
  or an image pulled, an `hvi` run on macOS older than 15 is refused with:

  ```
  brig: the hvi hypervisor needs macOS 15 or newer (this is 14.5): its in-kernel interrupt controller does not exist here. Set BRIG_HYPERVISOR=vz for this run, or upgrade macOS.
  ```

  The version comes from the `kern.osproductversion` sysctl, one standard
  library call with no subprocess, behind a seam the test sets. It does not
  fall back to `vz` on its own: the profile asked for `hvi` for a reason, and a
  downgrade nobody chose is the outcome to avoid. Tests: 14.5 refuses `hvi` and
  lets `vz` through; 15.0 lets `hvi` through.
- **`docs/support.md`.** Per platform: host OS and minimum version per backend,
  architecture, runtime and versions known to work, which hull pins a verified
  digest, and what CI actually exercises, stated plainly: CI runs on Linux and
  cross-compiles for macOS, and the macOS boot is not exercised in CI. Every
  cell says whether it is tested, expected to work, or known not to work, and
  six cells say unknown rather than guess. Includes the note that `brew trust`
  needs a Homebrew version that has it.
- One README Documentation link.

## Checklist

- [x] `make all` passes (vet, test, build)
- [x] `script/smoke.sh` passes
- [x] I have added or updated tests covering the change
- [x] I have run `go test ./... -race`, if the change touches concurrency, subprocesses or the daemon
- [x] I have exercised the change against a real runtime (`brig run <agent>`), if it touches the run, exec or credential path
- [x] I have updated the affected docs (README, `docs/security.md`, `docs/profiles.md`, `docs/brigd.md`)

Both cross-compiles build. The refusal has not been seen on a real macOS 14
machine; the reporter of #4 is the person who can confirm it reads right.

## Credentials and the sandbox boundary

No change to either promise. The preflight refuses before anything is created,
so a machine below the floor leaves no half-made workspace behind.
