### PR TITLE
fix(wrap): remember the workspace a sandbox was started with

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,15 @@ To drop the workspace too, remove the directory `brig env` prints. And
 `brig reset` stops and removes every brig sandbox at once, named ones
 included, leaving all workspaces alone.
 
+**`-w` is remembered.** A session created with `--workspace` keeps that
+directory for every later verb, so `brig exec claude --name refactor -- ls`
+finds it without repeating the flag. brig records the path a sandbox was
+started with under `~/.brig`, and reads it back when neither `--workspace` nor
+`BRIG_WORKSPACE` names one; `brig rm` and `brig reset` drop the entry with the
+sandbox. Pass either of them a directory that is not the one the sandbox is
+mounting and it restarts, as it always has -- a share cannot be moved on a
+running guest, and you asked for a different directory.
+
 ### If you know Docker Sandboxes (`sbx`)
 
 The verbs line up deliberately, so muscle memory carries over:
@@ -522,6 +531,7 @@ Booleans are shell-style: anything except `0` is on.
 | `BRIG_WORKSPACE` | `~/brig/<agent>` | Host directory mounted as the guest home. A named session appends `-<slug>` |
 | `BRIG_NAME` | `brig-<agent>` | Sandbox (VM or container) name. A named session appends `-<slug>` |
 | `BRIG_PROFILE_DIR` | `~/.config/brig` | Where custom profiles are read from and written to (`BRIG_TEMPLATE_DIR` still works) |
+| `BRIG_STATE_DIR` | `~/.brig` | Where brig keeps what has to outlive one command, including the workspace each sandbox was started with. Bookkeeping only: an unusable file there costs a restart, never a failed command |
 
 ### Image and guest
 

--- a/cmd/brig/main.go
+++ b/cmd/brig/main.go
@@ -543,9 +543,20 @@ func listSandboxes() error {
 	return nil
 }
 
-// workspaceOf recovers the workspace for a sandbox by asking the profile it
-// was named after. A sandbox brig did not name has none to report.
+// workspaceOf recovers the workspace for a sandbox: what it was started with
+// if brig recorded that, and otherwise the path the profile it was named after
+// would derive. A sandbox brig did not name has none to report.
+//
+// The recorded path wins over the derivation, and over an ambient
+// BRIG_WORKSPACE that the derivation would otherwise pick up. This column says
+// what a sandbox is mounting, not what a run started from this shell would
+// mount: a session created with -w has a directory neither of those two can
+// name, and reporting the derived one was reporting the wrong directory with
+// no sign that it was wrong.
 func workspaceOf(vmName string, rt runtime.Runtime) string {
+	if ws := wrap.RememberedWorkspace(vmName); ws != "" {
+		return ws
+	}
 	rest := strings.TrimPrefix(vmName, sandboxPrefix)
 	// Longest profile name first, so claude-code wins over a hypothetical
 	// claude when both could prefix-match.
@@ -591,7 +602,13 @@ func reset() error {
 			continue
 		}
 		_ = rt.Stop(inst.Name)
-		if err := rt.Remove(inst.Name); err != nil {
+		err := rt.Remove(inst.Name)
+		// The same pruning `brig rm` does, for the same reason and on the same
+		// terms: this goes through the runtime directly rather than through a
+		// Config, because reset works from the instance list and a stopped
+		// sandbox need not correspond to a profile brig can still look up.
+		wrap.ForgetWorkspace(inst.Name)
+		if err != nil {
 			fmt.Fprintf(os.Stderr, "brig: could not remove %s: %v\n", inst.Name, err)
 			continue
 		}

--- a/cmd/brig/main_test.go
+++ b/cmd/brig/main_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -299,5 +300,36 @@ func TestParseSkillsIsOptIn(t *testing.T) {
 	// After the agent's arguments start it is the agent's word, not brig's.
 	if o, _, _, _ = parse([]string{"claude", "-p", "hi", "--skills"}); o.load.Skills {
 		t.Error("--skills was read out of the agent's own arguments")
+	}
+}
+
+// `brig ls` reports what a sandbox is mounting, so the recorded workspace beats
+// the one derived from the sandbox name -- and beats an ambient BRIG_WORKSPACE
+// that the derivation would otherwise pick up. A session created with -w has a
+// directory neither of those can name, and the column used to show the derived
+// one with no sign that it was wrong.
+func TestWorkspaceOfPrefersTheRecordedWorkspace(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("BRIG_STATE_DIR", dir)
+	t.Setenv("BRIG_WORKSPACE", "/somewhere/else")
+
+	index := filepath.Join(dir, "workspaces.json")
+	body := `{"brig-claude-code-rc23test": "/private/tmp/ws-rc23"}`
+	if err := os.WriteFile(index, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	// The runtime is never reached: the recorded path answers the question
+	// before anything has to resolve a profile.
+	if got := workspaceOf("brig-claude-code-rc23test", nil); got != "/private/tmp/ws-rc23" {
+		t.Errorf("ls reported %q, want the workspace the session was created with", got)
+	}
+
+	// With nothing recorded, the derivation still answers, which is what a
+	// sandbox created before the index existed relies on.
+	if err := os.Remove(index); err != nil {
+		t.Fatal(err)
+	}
+	if got := workspaceOf("brig-claude-code", nil); got != "/somewhere/else" {
+		t.Errorf("ls reported %q for an unrecorded sandbox, want the derived path", got)
 	}
 }

--- a/cmd/brig/workspaceof_test.go
+++ b/cmd/brig/workspaceof_test.go
@@ -6,7 +6,12 @@ import "testing"
 // workspace of a session that happens to be called after the template is a
 // quiet lie: `brig ls` sent people to ~/brig/claude-code-claude-cod, which is
 // not where the running sandbox lives.
+//
+// The derivation these cases are about is the fallback now, so they run against
+// an empty state directory: an index recorded by whoever is running the tests
+// would answer first and the derivation would never be reached.
 func TestWorkspaceOfUnnamedSandbox(t *testing.T) {
+	t.Setenv("BRIG_STATE_DIR", t.TempDir())
 	for _, c := range []struct{ vm, want string }{
 		{"brig-claude-code", "/claude-code"},
 		{"brig-claude-code-skilltest", "/claude-code-skilltest"},

--- a/internal/wrap/config.go
+++ b/internal/wrap/config.go
@@ -125,9 +125,23 @@ func Load(t profile.Profile, o Options, rt runtime.Runtime) (*Config, error) {
 		return nil, fmt.Errorf("cannot determine the current directory: %w", err)
 	}
 
-	base := env.String("WORKSPACE", defaultWorkspace(t))
+	// The sandbox name is settled first because the workspace may be read back
+	// from an index keyed by it. See index.go.
+	vmName := env.String("NAME", "brig-"+t.Name)
+	if slug != "" {
+		vmName += "-" + slug
+	}
+
+	// Whether this invocation named a directory at all, tracked apart from the
+	// value: the default is a directory too, and telling a chosen one from a
+	// derived one is what lets the remembered path beat the second and not the
+	// first.
+	base, given := defaultWorkspace(t), false
+	if v, ok := env.Get("WORKSPACE"); ok && v != "" {
+		base, given = v, true
+	}
 	if o.Workspace != "" {
-		base = o.Workspace
+		base, given = o.Workspace, true
 	}
 	// Made absolute whichever of the two supplied it. A relative
 	// --workspace was already resolved here and a relative BRIG_WORKSPACE was
@@ -145,10 +159,19 @@ func Load(t profile.Profile, o Options, rt runtime.Runtime) (*Config, error) {
 	// an exported BRIG_WORKSPACE keeps working alongside --name instead of
 	// fighting it. An unnamed run adds nothing.
 	workspace := base
-	vmName := env.String("NAME", "brig-"+t.Name)
 	if slug != "" {
 		workspace += "-" + slug
-		vmName += "-" + slug
+	}
+	// Nothing on this invocation named a directory, so the one the sandbox was
+	// started with beats the default just computed. Without this, a session
+	// created with --workspace matches its own default on no later command, and
+	// every flagless verb takes that for a stale share and restarts it -- see
+	// index.go. The suffix is not reapplied: what was recorded is the workspace
+	// as it was finally resolved, slug and all.
+	if !given {
+		if remembered := RememberedWorkspace(vmName); remembered != "" {
+			workspace = remembered
+		}
 	}
 
 	bindings, envWarnings := envOverride(t.Env, env.Fields("FORWARD_ENV", nil))

--- a/internal/wrap/index.go
+++ b/internal/wrap/index.go
@@ -1,0 +1,172 @@
+package wrap
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// The workspace index: the host directory each sandbox was started with.
+//
+// Every invocation resolves the workspace from scratch -- --workspace, then
+// BRIG_WORKSPACE, then ~/brig/<profile>-<name> -- and EnsureRunning compares
+// the running sandbox against whatever that produced. That is right for an
+// invocation that names a directory and wrong for one that does not: a session
+// created with --workspace never matches its own default, so the next flagless
+// verb reads the mismatch as a stale share and restarts the sandbox. The work
+// survives that, because it is in the workspace on the host. The guest's
+// memory-only state does not, and an in-sandbox login goes with it.
+//
+// So the path a sandbox was started with is written down, and read back when
+// the invocation names none. It is an index and not a source of truth: the
+// runtime stays authoritative about what is actually mounted, the stale-share
+// check still runs against whatever path is resolved, and an explicit
+// --workspace or BRIG_WORKSPACE still wins -- asking for a different directory
+// is something a user is entitled to do, restart and all.
+//
+// It lives beside gateway-ips.json, which is the same kind of file for the
+// same kind of reason: small per-sandbox bookkeeping that has to outlive one
+// invocation. Deliberately not a record inside the workspace itself, which
+// would make that directory both state and identity -- copy it to a second
+// machine, or point two sandbox names at it, and it would carry a claim about
+// which sandbox owns it.
+//
+// Two brig processes recording at once can lose one of the two entries, since
+// each reads the file, edits its own key and writes the whole map back. The
+// cost is one restart for whichever sandbox lost, which is the cost of not
+// having the index at all -- worth less than a lock file on the path every
+// boot takes.
+
+// workspaceIndexName is the file, inside stateDir.
+const workspaceIndexName = "workspaces.json"
+
+// stateDir is where brig keeps what has to outlive a single invocation.
+// BRIG_STATE_DIR moves it, which is what lets a test run without writing into
+// the state of whoever is running the test.
+func stateDir() (string, error) {
+	if dir := os.Getenv("BRIG_STATE_DIR"); dir != "" {
+		return dir, nil
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("no home directory to keep brig's state in: %w", err)
+	}
+	return filepath.Join(home, ".brig"), nil
+}
+
+func workspaceIndexPath() (string, error) {
+	dir, err := stateDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, workspaceIndexName), nil
+}
+
+// readWorkspaceIndex returns what has been recorded, and an empty map for
+// every way that can fail.
+//
+// A file that is missing, unreadable or corrupt is not worth failing a command
+// over: an absent entry costs the sandbox one restart, and that is exactly the
+// behaviour of the release before this file existed. Failing instead would
+// make a stray file in ~/.brig able to stop every brig command on the host.
+func readWorkspaceIndex() map[string]string {
+	index := map[string]string{}
+	path, err := workspaceIndexPath()
+	if err != nil {
+		return index
+	}
+	blob, err := os.ReadFile(path)
+	if err != nil {
+		return index
+	}
+	if err := json.Unmarshal(blob, &index); err != nil {
+		return map[string]string{}
+	}
+	return index
+}
+
+// writeWorkspaceIndex replaces the file with the map it is given.
+func writeWorkspaceIndex(index map[string]string) error {
+	path, err := workspaceIndexPath()
+	if err != nil {
+		return err
+	}
+	// 0700 for the directory: it holds nothing secret, but it names host
+	// directories of somebody's, and brig's other state is already private.
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return err
+	}
+	blob, err := json.MarshalIndent(index, "", "  ")
+	if err != nil {
+		return err
+	}
+	// Written through a temporary file and renamed, so a crash mid-write
+	// cannot leave a half-parsed map behind -- which would cost every sandbox
+	// on the host its entry rather than one of them.
+	tmp, err := os.CreateTemp(filepath.Dir(path), ".workspaces-*")
+	if err != nil {
+		return err
+	}
+	defer func() { _ = os.Remove(tmp.Name()) }()
+	if _, err := tmp.Write(append(blob, '\n')); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	return os.Rename(tmp.Name(), path)
+}
+
+// RememberedWorkspace is the workspace a sandbox was started with, or "" when
+// nothing has been recorded for it -- a sandbox created before this index
+// existed, or one whose entry has been pruned.
+//
+// Exported for the two callers outside a run: `brig ls`, which reports the
+// directory a running sandbox actually has rather than the one its name would
+// derive, and anything that has a sandbox name and no Config.
+func RememberedWorkspace(vmName string) string {
+	return readWorkspaceIndex()[vmName]
+}
+
+// ForgetWorkspace drops a removed sandbox's entry, so the next sandbox to take
+// that name starts from the ordinary resolution rather than inheriting a
+// directory chosen for a different one.
+//
+// Errors are dropped rather than returned, the way releaseGatewayIP drops its
+// own: a removal that worked must not report a failure because a bookkeeping
+// file could not be rewritten.
+func ForgetWorkspace(vmName string) {
+	index := readWorkspaceIndex()
+	if _, ok := index[vmName]; !ok {
+		return
+	}
+	delete(index, vmName)
+	_ = writeWorkspaceIndex(index)
+}
+
+// rememberWorkspace records the directory this sandbox has just been started
+// with, so a later invocation that names none finds it again.
+//
+// Also called when the running sandbox already matches, which is what fills
+// the index in for a sandbox created before it existed: the entry is written
+// once, and every invocation after that is a read.
+//
+// A failure to write is a warning rather than an error. The sandbox is up and
+// working, so failing the command here would be refusing the thing that
+// succeeded over the note about it -- but the cost lands later and nowhere
+// near this line, on some flagless verb that restarts the sandbox, so it is
+// worth saying out loud where the reason is still visible.
+func (c *Config) rememberWorkspace() {
+	index := readWorkspaceIndex()
+	if index[c.VMName] == c.Workspace {
+		return
+	}
+	index[c.VMName] = c.Workspace
+	if err := writeWorkspaceIndex(index); err != nil {
+		c.warnf("could not record %s as the workspace of %s (%v). A later command "+
+			"that names no workspace will fall back to the default one and restart "+
+			"the sandbox.", c.Workspace, c.VMName, err)
+	}
+}

--- a/internal/wrap/index_test.go
+++ b/internal/wrap/index_test.go
@@ -1,0 +1,253 @@
+package wrap
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/brig-sh/brig/internal/profile"
+	"github.com/brig-sh/brig/internal/runtime"
+)
+
+// isolateState points brig's state directory at a scratch one and clears the
+// workspace settings, so a case runs against the index it writes itself rather
+// than against whatever the machine running the test happens to have.
+func isolateState(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	t.Setenv("BRIG_STATE_DIR", dir)
+	// Set, then removed. t.Setenv is what restores the caller's own value when
+	// the case ends, and it cannot unset -- but a variable present and empty is
+	// not the same as an absent one here: Get takes the first prefix that
+	// exists, so an empty BRIG_CLAUDE_CODE_WORKSPACE would mask a
+	// BRIG_WORKSPACE a case sets deliberately.
+	for _, key := range []string{
+		"BRIG_WORKSPACE", "BRIG_CLAUDE_CODE_WORKSPACE",
+		"BRIG_NAME", "BRIG_CLAUDE_CODE_NAME",
+	} {
+		t.Setenv(key, "")
+		if err := os.Unsetenv(key); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return dir
+}
+
+// mustLoad resolves one invocation the way the command line does. These cases
+// go through Load rather than building a Config, because the resolution order
+// is the thing being tested.
+func mustLoad(t *testing.T, o Options) *Config {
+	t.Helper()
+	p, ok := profile.Lookup("claude-code")
+	if !ok {
+		t.Fatal("the claude-code profile is not loaded")
+	}
+	c, err := Load(p, o, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return c
+}
+
+// removingRuntime answers the two calls Remove makes and nothing else:
+// anything further panics through the embedded nil interface, which is louder
+// than a stub that quietly succeeds.
+type removingRuntime struct {
+	runtime.Runtime
+	removed []string
+}
+
+func (r *removingRuntime) Stop(string) error { return nil }
+
+func (r *removingRuntime) Remove(name string) error {
+	r.removed = append(r.removed, name)
+	return nil
+}
+
+// The transcript in issue #72: a session created with --workspace, then a verb
+// that names none. Before the index, the second one resolved the default
+// ~/brig/<profile>-<name>, found the running sandbox mounting something else,
+// called that a stale share and restarted it -- discarding the guest's
+// memory-only state, an in-sandbox login included.
+func TestAWorkspaceGivenOnceIsFoundAgainWithoutTheFlag(t *testing.T) {
+	isolateState(t)
+	base := t.TempDir()
+	// --workspace names the base, and a named session suffixes its slug onto
+	// whatever the base is, so this is the directory the session actually gets.
+	ws := base + "-rc23test"
+
+	created := mustLoad(t, Options{Name: "rc23test", Workspace: base})
+	if created.Workspace != ws {
+		t.Fatalf("--workspace resolved to %q, want %q", created.Workspace, ws)
+	}
+	created.rememberWorkspace()
+
+	next := mustLoad(t, Options{Name: "rc23test"})
+	if next.VMName != created.VMName {
+		t.Fatalf("the two invocations addressed different sandboxes: %q and %q",
+			created.VMName, next.VMName)
+	}
+	if next.Workspace != ws {
+		t.Errorf("a flagless verb resolved %q, want the workspace the session was "+
+			"created with (%q)", next.Workspace, ws)
+	}
+}
+
+// An explicit directory is a request, not a guess, so it still beats what was
+// recorded -- and still restarts the sandbox, because a share cannot be moved
+// on a live guest. Both spellings, since either one is the user saying it.
+func TestAnExplicitWorkspaceBeatsTheRememberedOne(t *testing.T) {
+	isolateState(t)
+	remembered, other := t.TempDir(), t.TempDir()
+
+	created := mustLoad(t, Options{Name: "rc23test", Workspace: remembered})
+	created.rememberWorkspace()
+
+	byFlag := mustLoad(t, Options{Name: "rc23test", Workspace: other})
+	if want := other + "-rc23test"; byFlag.Workspace != want {
+		t.Errorf("--workspace resolved to %q, want %q", byFlag.Workspace, want)
+	}
+
+	// Either spelling names the base rather than the session's own directory,
+	// so the slug is suffixed onto it exactly as it is without an index.
+	t.Setenv("BRIG_WORKSPACE", other)
+	bySetting := mustLoad(t, Options{Name: "rc23test"})
+	if want := other + "-rc23test"; bySetting.Workspace != want {
+		t.Errorf("BRIG_WORKSPACE resolved to %q, want %q", bySetting.Workspace, want)
+	}
+}
+
+// An unnamed run records and reads back its own entry too: the default
+// workspace is one a flag can override just as well.
+func TestTheUnnamedSandboxIsRememberedToo(t *testing.T) {
+	isolateState(t)
+	ws := t.TempDir()
+
+	created := mustLoad(t, Options{Workspace: ws})
+	if created.VMName != "brig-claude-code" {
+		t.Fatalf("the unnamed sandbox is %q", created.VMName)
+	}
+	created.rememberWorkspace()
+
+	if got := mustLoad(t, Options{}).Workspace; got != ws {
+		t.Errorf("a flagless verb resolved %q, want %q", got, ws)
+	}
+}
+
+// `brig rm` drops the entry, so the next sandbox to take the name resolves its
+// workspace the ordinary way rather than inheriting a directory chosen for a
+// sandbox that is gone.
+func TestRemoveDropsTheEntry(t *testing.T) {
+	isolateState(t)
+	base := t.TempDir()
+	ws := base + "-rc23test"
+
+	c := mustLoad(t, Options{Name: "rc23test", Workspace: base})
+	c.rememberWorkspace()
+	if got := RememberedWorkspace(c.VMName); got != ws {
+		t.Fatalf("the workspace was recorded as %q, want %q", got, ws)
+	}
+
+	rt := &removingRuntime{}
+	c.Runtime = rt
+	if err := c.Remove(); err != nil {
+		t.Fatalf("remove failed: %v", err)
+	}
+	if len(rt.removed) != 1 || rt.removed[0] != c.VMName {
+		t.Errorf("the runtime was asked to remove %v", rt.removed)
+	}
+	if got := RememberedWorkspace(c.VMName); got != "" {
+		t.Errorf("rm left %q recorded for a sandbox it removed", got)
+	}
+	if got := mustLoad(t, Options{Name: "rc23test"}).Workspace; got == ws {
+		t.Errorf("a later run still resolved the removed sandbox's workspace %q", got)
+	}
+}
+
+// `brig reset` works from the runtime's instance list, so it prunes by name
+// without a Config -- the entry has to go on that path too, or a reset leaves
+// the index naming every sandbox it just removed.
+func TestForgetWorkspacePrunesByName(t *testing.T) {
+	isolateState(t)
+	ws := t.TempDir()
+
+	c := mustLoad(t, Options{Name: "rc23test", Workspace: ws})
+	c.rememberWorkspace()
+
+	// A name that was never recorded is not an error: reset walks every brig
+	// sandbox, including ones created before the index existed.
+	ForgetWorkspace("brig-claude-code-neverseen")
+	ForgetWorkspace(c.VMName)
+
+	if got := RememberedWorkspace(c.VMName); got != "" {
+		t.Errorf("reset left %q recorded for %s", got, c.VMName)
+	}
+}
+
+// The index is bookkeeping, so nothing about it is worth failing a command
+// over: a missing file, a corrupt one and one that cannot be opened at all
+// each resolve the default, which is what the release before it did.
+func TestAnUnusableIndexIsIgnoredRatherThanFatal(t *testing.T) {
+	dir := isolateState(t)
+	path := filepath.Join(dir, workspaceIndexName)
+
+	// Missing: nothing has been recorded yet, which is every first run.
+	fallback := mustLoad(t, Options{Name: "rc23test"}).Workspace
+	if fallback == "" {
+		t.Fatal("no workspace was resolved at all")
+	}
+
+	// Corrupt: half a write, or a file somebody edited.
+	if err := os.WriteFile(path, []byte("{not json at all"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if got := RememberedWorkspace("brig-claude-code-rc23test"); got != "" {
+		t.Errorf("a corrupt index returned %q", got)
+	}
+	if got := mustLoad(t, Options{Name: "rc23test"}).Workspace; got != fallback {
+		t.Errorf("a corrupt index changed the resolved workspace to %q, want %q", got, fallback)
+	}
+
+	// Unreadable: a directory where the file should be is the shape that takes
+	// on a host where the read cannot succeed whatever the permissions say.
+	if err := os.Remove(path); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(path, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if got := mustLoad(t, Options{Name: "rc23test"}).Workspace; got != fallback {
+		t.Errorf("an unreadable index changed the resolved workspace to %q, want %q", got, fallback)
+	}
+	// And recording against one says so rather than failing the run: the
+	// sandbox is up, and the note is what explains the restart that follows.
+	c := mustLoad(t, Options{Name: "rc23test"})
+	said := &bytes.Buffer{}
+	c.Err = said
+	c.rememberWorkspace()
+	if !strings.Contains(said.String(), c.VMName) {
+		t.Errorf("an index that cannot be written said %q, which does not name the sandbox",
+			said.String())
+	}
+}
+
+// Every entry survives a write, so recording one sandbox does not cost another
+// its own -- the file is read, edited and written back whole.
+func TestRecordingOneSandboxKeepsTheOthers(t *testing.T) {
+	isolateState(t)
+	first, second := t.TempDir(), t.TempDir()
+
+	a := mustLoad(t, Options{Name: "one", Workspace: first})
+	a.rememberWorkspace()
+	b := mustLoad(t, Options{Name: "two", Workspace: second})
+	b.rememberWorkspace()
+
+	if want := first + "-one"; RememberedWorkspace(a.VMName) != want {
+		t.Errorf("%s lost its entry: %q", a.VMName, RememberedWorkspace(a.VMName))
+	}
+	if want := second + "-two"; RememberedWorkspace(b.VMName) != want {
+		t.Errorf("%s was recorded as %q, want %q", b.VMName, RememberedWorkspace(b.VMName), want)
+	}
+}

--- a/internal/wrap/run.go
+++ b/internal/wrap/run.go
@@ -195,6 +195,10 @@ func (c *Config) EnsureRunning(set creds.Set) error {
 
 	if c.Runtime.Running(c.VMName) {
 		if c.guestMountsWorkspace() {
+			// The guest has confirmed this workspace, so record it. Nothing has
+			// changed for a session brig already knows about; for one created
+			// before the index existed, this is where its entry appears.
+			c.rememberWorkspace()
 			// Running a graphical agent again is how you get back to its
 			// window, so the focus is not part of the boot -- it belongs on
 			// every path that leaves a sandbox running.
@@ -280,6 +284,12 @@ func (c *Config) EnsureRunning(set creds.Set) error {
 	if err := c.Runtime.Run(spec); err != nil {
 		return fmt.Errorf("could not start the sandbox: %w", err)
 	}
+	// The share is bound now and cannot be changed on a live sandbox, so this
+	// is the moment the path becomes a fact about the instance. Recorded before
+	// the readiness wait for that reason: a sandbox that boots and never answers
+	// still has this workspace, and the next command has to resolve the same one
+	// to find out.
+	c.rememberWorkspace()
 	if !c.waitReady() {
 		return fmt.Errorf("sandbox did not become ready; check '%s'",
 			c.Runtime.LogsHint(c.VMName))
@@ -365,10 +375,20 @@ func (c *Config) Stop() error {
 }
 
 // Remove stops the sandbox and clears the instance holding its name. The
-// workspace is untouched: it lives on the host and holds your work.
+// workspace is untouched: it lives on the host and holds your work. Only the
+// index entry goes, so the next sandbox to take this name resolves its
+// workspace the ordinary way instead of inheriting one chosen for a sandbox
+// that no longer exists.
+//
+// Pruned whether or not the runtime could remove the instance, which is how
+// hull releases the gateway address it hands out: the entry describes a sandbox
+// the user has asked to be rid of either way, and a removal that failed is
+// reported on its own.
 func (c *Config) Remove() error {
 	_ = c.Runtime.Stop(c.VMName)
-	return c.Runtime.Remove(c.VMName)
+	err := c.Runtime.Remove(c.VMName)
+	ForgetWorkspace(c.VMName)
+	return err
 }
 
 // Exec hands the terminal to a command inside the sandbox. It does not return

--- a/script/smoke.sh
+++ b/script/smoke.sh
@@ -125,6 +125,10 @@ export BRIG_RUNTIME=hull
 export BRIG_RUNTIME_BIN="$WORK/hull"
 export BRIG_WORKSPACE="$WS"
 export BRIG_READY_TIMEOUT=5
+# brig remembers which workspace each sandbox was started with, in a file under
+# its state directory. Scratch, like the profile directory: the test creates and
+# removes sandboxes, and it must not edit the state of whoever is running it.
+export BRIG_STATE_DIR="$WORK/state"
 # The image checks get their own cases below, with a stub cosign. Everywhere
 # else they are off: a CI runner has no cosign and must not reach a registry.
 export BRIG_VERIFY=off
@@ -282,6 +286,62 @@ out="$("$WORK/brig" run claude -d 2>/dev/null)"
 "$WORK/brig" reset > /dev/null 2>&1
 grep -q '^argv: rm brig-claude-code' "$STUB_LOG" \
   && ok "reset removes brig sandboxes" || bad "reset removes brig sandboxes"
+
+echo "== remembered workspace =="
+# A session created with -w used to be restarted by the next verb that left the
+# flag off: the workspace resolved back to the default, the running sandbox was
+# mounting something else, and that read as a stale share. The workspace
+# survives a restart because it is on the host; the guest's memory-only state
+# does not, an in-sandbox login included.
+#
+# BRIG_WORKSPACE is removed from the environment for these, because it is a
+# setting that names a directory and this is about the case where nothing does.
+RC="$WORK/ws-rc23"
+brig_bare() { env -u BRIG_WORKSPACE "$WORK/brig" "$@"; }
+brig_bare create claude --name rc23 -w "$RC" > /dev/null 2>&1
+: > "$STUB_LOG"
+brig_bare exec claude --name rc23 -- uname -a > /dev/null 2>&1
+grep -q '^argv: run ' "$STUB_LOG" \
+  && bad "exec without -w restarted the session" \
+  || ok "exec without -w finds the workspace the session was created with"
+
+# The listing says what the sandbox is mounting, so the remembered directory
+# wins there over the one the sandbox name would derive -- and over the
+# BRIG_WORKSPACE this shell is carrying, which names neither.
+listing="$("$WORK/brig" ls 2>/dev/null)"
+case "$listing" in
+  *"$RC-rc23"*) ok "ls names the workspace the session was created with" ;;
+  *) bad "ls names the workspace the session was created with -- got: $listing" ;;
+esac
+
+# An explicit directory is a request rather than a guess, so it still wins and
+# still restarts: a share cannot be moved on a live guest.
+: > "$STUB_LOG"
+brig_bare exec claude --name rc23 -w "$WORK/ws-other" -- uname -a > /dev/null 2>&1
+grep -q '^argv: run ' "$STUB_LOG" \
+  && ok "a -w naming a different directory still restarts the sandbox" \
+  || bad "a -w naming a different directory still restarts the sandbox"
+
+brig_bare rm claude --name rc23 > /dev/null 2>&1
+grep -q 'brig-claude-code-rc23' "$BRIG_STATE_DIR/workspaces.json" \
+  && bad "rm left the sandbox in the workspace index" \
+  || ok "rm drops the remembered workspace"
+
+brig_bare create claude --name rc23 -w "$RC" > /dev/null 2>&1
+"$WORK/brig" reset > /dev/null 2>&1
+grep -q 'brig-claude-code-rc23' "$BRIG_STATE_DIR/workspaces.json" \
+  && bad "reset left a sandbox in the workspace index" \
+  || ok "reset drops the remembered workspaces"
+
+# The index is bookkeeping, so an unusable one costs a restart and nothing
+# more: every command still works, and the workspace resolves as it did before
+# the file existed.
+printf '{not json at all' > "$BRIG_STATE_DIR/workspaces.json"
+brig_bare run claude -d > "$WORK/corrupt.out" 2>&1
+rc=$?
+[ "$rc" = 0 ] && ok "a corrupt index is ignored rather than fatal" \
+  || bad "a corrupt index failed the run -- got: $(cat "$WORK/corrupt.out")"
+"$WORK/brig" reset > /dev/null 2>&1
 
 echo "== flags =="
 : > "$STUB_LOG"


### PR DESCRIPTION
## Summary

A session created with `--workspace` was restarted by the next `exec` that
omitted the flag. The workspace was resolved on every invocation from the flag,
then `BRIG_WORKSPACE`, then the derived default, and the running sandbox was
compared against that; a session started with an explicit directory therefore
never matched its own default, and every flagless verb reported a stale share
and rebooted it, which discarded the guest's memory-only state including an
in-sandbox login.

brig now remembers the workspace a sandbox was started with, and uses it when
neither the flag nor the setting names one.

## Related issues

Closes #72

## Changes

- `internal/wrap/index.go`: `$BRIG_STATE_DIR/workspaces.json`, default
  `~/.brig/workspaces.json`, beside `gateway-ips.json`. One object, sandbox
  name to workspace path, written through a temp file and renamed. It is an
  index, not a source of truth: the runtime stays authoritative and the
  existing staleness check runs unchanged against whichever path is resolved.
- `Load` reads it only when neither `--workspace` nor `BRIG_WORKSPACE` names a
  directory. The flag and the setting are tracked apart from their value, so a
  chosen directory beats the recorded one and a derived default does not.
- `EnsureRunning` writes it after a successful boot, and on the
  already-running path, which backfills an entry for a sandbox created before
  the index existed. `brig rm` and `brig reset` prune it. `brig ls` prefers it
  over the path derived from the name, since that column says what a sandbox is
  mounting.
- A read failure of any kind resolves the default instead; a write failure warns
  and the command continues.
- `BRIG_STATE_DIR` is new and documented; `script/smoke.sh` sets it so the suite
  never edits the state of whoever runs it.
- Tests in `internal/wrap/index_test.go` and `cmd/brig`, plus six smoke cases,
  each confirmed to fail when the index read or the pruning is removed.

## One thing to know

`-w` names a base that a named session suffixes its slug onto:
`brig create claude --name rc23 -w /tmp/ws` mounts `/tmp/ws-rc23`. That is
existing behaviour and unchanged here; it means the recorded path carries the
suffix. Whether `-w` should mean exactly what was typed is a separate question
for #47.

## Checklist

- [x] `make all` passes (vet, test, build)
- [x] `script/smoke.sh` passes
- [x] I have added or updated tests covering the change
- [x] I have run `go test ./... -race`, if the change touches concurrency, subprocesses or the daemon
- [ ] I have exercised the change against a real runtime (`brig run <agent>`), if it touches the run, exec or credential path
- [x] I have updated the affected docs (README, `docs/security.md`, `docs/profiles.md`, `docs/brigd.md`)

Not yet run against a real sandbox. The transcript in #72 is the test to repeat
before merge: create with `-w`, then `exec` without it, and see no restart.

## Credentials and the sandbox boundary

The index records a path, never a credential, and is written only under brig's
own state directory. Its effect on the boundary is to stop a needless restart,
which is what was throwing away the in-sandbox login.
