### PR TITLE
fix(cli): refuse stray arguments, keep BRIG_NAME visible, answer without a runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -543,7 +543,7 @@ Booleans are shell-style: anything except `0` is on.
 | variable | default | what it does |
 | --- | --- | --- |
 | `BRIG_WORKSPACE` | `~/brig/<agent>` | Host directory mounted as the guest home. A named session appends `-<slug>` |
-| `BRIG_NAME` | `brig-<agent>` | Sandbox (VM or container) name. A named session appends `-<slug>` |
+| `BRIG_NAME` | `brig-<agent>` | Sandbox (VM or container) name; must begin with `brig-`. A named session appends `-<slug>` |
 | `BRIG_PROFILE_DIR` | `~/.config/brig` | Where custom profiles are read from and written to (`BRIG_TEMPLATE_DIR` still works) |
 | `BRIG_STATE_DIR` | `~/.brig` | Where brig keeps what has to outlive one command, including the workspace each sandbox was started with. Bookkeeping only: an unusable file there costs a restart, never a failed command |
 

--- a/cmd/brig/hygiene_test.go
+++ b/cmd/brig/hygiene_test.go
@@ -1,0 +1,102 @@
+package main
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+// An unknown flag standing where brig's own flags go, before the profile is
+// named, is refused rather than forwarded. Forwarding it consumed the profile
+// as the flag's value and left the line reporting that the profile was missing,
+// blaming the one word on it that was right.
+func TestParseRefusesUnknownFlagBeforeProfile(t *testing.T) {
+	for _, args := range [][]string{
+		{"--nope", "claude"},
+		{"--dry-run", "claude"},
+		{"-x", "claude"},
+	} {
+		_, _, _, err := parse(args)
+		if err == nil {
+			t.Errorf("parse(%q) was accepted", args)
+			continue
+		}
+		var ue *usageError
+		if !errors.As(err, &ue) {
+			t.Errorf("parse(%q): %v, want a usageError", args, err)
+		}
+		if !strings.Contains(err.Error(), args[0]) {
+			t.Errorf("parse(%q): %v, want it to name %q", args, err, args[0])
+		}
+	}
+}
+
+// The same flag once the profile is named is the agent's, and still passes
+// through. This is the line the refusal above must not break.
+func TestParseKeepsUnknownFlagAfterProfileForTheAgent(t *testing.T) {
+	_, name, tail, err := parse([]string{"claude", "--nope"})
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if name != "claude" || strings.Join(tail, " ") != "--nope" {
+		t.Errorf("parse = (%q, %q), want (claude, --nope)", name, tail)
+	}
+}
+
+// The verbs that take a profile and nothing more refuse a stray argument
+// instead of discarding it. The ones that consume a tail keep it.
+func TestRejectTail(t *testing.T) {
+	for _, verb := range []string{"create", "stop", "rm", "env"} {
+		err := rejectTail(verb, []string{"extra"})
+		if err == nil {
+			t.Errorf("rejectTail(%q, extra) was accepted", verb)
+			continue
+		}
+		var ue *usageError
+		if !errors.As(err, &ue) {
+			t.Errorf("rejectTail(%q): %v, want a usageError", verb, err)
+		}
+		if !strings.Contains(err.Error(), "extra") {
+			t.Errorf("rejectTail(%q): %v, want it to name the token", verb, err)
+		}
+	}
+	for _, verb := range []string{"run", "shell", "exec"} {
+		if err := rejectTail(verb, []string{"-p", "hi"}); err != nil {
+			t.Errorf("rejectTail(%q) refused an agent tail: %v", verb, err)
+		}
+	}
+	// No tail is fine for every verb.
+	for _, verb := range []string{"create", "stop", "rm", "env", "run", "shell", "exec"} {
+		if err := rejectTail(verb, nil); err != nil {
+			t.Errorf("rejectTail(%q, nil): %v", verb, err)
+		}
+	}
+}
+
+// ls and reset name no profile and take no flags, so an argument is a token
+// they would read and drop. reset is the sharp one: `brig reset --dry-run`
+// reads like a preview and removes everything, so it must refuse before it
+// reaches the runtime.
+func TestLsAndResetRefuseArguments(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		fn   func([]string) error
+		args []string
+	}{
+		{"ls", listSandboxes, []string{"claude"}},
+		{"reset", reset, []string{"--dry-run"}},
+	} {
+		err := tc.fn(tc.args)
+		if err == nil {
+			t.Errorf("%s(%q) was accepted", tc.name, tc.args)
+			continue
+		}
+		var ue *usageError
+		if !errors.As(err, &ue) {
+			t.Errorf("%s(%q): %v, want a usageError", tc.name, tc.args, err)
+		}
+		if !strings.Contains(err.Error(), tc.args[0]) {
+			t.Errorf("%s(%q): %v, want it to name %q", tc.name, tc.args, err, tc.args[0])
+		}
+	}
+}

--- a/cmd/brig/main.go
+++ b/cmd/brig/main.go
@@ -95,9 +95,28 @@ settings (BRIG_<AGENT>_<KEY> wins over BRIG_<KEY>; see the README for all):
 func main() {
 	if err := run(os.Args[1:]); err != nil {
 		fmt.Fprintln(os.Stderr, "brig: "+err.Error())
+		// A mistake in how the command was typed exits 2, the conventional
+		// usage-error code, kept apart from 1 so a script can tell "you asked
+		// for the wrong thing" from "it ran and failed". A run that stops and
+		// removes nothing because it was refused must not read as success.
+		var ue *usageError
+		if errors.As(err, &ue) {
+			os.Exit(2)
+		}
 		os.Exit(1)
 	}
 }
+
+// usageError is a command that was typed wrong: an unknown flag, a stray
+// argument, a token in a place nothing consumes it. It carries the exit code
+// apart from an ordinary failure, and its message names the token at fault so
+// the reader knows which word to fix.
+type usageError struct{ msg string }
+
+func (e *usageError) Error() string { return e.msg }
+
+// usagef builds a usageError the way fmt.Errorf builds an ordinary one.
+func usagef(format string, a ...any) error { return &usageError{fmt.Sprintf(format, a...)} }
 
 func run(args []string) error {
 	if len(args) == 0 {
@@ -151,9 +170,9 @@ func run(args []string) error {
 		}
 		return profileCmd(rest)
 	case "ls":
-		return listSandboxes()
+		return listSandboxes(rest)
 	case "reset":
-		return reset()
+		return reset(rest)
 	case "run", "create", "exec", "shell", "stop", "rm", "env":
 	default:
 		return fmt.Errorf("unknown command %q (try `brig help`)", verb)
@@ -161,6 +180,9 @@ func run(args []string) error {
 
 	opts, profileName, tail, err := parse(rest)
 	if err != nil {
+		return err
+	}
+	if err := rejectTail(verb, tail); err != nil {
 		return err
 	}
 	t, ok := profile.Lookup(profileName)
@@ -328,25 +350,38 @@ func ours(arg string) (mine bool, takesValue bool) {
 // unrecognised flag is not a mistake but the agent's -- `brig run claude -p hi`
 // runs the agent with -p hi. So the boundary is decided here, from the table,
 // and the flag package parses what is left of it.
-func split(args []string) (mine []string, profileName string, tail []string) {
+func split(args []string) (mine []string, profileName string, tail []string, err error) {
 	for i := 0; i < len(args); i++ {
 		a := args[i]
 		switch {
 		case a == "--":
 			// An explicit end to brig's parsing, so an agent argument spelled
 			// like one of brig's flags still reaches the agent.
-			return mine, profileName, args[i+1:]
+			return mine, profileName, args[i+1:], nil
 		case !strings.HasPrefix(a, "-"):
 			if profileName == "" {
 				profileName = a
 				continue
 			}
 			// A second bare word is the agent's command, not a second profile.
-			return mine, profileName, args[i:]
+			return mine, profileName, args[i:], nil
 		default:
 			isOurs, takesValue := ours(a)
 			if !isOurs {
-				return mine, profileName, args[i:]
+				// An unknown flag once the profile is named is the agent's:
+				// `brig run claude --resume` runs the agent with --resume, and
+				// brig forwards everything from here on. Before the profile is
+				// named there is no agent yet to own it, so a flag brig does not
+				// recognise in that position is not passed through -- it is a
+				// brig flag that does not exist. Forwarding it would make the
+				// profile look like the flag's value and leave the line blaming
+				// the one word on it that was right, so refuse it and name it.
+				if profileName == "" {
+					return nil, "", nil, usagef("unknown flag %q before the profile name. "+
+						"brig's own flags come before the profile and the agent's after it; "+
+						"put %q after the profile to pass it through, or -- to end brig's flags", a, a)
+				}
+				return mine, profileName, args[i:], nil
 			}
 			mine = append(mine, a)
 			if takesValue && i+1 < len(args) {
@@ -358,14 +393,36 @@ func split(args []string) (mine []string, profileName string, tail []string) {
 			}
 		}
 	}
-	return mine, profileName, nil
+	return mine, profileName, nil, nil
+}
+
+// rejectTail refuses a token a verb has no use for, rather than dropping it.
+//
+// run forwards the tail to the agent, and shell and exec turn it into the guest
+// command, so those keep whatever follows the profile. create, stop, rm and env
+// take a profile and nothing after it: a word left there is a mistake to name,
+// not an operand to swallow. create is grouped with the others rather than with
+// run because it does not attach -- split hands it the same agent tail run gets,
+// but there is no agent here to receive it, so a tail is still a mistake.
+func rejectTail(verb string, tail []string) error {
+	switch verb {
+	case "run", "shell", "exec":
+		return nil
+	}
+	if len(tail) > 0 {
+		return usagef("unexpected argument %q; `brig %s` takes a profile and nothing more", tail[0], verb)
+	}
+	return nil
 }
 
 // parse reads brig's own flags off the run line in any order and leaves
 // whatever remains for the agent. split decides where brig's arguments end;
 // the flag package turns them into values.
 func parse(args []string) (o options, profileName string, tail []string, err error) {
-	mine, profileName, tail := split(args)
+	mine, profileName, tail, err := split(args)
+	if err != nil {
+		return options{}, "", nil, err
+	}
 
 	fs := flag.NewFlagSet("brig", flag.ContinueOnError)
 	// The flag package's own output is a usage dump on every error. brig's
@@ -518,7 +575,14 @@ func spell(name string) string {
 // listSandboxes shows what is running, and what is merely holding a name. A
 // stopped sandbox still owns its name, which is exactly the thing to see
 // before wondering why a name is taken.
-func listSandboxes() error {
+func listSandboxes(args []string) error {
+	// ls names no profile and takes no flags, so anything here is a token it
+	// would otherwise read and discard -- `brig ls claude` looks like it filters
+	// to one profile and does not. Refuse it rather than answer a question that
+	// was not asked.
+	if len(args) > 0 {
+		return usagef("unexpected argument %q; `brig ls` takes no arguments", args[0])
+	}
 	rt, err := runtime.Detect()
 	if err != nil {
 		return err
@@ -587,7 +651,17 @@ func workspaceOf(vmName string, rt runtime.Runtime) string {
 // reset stops and removes every sandbox brig started. Workspaces are left
 // alone: they are on the host, they hold your work, and this is a command
 // about sandboxes.
-func reset() error {
+func reset(args []string) error {
+	// reset stops and removes every brig sandbox, so a flag typed to make it
+	// safer -- `brig reset --dry-run` -- must not be read past and ignored,
+	// which is exactly how a command meant to preview ends up removing
+	// everything. It has no flags and no operands today; refuse anything here so
+	// a flag that gains a meaning later is one this release declined rather than
+	// silently swallowed.
+	if len(args) > 0 {
+		return usagef("unexpected argument %q; `brig reset` takes no arguments and removes "+
+			"every brig sandbox", args[0])
+	}
 	rt, err := runtime.Detect()
 	if err != nil {
 		return err

--- a/cmd/brig/main.go
+++ b/cmd/brig/main.go
@@ -30,8 +30,10 @@ import (
 var version = "dev"
 
 // sandboxPrefix is how brig recognises its own sandboxes in a runtime that
-// may be running other things.
-const sandboxPrefix = "brig-"
+// may be running other things. It is the same mark wrap stamps onto every
+// sandbox name, taken from there so the two cannot drift: ls and reset select
+// on exactly what Load refuses to let BRIG_NAME drop.
+const sandboxPrefix = wrap.NamePrefix
 
 const usage = `brig -- run a coding agent in a sandbox
 

--- a/cmd/brig/main.go
+++ b/cmd/brig/main.go
@@ -206,7 +206,22 @@ func run(args []string) error {
 
 	rt, err := runtime.DetectFor(runtime.Preference{Bin: t.RuntimeBin})
 	if err != nil {
-		return err
+		// brig env is the report worth giving when the runtime is the thing
+		// that is broken: only one of its lines comes from the runtime, and the
+		// person most likely to run it is the one whose runtime is not on PATH.
+		// So env carries on without one, and Status marks that single line
+		// unavailable. Every other verb needs the runtime to do its work, so
+		// they still fail here, naming what is missing.
+		//
+		// But only "no runtime on PATH" is a state env should paper over. An
+		// unknown BRIG_RUNTIME or a runtimeBin that is not there is a mistake to
+		// fix, and env is the verb people run to find it -- so those surface
+		// here as they do for run, naming the real cause. Match the sentinel,
+		// not any error, or a future error type silently rejoins the swallow.
+		if verb != "env" || !errors.Is(err, runtime.ErrNoRuntime) {
+			return err
+		}
+		rt = nil
 	}
 	cfg, err := wrap.Load(t, opts.load, rt)
 	if err != nil {
@@ -587,7 +602,25 @@ func listSandboxes(args []string) error {
 	}
 	rt, err := runtime.Detect()
 	if err != nil {
-		return err
+		if !errors.Is(err, runtime.ErrNoRuntime) {
+			// An unknown BRIG_RUNTIME is a mistake, not an empty list: reading a
+			// typo as "you have no sandboxes" hides it. Fail with the value
+			// named, exactly as run does, rather than answering a question that
+			// was not asked.
+			return err
+		}
+		// No runtime on PATH means nothing is running and nothing is holding a
+		// name: there is nothing to list. Answer the question that was asked --
+		// there are no sandboxes -- and exit 0, rather than failing a read-only
+		// query with the error of the thing it would have queried.
+		// Print the same header the runtime-present empty case does, so the
+		// shape of `brig ls` does not change with the runtime, and surface the
+		// platform-specific way to get one -- the hint run gives -- so a fresh
+		// box is told how rather than only that there is nothing.
+		fmt.Printf("%-28s %-10s %s\n", "SANDBOX", "STATE", "WORKSPACE")
+		fmt.Println("(none -- no runtime found on PATH, so there are no sandboxes)")
+		fmt.Printf("  %s\n", strings.TrimPrefix(err.Error(), "no runtime found on PATH: "))
+		return nil
 	}
 	list, err := rt.List()
 	if err != nil {

--- a/cmd/brig/runtime_guard_test.go
+++ b/cmd/brig/runtime_guard_test.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/brig-sh/brig/internal/profile"
+)
+
+// emptyPath points PATH at a directory with no runtime in it, so LookPath finds
+// neither hull nor nerdctl and DetectFor returns the not-found sentinel. This
+// is the only detection failure env and ls are allowed to paper over.
+func emptyPath(t *testing.T) {
+	t.Helper()
+	t.Setenv("PATH", t.TempDir())
+	t.Setenv("BRIG_RUNTIME_BIN", "")
+}
+
+// env touches the runtime for one line of its report, so with no runtime on
+// PATH it degrades: exit 0, that line marked unavailable. But an unknown
+// BRIG_RUNTIME is a mistake to fix, not a missing install, and env is the verb
+// people run to diagnose exactly that -- so it must surface the same message
+// run gives, with a non-zero (here non-nil) result, not swallow it as "no
+// runtime found".
+func TestEnvSurfacesUnknownRuntime(t *testing.T) {
+	t.Setenv("BRIG_PROFILE_DIR", t.TempDir())
+	t.Setenv("BRIG_RUNTIME", "podman")
+
+	err := run([]string{"env", "claude-code"})
+	if err == nil {
+		t.Fatal("brig env with an unknown BRIG_RUNTIME was accepted")
+	}
+	if want := `unknown BRIG_RUNTIME "podman" (want hull or nerdctl)`; !strings.Contains(err.Error(), want) {
+		t.Errorf("env error = %v, want it to name the bad value: %q", err, want)
+	}
+}
+
+// ls asks the runtime what exists, and with none installed the honest answer is
+// nothing. An unknown BRIG_RUNTIME is a different thing: reading a typo as "you
+// have no sandboxes" hides the mistake, so it fails with the value named,
+// exactly as run does.
+func TestLsSurfacesUnknownRuntime(t *testing.T) {
+	t.Setenv("BRIG_PROFILE_DIR", t.TempDir())
+	t.Setenv("BRIG_RUNTIME", "podman")
+
+	err := listSandboxes(nil)
+	if err == nil {
+		t.Fatal("brig ls with an unknown BRIG_RUNTIME was accepted")
+	}
+	if want := `unknown BRIG_RUNTIME "podman" (want hull or nerdctl)`; !strings.Contains(err.Error(), want) {
+		t.Errorf("ls error = %v, want it to name the bad value: %q", err, want)
+	}
+}
+
+// A profile whose runtimeBin points nowhere is a misconfiguration, not a
+// missing runtime. env is the verb run to find that out, so it names the bad
+// path rather than exiting 0 with the runtime line marked unavailable, which
+// would blame the wrong cause.
+func TestEnvSurfacesMissingRuntimeBin(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("BRIG_PROFILE_DIR", dir)
+	t.Setenv("BRIG_RUNTIME", "hull")
+	t.Setenv("BRIG_RUNTIME_BIN", "")
+	missing := filepath.Join(t.TempDir(), "hull")
+	body := "name: pinned\nimage: i\nguestHome: /home/pinned\nbinary: m\nmem: 1\ncpus: 1\n" +
+		"runtimeBin: " + missing + "\n"
+	if err := os.WriteFile(filepath.Join(dir, "pinned.yaml"), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// run reloads profiles from BRIG_PROFILE_DIR, but load the file here too so a
+	// failure to parse it surfaces as a test error rather than a missing profile.
+	if err := profile.Load(profile.Dir()); err != nil {
+		t.Fatal(err)
+	}
+
+	err := run([]string{"env", "pinned"})
+	if err == nil {
+		t.Fatal("brig env with a missing runtimeBin was accepted")
+	}
+	if !strings.Contains(err.Error(), "runtimeBin") || !strings.Contains(err.Error(), missing) {
+		t.Errorf("env error = %v, want it to name the bad runtimeBin %q", err, missing)
+	}
+}
+
+// With genuinely no runtime on PATH, ls answers the question that was asked --
+// there are no sandboxes -- and exits 0, rather than failing a read-only query
+// with the error of the thing it would have queried. This is the one case the
+// guard is allowed to swallow, and it keys off the sentinel to do it.
+func TestLsWithoutARuntimeSaysNothingToList(t *testing.T) {
+	t.Setenv("BRIG_PROFILE_DIR", t.TempDir())
+	t.Setenv("BRIG_RUNTIME", "")
+	emptyPath(t)
+
+	if err := listSandboxes(nil); err != nil {
+		t.Errorf("ls with no runtime on PATH failed instead of listing nothing: %v", err)
+	}
+}

--- a/internal/runtime/hull.go
+++ b/internal/runtime/hull.go
@@ -30,9 +30,9 @@ func newHull(bin string) (Runtime, error) {
 	if p, err := exec.LookPath("hull"); err == nil {
 		return &hull{bin: p}, nil
 	}
-	return nil, fmt.Errorf("no microVM runtime found on PATH. brig drives hull " +
-		"on macOS: see https://github.com/brig-sh/brig#macos. " +
-		"Or point BRIG_RUNTIME_BIN at a build")
+	return nil, fmt.Errorf("%w: brig drives hull on macOS, and none was there. "+
+		"See https://github.com/brig-sh/brig#macos, "+
+		"or point BRIG_RUNTIME_BIN at a build", ErrNoRuntime)
 }
 
 func (h *hull) Kind() string { return "hull" }

--- a/internal/runtime/nerdctl.go
+++ b/internal/runtime/nerdctl.go
@@ -42,8 +42,8 @@ func newNerdctl(bin string) (Runtime, error) {
 			return &nerdctl{bin: p}, nil
 		}
 	}
-	return nil, fmt.Errorf("no container runtime found: install nerdctl, " +
-		"or point BRIG_RUNTIME_BIN at one")
+	return nil, fmt.Errorf("%w: install nerdctl, "+
+		"or point BRIG_RUNTIME_BIN at one", ErrNoRuntime)
 }
 
 func (n *nerdctl) Kind() string { return "nerdctl" }

--- a/internal/runtime/preference_test.go
+++ b/internal/runtime/preference_test.go
@@ -1,6 +1,7 @@
 package runtime
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -71,6 +72,47 @@ func TestDetectForRefusesADirectoryAsRuntimeBin(t *testing.T) {
 
 	if _, err := DetectFor(Preference{Bin: t.TempDir()}); err == nil {
 		t.Fatal("expected a directory to be refused")
+	}
+}
+
+// Only "no runtime binary on PATH" carries ErrNoRuntime. That is the seam env
+// and ls degrade on -- exit 0, report what they can -- so an unknown
+// BRIG_RUNTIME and a runtimeBin that is not there must NOT match it, or those
+// mistakes would be swallowed as "nothing installed". This test is what stops a
+// future change to the error type or message from silently widening that
+// swallow: it asserts the sentinel is the seam, not "err != nil".
+func TestDetectForSentinelMarksOnlyTheMissingRuntime(t *testing.T) {
+	t.Setenv("BRIG_RUNTIME_BIN", "")
+
+	// No runtime on PATH: LookPath finds nothing, so both backends report the
+	// sentinel.
+	t.Setenv("PATH", t.TempDir())
+	for _, kind := range []string{"hull", "nerdctl"} {
+		t.Setenv("BRIG_RUNTIME", kind)
+		_, err := DetectFor(Preference{})
+		if err == nil {
+			t.Fatalf("BRIG_RUNTIME=%s with an empty PATH was accepted", kind)
+		}
+		if !errors.Is(err, ErrNoRuntime) {
+			t.Errorf("BRIG_RUNTIME=%s: %v does not match ErrNoRuntime", kind, err)
+		}
+	}
+
+	// An unknown BRIG_RUNTIME is a mistake, not a missing install.
+	t.Setenv("BRIG_RUNTIME", "podman")
+	if _, err := DetectFor(Preference{}); errors.Is(err, ErrNoRuntime) {
+		t.Errorf("unknown BRIG_RUNTIME matched ErrNoRuntime, so env/ls would swallow it: %v", err)
+	}
+
+	// A runtimeBin that is not there is a misconfiguration, not a missing
+	// install.
+	t.Setenv("BRIG_RUNTIME", "hull")
+	_, err := DetectFor(Preference{Bin: filepath.Join(t.TempDir(), "not-there")})
+	if err == nil {
+		t.Fatal("a missing runtimeBin was accepted")
+	}
+	if errors.Is(err, ErrNoRuntime) {
+		t.Errorf("a bad runtimeBin matched ErrNoRuntime, so env/ls would swallow it: %v", err)
 	}
 }
 

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -10,12 +10,23 @@
 package runtime
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"os"
 	"path/filepath"
 	"strings"
 )
+
+// ErrNoRuntime is the one DetectFor failure that means "nothing is installed"
+// rather than "you asked for the wrong thing": no runtime binary was on PATH
+// and none was pinned. env and ls degrade to it -- report what they can and
+// exit 0 -- and they must key off this with errors.Is, never off "err != nil".
+// An unknown BRIG_RUNTIME or a runtimeBin that is not there is a mistake to
+// fix, and env is the verb people run to find it, so those still surface with a
+// non-zero exit even there. Matching the sentinel rather than any error is what
+// stops the day the message or type changes from silently widening the swallow.
+var ErrNoRuntime = errors.New("no runtime found on PATH")
 
 // Share is a host directory made visible in the guest.
 type Share struct {

--- a/internal/wrap/config.go
+++ b/internal/wrap/config.go
@@ -16,6 +16,12 @@ import (
 	"github.com/brig-sh/brig/internal/verify"
 )
 
+// NamePrefix is what every brig sandbox name begins with. It is how brig picks
+// its own sandboxes out of a runtime that may be running other things, so it is
+// the one part of the name that is not the caller's to drop -- see the BRIG_NAME
+// check in Load. cmd/brig reads the same prefix back when it lists and resets.
+const NamePrefix = "brig-"
+
 // Config is everything a run needs, resolved once.
 type Config struct {
 	Profile profile.Profile
@@ -133,7 +139,20 @@ func Load(t profile.Profile, o Options, rt runtime.Runtime) (*Config, error) {
 
 	// The sandbox name is settled first because the workspace may be read back
 	// from an index keyed by it. See index.go.
-	vmName := env.String("NAME", "brig-"+t.Name)
+	vmName := env.String("NAME", NamePrefix+t.Name)
+	// BRIG_NAME replaces the whole sandbox name, and brig finds its own
+	// sandboxes by the brig- prefix: ls lists what carries it and reset removes
+	// what carries it. A name set through BRIG_NAME without the prefix boots and
+	// runs fine and is then invisible to both -- a sandbox brig started that it
+	// can no longer see or clean up. Refuse it at creation and say what it must
+	// carry, rather than track brig's own sandboxes through some second channel:
+	// the runtime hands back only the name `ps` prints, so the prefix is the one
+	// mark that survives a stop, a reboot and a brig that has forgotten it ever
+	// ran. See sandboxPrefix in cmd/brig, which reads the same mark back.
+	if !strings.HasPrefix(vmName, NamePrefix) {
+		return nil, fmt.Errorf("BRIG_NAME is %q, but a brig sandbox name must begin with %q so that "+
+			"`brig ls` and `brig reset` can find it; use %q instead", vmName, NamePrefix, NamePrefix+vmName)
+	}
 	if slug != "" {
 		vmName += "-" + slug
 	}

--- a/internal/wrap/load_test.go
+++ b/internal/wrap/load_test.go
@@ -2,6 +2,7 @@ package wrap
 
 import (
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/brig-sh/brig/internal/profile"
@@ -27,6 +28,41 @@ func bound(c *Config, name string) bool {
 		}
 	}
 	return false
+}
+
+// BRIG_NAME replaces the whole sandbox name, and ls and reset find brig's own
+// sandboxes by the brig- prefix. A name without it boots and runs but is
+// invisible to both, so it is refused at creation with a message naming the
+// constraint -- the alternative to tracking the sandbox by a mark the runtime
+// does not hand back.
+func TestBrigNameMustCarryThePrefix(t *testing.T) {
+	p, ok := profile.Lookup("claude-code")
+	if !ok {
+		t.Fatal("no claude-code profile")
+	}
+
+	t.Setenv("BRIG_NAME", "custom")
+	_, err := Load(p, Options{}, nil)
+	if err == nil {
+		t.Fatal("Load accepted a BRIG_NAME without the brig- prefix")
+	}
+	if !strings.Contains(err.Error(), NamePrefix) {
+		t.Errorf("Load error %q does not name the required prefix %q", err, NamePrefix)
+	}
+
+	// The same name with the prefix is accepted and stamped onto the sandbox
+	// verbatim, so ls and reset select it the way they select any other.
+	t.Setenv("BRIG_NAME", "brig-custom")
+	c, err := Load(p, Options{}, nil)
+	if err != nil {
+		t.Fatalf("Load refused a prefixed BRIG_NAME: %v", err)
+	}
+	if c.VMName != "brig-custom" {
+		t.Errorf("VMName = %q, want brig-custom", c.VMName)
+	}
+	if !strings.HasPrefix(c.VMName, NamePrefix) {
+		t.Errorf("VMName = %q, which ls and reset would not find", c.VMName)
+	}
 }
 
 // --workspace was made absolute and BRIG_WORKSPACE was not, so one exported

--- a/internal/wrap/status.go
+++ b/internal/wrap/status.go
@@ -16,7 +16,16 @@ func (c *Config) Status(set creds.Set) {
 	} else {
 		c.sayf("workspace %s (sandbox %s)", c.Workspace, c.VMName)
 	}
-	c.sayf("runtime %s (%s)", c.Runtime.Kind(), c.Runtime.Bin())
+	// The runtime is the one line here that needs a runtime. When none is on
+	// PATH env still reports the rest -- the profile, the environment, the host
+	// git config -- and marks this line unavailable rather than failing the
+	// whole report, because the person reading it is often the one whose runtime
+	// is what broke.
+	if c.Runtime != nil {
+		c.sayf("runtime %s (%s)", c.Runtime.Kind(), c.Runtime.Bin())
+	} else {
+		c.sayf("runtime unavailable (no runtime found on PATH)")
+	}
 	c.sayf("image %s (pull %s)", c.Image, c.Pull)
 
 	names := credentialNames(set)

--- a/internal/wrap/status_test.go
+++ b/internal/wrap/status_test.go
@@ -34,6 +34,26 @@ func statusOutput(t *testing.T, body string, set creds.Set) string {
 	return out.String()
 }
 
+// With no runtime on PATH, env reports what it can and marks the one line that
+// needs a runtime unavailable, rather than failing the whole report -- the
+// reader is often the one whose runtime is what broke.
+func TestStatusReportsWithoutARuntime(t *testing.T) {
+	c := bindingConfig(t, credentialProfile)
+	out := &bytes.Buffer{}
+	c.Out = out
+	c.Runtime = nil // no runtime detected
+	c.Status(creds.Set{})
+	got := out.String()
+	if !strings.Contains(got, "runtime unavailable") {
+		t.Errorf("the runtime line was not marked unavailable:\n%s", got)
+	}
+	// The rest of the report is still there: the profile's image is knowable
+	// without a runtime, and is the kind of line env exists to print.
+	if !strings.Contains(got, "image ") {
+		t.Errorf("the report dropped the lines it could still give:\n%s", got)
+	}
+}
+
 // Set.Names annotates a store-sourced variable as "TOK(secret)", the way it
 // already annotates the host credential's as "TOK(host)". An exact-string
 // check against the bare name misses it, and because a secret-bound run

--- a/script/smoke.sh
+++ b/script/smoke.sh
@@ -348,6 +348,35 @@ rc=$?
   || bad "a corrupt index failed the run -- got: $(cat "$WORK/corrupt.out")"
 "$WORK/brig" reset > /dev/null 2>&1
 
+echo "== argument hygiene =="
+# A flag typed to make a destructive command safe must not be read past and
+# ignored. reset has no flags today, so --dry-run is refused (exit 2) and
+# removes nothing rather than stopping every sandbox.
+"$WORK/brig" run claude -d > /dev/null 2>&1
+: > "$STUB_LOG"
+"$WORK/brig" reset --dry-run > "$WORK/dry.out" 2>&1; rc=$?
+[ "$rc" = 2 ] && ok "reset --dry-run exits 2" || bad "reset --dry-run exits 2 -- got $rc"
+grep -q -- '--dry-run' "$WORK/dry.out" \
+  && ok "reset --dry-run names the token" || bad "reset --dry-run names the token"
+grep -q '^argv: rm ' "$STUB_LOG" \
+  && bad "reset --dry-run removed a sandbox" || ok "reset --dry-run removes nothing"
+"$WORK/brig" reset > /dev/null 2>&1
+
+# An unknown flag to the left of the profile is refused and named, rather than
+# consuming the profile and blaming it for being absent.
+out="$("$WORK/brig" run --nope claude 2>&1)"; rc=$?
+[ "$rc" = 2 ] && ok "run --nope claude exits 2" || bad "run --nope claude exits 2 -- got $rc"
+case "$out" in
+  *--nope*) ok "run --nope claude names the flag" ;;
+  *) bad "run --nope claude names the flag -- got: $out" ;;
+esac
+
+# A verb that takes a profile and nothing more refuses a stray argument.
+out="$("$WORK/brig" ls claude 2>&1)"; rc=$?
+[ "$rc" = 2 ] && ok "ls refuses an argument" || bad "ls refuses an argument -- got $rc: $out"
+out="$("$WORK/brig" stop claude extra 2>&1)"; rc=$?
+[ "$rc" = 2 ] && ok "stop refuses a stray argument" || bad "stop refuses a stray argument -- got $rc: $out"
+
 echo "== flags =="
 : > "$STUB_LOG"
 "$WORK/brig" run claude -t ghcr.io/me/img:latest -w "$WORK/other" -m 8192 --cpus 2 -d \

--- a/script/smoke.sh
+++ b/script/smoke.sh
@@ -400,6 +400,32 @@ case "$out" in
   *brig-*) ok "the refusal names the required prefix" ;;
   *) bad "the refusal names the required prefix -- got: $out" ;;
 esac
+"$WORK/brig" reset > /dev/null 2>&1
+
+echo "== no runtime =="
+# With no runtime on PATH, env still reports what is knowable and marks only the
+# runtime line unavailable, and ls answers that there is nothing to list. Both
+# exit 0: the person most likely to run them is the one whose runtime is broken.
+out="$(PATH="" BRIG_RUNTIME_BIN= "$WORK/brig" env claude 2>&1)"; rc=$?
+[ "$rc" = 0 ] && ok "env with no runtime exits 0" || bad "env with no runtime exits 0 -- got $rc: $out"
+case "$out" in
+  *"runtime unavailable"*) ok "env marks the runtime line unavailable" ;;
+  *) bad "env marks the runtime line unavailable -- got: $out" ;;
+esac
+case "$out" in
+  *"image "*) ok "env still reports the lines it can" ;;
+  *) bad "env still reports the lines it can -- got: $out" ;;
+esac
+out="$(PATH="" BRIG_RUNTIME_BIN= "$WORK/brig" ls 2>&1)"; rc=$?
+[ "$rc" = 0 ] && ok "ls with no runtime exits 0" || bad "ls with no runtime exits 0 -- got $rc: $out"
+case "$out" in
+  *none*) ok "ls with no runtime says there is nothing to list" ;;
+  *) bad "ls with no runtime says there is nothing to list -- got: $out" ;;
+esac
+case "$out" in
+  *BRIG_RUNTIME_BIN*) ok "ls with no runtime points at getting one" ;;
+  *) bad "ls with no runtime points at getting one -- got: $out" ;;
+esac
 
 echo "== flags =="
 : > "$STUB_LOG"

--- a/script/smoke.sh
+++ b/script/smoke.sh
@@ -377,6 +377,30 @@ out="$("$WORK/brig" ls claude 2>&1)"; rc=$?
 out="$("$WORK/brig" stop claude extra 2>&1)"; rc=$?
 [ "$rc" = 2 ] && ok "stop refuses a stray argument" || bad "stop refuses a stray argument -- got $rc: $out"
 
+echo "== BRIG_NAME =="
+"$WORK/brig" reset > /dev/null 2>&1
+# A name set through BRIG_NAME still carries the prefix, so ls lists it and
+# reset removes it the way they do any brig sandbox.
+BRIG_NAME=brig-custom "$WORK/brig" run claude -d > /dev/null 2>&1
+listing="$("$WORK/brig" ls 2>/dev/null)"
+case "$listing" in
+  *brig-custom*) ok "a BRIG_NAME sandbox appears in ls" ;;
+  *) bad "a BRIG_NAME sandbox appears in ls -- got: $listing" ;;
+esac
+: > "$STUB_LOG"
+"$WORK/brig" reset > /dev/null 2>&1
+grep -q '^argv: rm brig-custom' "$STUB_LOG" \
+  && ok "reset removes a BRIG_NAME sandbox" || bad "reset removes a BRIG_NAME sandbox"
+# A BRIG_NAME without the prefix would be invisible to both, so it is refused at
+# creation with a message naming the constraint.
+out="$(BRIG_NAME=custom "$WORK/brig" run claude -d 2>&1)"; rc=$?
+[ "$rc" != 0 ] && ok "a BRIG_NAME without the prefix is refused" \
+  || bad "a BRIG_NAME without the prefix is refused -- got $rc"
+case "$out" in
+  *brig-*) ok "the refusal names the required prefix" ;;
+  *) bad "the refusal names the required prefix -- got: $out" ;;
+esac
+
 echo "== flags =="
 : > "$STUB_LOG"
 "$WORK/brig" run claude -t ghcr.io/me/img:latest -w "$WORK/other" -m 8192 --cpus 2 -d \


### PR DESCRIPTION
## Summary

Three argument-handling defects in the CLI, fixed as three commits because they
touch the same functions in `cmd/brig/main.go`.

`brig reset --dry-run` removed every sandbox and exited 0, because `reset` never
read what followed it. An unknown flag to the left of the profile consumed the
profile, so `brig run --nope claude` blamed a missing profile. A sandbox named
through the documented `BRIG_NAME` was invisible to `ls` and immune to `reset`.
And `brig env` and `brig ls` failed outright with no runtime on PATH, though
`env` needed the runtime for one line of eight.

## Related issues

Closes #41
Closes #42
Closes #43

## Changes

- **#41.** A `usageError` type that `main` maps to exit 2, kept apart from exit
  1 so a script can tell a typo from a run that failed. `split` refuses an
  unknown flag left of the profile and names it; right of the profile is
  unchanged, so `brig run claude --resume` still reaches the agent. Each verb
  refuses a token it does not consume; `ls` and `reset` refuse any argument.
- **#42.** A `BRIG_NAME` without the `brig-` prefix is refused at creation,
  naming the constraint. The runtime hands back only the name `ps` prints, so
  there is no other label that survives a stop or a reboot; the prefix is the one
  durable mark `ls` and `reset` already select on, and it now lives in one place,
  `wrap.NamePrefix`, so what `reset` selects and what `Load` enforces cannot
  drift.
- **#43.** `env` carries on when no runtime is found and marks only the runtime
  line unavailable; `ls` says there is nothing to list. Both exit 0. Every other
  verb still fails there.
- Tests in `cmd/brig/hygiene_test.go`, `internal/wrap/load_test.go` and
  `status_test.go`, plus twelve smoke cases against the real binary.

Seen on the built binary here:

```
$ brig reset --dry-run
brig: unexpected argument "--dry-run"; `brig reset` takes no arguments and removes every brig sandbox
$ echo $?
2
$ brig run --nope claude
brig: unknown flag "--nope" before the profile name. brig's own flags come before the profile and the agent's after it; put "--nope" after the profile to pass it through, or -- to end brig's flags
$ brig ls        # no runtime on PATH
(none -- no runtime found on PATH, so there are no sandboxes)
$ echo $?
0
```

## Scope

The "every verb rejects what it does not consume" rule covers the sandbox
lifecycle verbs. `profiles`, `secret`, `export` and `import` have their own
subcommand parsing and were left as they are.

## Checklist

- [x] `make all` passes (vet, test, build)
- [x] `script/smoke.sh` passes
- [x] I have added or updated tests covering the change
- [x] I have run `go test ./... -race`, if the change touches concurrency, subprocesses or the daemon
- [x] I have exercised the change against a real runtime (`brig run <agent>`), if it touches the run, exec or credential path
- [ ] ~~I have updated the affected docs~~

## Credentials and the sandbox boundary

The `reset` change is the one that touches safety: a destructive verb no longer
silently ignores a flag typed to make it safe. #11 gives `--dry-run` a meaning;
this makes sure it cannot be swallowed in the meantime.
