### PR TITLE
fix(profile): make the export-edit-run recipe work, and guard rm

### DIFF
--- a/README.md
+++ b/README.md
@@ -488,12 +488,16 @@ credential variables every time:
 
 ```bash
 brig profile export claude-code mine   # start from the closest one
-brig profile edit mine                 # change name, image, forward/deny
+brig profile edit mine                 # change the image, forward/deny
 brig run mine
 ```
 
 The second word is a name, not a path: brig writes `~/.config/brig/mine.yaml`,
-which is where a profile file has to be for brig to read it back. Export
+which is where a profile file has to be for brig to read it back. It is the
+profile's name as well as the file's -- export writes `name: mine` into the
+file, so `mine` is what every later command takes, `brig profile rm mine`
+included. Everything else in there still describes claude-code, which is what
+the edit on the second line is for. Export
 writes that directory and nowhere else, so a path is refused rather than
 honoured -- redirect stdout (`brig profile export claude-code > mine.yaml`)
 if you want a copy of your own. It also refuses to overwrite an existing file

--- a/cmd/brig/main.go
+++ b/cmd/brig/main.go
@@ -782,7 +782,7 @@ func listProfiles() error {
 	}
 	fmt.Printf("\nan unmarked profile is built in; your own live in %s\n", profile.Dir())
 	fmt.Printf("to override one:  brig profile export claude-code claude-code, then brig profile edit claude-code\n")
-	fmt.Printf("to add your own:  brig profile export claude-code mytool, then brig profile edit mytool (change name:)\n")
+	fmt.Printf("to add your own:  brig profile export claude-code mytool, then brig profile edit mytool\n")
 	fmt.Printf("to build an image for one: %s\n", profile.BringYourOwnImageDoc)
 	return nil
 }
@@ -811,26 +811,68 @@ func handCreatedNames(p profile.Profile) []string {
 	return names
 }
 
+// profileUsage is what `brig profile --help` prints. Held here rather than in
+// the top-level usage text for the same reason secretUsage is: it names the
+// flags of five verbs, which is more than the one line the command list can
+// give them.
+const profileUsage = `brig profile -- manage profiles
+
+usage:
+  brig profile ls                        list the profiles
+  brig profile export <profile>          print one, to edit or to pipe
+  brig profile export <profile> <name>   save it as <name> in the profile dir
+  brig profile import <file>             add one of your own (- reads stdin)
+  brig profile edit <name>               open yours in $VISUAL or $EDITOR
+  brig profile rm <name> [-y]            delete yours, after asking
+
+flags:
+      --json        with export: render JSON rather than YAML
+  -f, --force       with export: replace a file that is already there
+  -y, --yes         with rm: the answer, given in advance
+
+A destination is a name and never a path: export writes the profile directory
+and nowhere else, because that is the only place a profile file does anything.
+Redirect the no-destination form to put a copy of your own anywhere.
+
+A profile saves you spelling out the image, the guest home and the credential
+variables on every run. Export the closest one, edit it, import it back.
+Building an image for one is documented at
+  ` + profile.BringYourOwnImageDoc + `
+`
+
 // profileCmd groups the profile verbs, which is where someone coming from
 // another sandbox tool will look for them.
 func profileCmd(args []string) error {
 	if len(args) == 0 {
 		return errors.New("profile needs a subcommand: ls, export, import, edit or rm")
 	}
+	var err error
 	switch args[0] {
+	case "--help", "-h", "help":
+		fmt.Print(profileUsage)
+		return nil
 	case "ls", "list":
 		return listProfiles()
 	case "export", "save":
-		return exportProfile(args[1:])
+		err = exportProfile(args[1:])
 	case "import", "load":
-		return importProfile(args[1:])
+		err = importProfile(args[1:])
 	case "edit":
-		return editProfile(args[1:])
+		err = editProfile(args[1:])
 	case "rm":
-		return removeProfile(args[1:])
+		err = removeProfile(args[1:])
 	default:
 		return fmt.Errorf("unknown profile subcommand %q (ls, export, import, edit, rm)", args[0])
 	}
+	// A verb's own parser reports --help as an error, because that is how the
+	// flag package says it. Asking for help is not a mistake, so it is answered
+	// with the help and an exit code of zero -- the same translation the secret
+	// group makes, and for the same reason.
+	if errors.Is(err, flag.ErrHelp) {
+		fmt.Print(profileUsage)
+		return nil
+	}
+	return err
 }
 
 // editProfile opens a file-backed profile in your editor.
@@ -944,6 +986,11 @@ func importProfile(args []string) error {
 // writes mine.yaml into the profile directory, because that is the only place
 // a profile file does anything. See profile.ExportPath, which owns the rule.
 //
+// The destination is also the name written into the file. brig keys on the
+// name: field rather than on the file name, so the two disagreeing is the
+// difference between a profile of your own and a copy of someone else's under
+// a misleading file name -- see profile.ExportAs.
+//
 // With no destination it prints, which is what keeps
 // `brig profile export x | brig profile import -` working, what stops the
 // command writing anything you did not ask for, and how you get a copy
@@ -1002,20 +1049,47 @@ func exportProfile(args []string) error {
 	if !ok {
 		return fmt.Errorf("unknown profile %q. `brig profiles` lists them", name)
 	}
-	render := profile.Export
-	if asJSON {
-		render = profile.ExportJSON
-	}
-	blob, err := render(p)
-	if err != nil {
-		return err
-	}
-	if dest == "" {
-		_, err = os.Stdout.Write(blob)
-		return err
-	}
 	path, err := profile.ExportPath(dest, asJSON)
 	if err != nil {
+		return err
+	}
+	// The name the exported profile carries: the file's own stem when there is
+	// a file, so that `brig profile export claude-code mytool` writes a profile
+	// called mytool and `brig profile edit mytool` can then open it. With no
+	// destination there is no file to agree with, and the export is the profile
+	// as it stands.
+	as := p.Name
+	if path != "" {
+		as = stemOf(path)
+	}
+	// The same collision profile.Import refuses, refused here for the same
+	// reason: a name that a reserved profile already answers to would take a
+	// workspace that is not its own. Export can reach it now that it writes the
+	// name rather than copying one that was already checked.
+	if owner, reserved := profile.Reserved(as); reserved && as != owner {
+		return fmt.Errorf("a profile named %q would collide with the %s profile, which "+
+			"reserves that word. Export it under another name", as, owner)
+	}
+	// An alias is the same collision one step further out: the word is already
+	// how people spell a profile, and a profile of that name wins the lookup,
+	// so the copy takes every run of the name it was copied from. Refused
+	// rather than warned about, because the export that causes it is the first
+	// step of the recipe brig prints and the shadowing shows up much later, as
+	// a run booting an image nobody chose.
+	if owner, ok := profile.Alias(as); ok {
+		return fmt.Errorf("a profile named %q would collide with %s, which is what brig "+
+			"already runs for that word. Export it under another name", as, owner)
+	}
+	render := profile.ExportAs
+	if asJSON {
+		render = profile.ExportJSONAs
+	}
+	blob, err := render(p, as)
+	if err != nil {
+		return err
+	}
+	if path == "" {
+		_, err = os.Stdout.Write(blob)
 		return err
 	}
 	// An export is generated bytes: it has none of the edits that are the
@@ -1037,19 +1111,25 @@ func exportProfile(args []string) error {
 	if err := os.WriteFile(path, blob, 0o644); err != nil {
 		return err
 	}
-	fmt.Printf("wrote %s -> %s\n", p.Name, path)
-	if profile.Embedded(p.Name) {
-		fmt.Printf("it is in your profile directory, so it now overrides the built-in %s\n", p.Name)
+	if as == p.Name {
+		fmt.Printf("wrote %s -> %s\n", p.Name, path)
+	} else {
+		fmt.Printf("wrote %s as %s -> %s\n", p.Name, as, path)
 	}
-	// brig keys on the name field, not the file name, so a file called
-	// mine.yaml that still says "name: codex" is an override of codex however
-	// it is spelled. Say so where it is fixable, which is before the edit
-	// rather than after two of them fight over one name.
-	if stem := stemOf(path); stem != p.Name {
-		fmt.Printf("brig reads the name: field, not the file name, so this is still "+
-			"the %s profile. Change name: to %s if you meant a profile of your own\n",
-			p.Name, stem)
+	// Embedded is asked about the name the file now declares rather than the
+	// one it was copied from: an export under a new name shadows nothing, and
+	// saying it overrode the built-in it started from would be exactly wrong.
+	if profile.Embedded(as) {
+		fmt.Printf("it is in your profile directory, so it now overrides the built-in %s\n", as)
 	}
+	// The name agrees with the file, and nothing else does yet: the image, the
+	// guest home and every comment in there still describe the profile this was
+	// copied from. Say so where it is actionable, and name the command that
+	// opens it, which is the next step of the recipe brig prints.
+	if as != p.Name {
+		fmt.Printf("its image, guest home and comments still describe %s\n", p.Name)
+	}
+	fmt.Printf("edit it with: brig profile edit %s\n", as)
 	return nil
 }
 
@@ -1063,21 +1143,28 @@ func stemOf(path string) string {
 // removeProfile deletes a profile of your own. A built-in is compiled in and
 // cannot be removed, only shadowed -- say so rather than reporting a missing
 // file.
+//
+// -y is the answer to the question below, given in advance, and it is spelled
+// the way the secret verbs spell it.
 func removeProfile(args []string) error {
-	if len(args) == 0 {
-		return errors.New("profile rm needs a name")
+	name, yes, err := nameAndYes("profile rm", "brig profile rm mine", args)
+	if err != nil {
+		return err
 	}
 	// Resolve through the registry rather than trusting the argument: it takes
 	// aliases, and it names the file actually loaded, which need not be
-	// <name>.yaml -- `brig profile export claude-code pinned.yaml` is an
-	// override whose basename says nothing about which profile it serves.
-	p, ok := profile.Lookup(args[0])
+	// <name>.yaml -- a file someone renamed by hand is an override whose
+	// basename says nothing about which profile it serves.
+	p, ok := profile.Lookup(name)
 	if !ok {
-		return fmt.Errorf("no profile of your own named %q", args[0])
+		return fmt.Errorf("no profile of your own named %q", name)
 	}
 	if _, ok := profile.Path(p.Name); !ok {
 		return fmt.Errorf("%s is a built-in profile, so there is nothing to remove. "+
 			"Import a profile of the same name to shadow it", p.Name)
+	}
+	if err := confirmRemoveProfile(name, p.Name, profile.Files(p.Name), yes); err != nil {
+		return err
 	}
 	// Every file that declares the name, not just the one that loaded: see
 	// profile.Remove. Two of them is a mistake brig reports at load time and
@@ -1088,6 +1175,81 @@ func removeProfile(args []string) error {
 		fmt.Printf("removed %s\n", f)
 	}
 	return err
+}
+
+// confirmRemoveProfile names the files an rm is about to delete, and asks
+// before deleting one the argument did not name.
+//
+// rm resolves the argument through the registry, which is what lets it work on
+// an alias and on a file whose basename says nothing about the profile inside
+// it. That resolution is also how `brig profile rm claude-code` could delete a
+// file called mytool.yaml and exit 0 without a word: the file the person had a
+// name for and the file brig found were different files, and only brig knew
+// which.
+//
+// So the question is whether brig had to work anything out, and there are two
+// ways it does. The argument may not be the profile's own name, which is the
+// alias case: `brig profile rm claude` deletes whatever backs claude-code, and
+// a file called claude.yaml declaring claude-code carries the stem the
+// argument spells while being a profile the argument never said. And a file's
+// basename may not be the argument at all, which is the renamed-by-hand case
+// and the second-file-shadowing-the-first case. `brig profile rm mytool`
+// against mytool.yaml declaring mytool is the one combination that is exactly
+// what was typed -- what export writes, and the only case where nothing can
+// surprise you.
+//
+// The message names every file profile.Remove will take rather than only the
+// ones that raised the question: what is being agreed to is the delete, and a
+// list one file short of it is the wrong thing to agree to.
+//
+// Without a terminal there is nobody to answer, and assuming yes would make
+// the scripted case the one that cannot be stopped, so it refuses and names
+// the flag that answers in advance -- the shape confirmDelete already uses,
+// for the same reason.
+func confirmRemoveProfile(arg, resolved string, files []string, yes bool) error {
+	surprising := arg != resolved
+	for _, f := range files {
+		if stemOf(f) != arg {
+			surprising = true
+		}
+	}
+	if !surprising {
+		return nil
+	}
+	list := strings.Join(files, ", ")
+	// A verb that agrees with the list, because two files declaring one profile
+	// is a case this message exists for rather than a curiosity.
+	declares := "declares"
+	if len(files) > 1 {
+		declares = "declare"
+	}
+	// Named on stderr either way, so an rm inside a pipeline still says which
+	// files it means where a person can see them. A run that answered in
+	// advance is told rather than asked, because -y is an answer to this
+	// question and not a reason to stop naming the files.
+	if yes {
+		fmt.Fprintf(os.Stderr, "brig: removing %s, which %s the %s profile\n",
+			list, declares, resolved)
+		return nil
+	}
+	if !wrap.IsTerminal(os.Stdin) {
+		return fmt.Errorf("removing %q would delete %s, which brig worked out from the "+
+			"name you typed rather than being told, and there is no terminal to ask on. "+
+			"Pass -y to answer in advance: brig profile rm %s -y", arg, list, arg)
+	}
+	fmt.Fprintf(os.Stderr, "brig: removing %q deletes %s, which %s the %s profile. "+
+		"Remove it? [y/N] ", arg, list, declares, resolved)
+	line, err := readAnswer(os.Stdin)
+	if err != nil {
+		// EOF is the answer a closed stdin gives, and it is not yes.
+		return fmt.Errorf("aborted: nothing was removed. To answer in advance: "+
+			"brig profile rm %s -y", arg)
+	}
+	switch strings.ToLower(strings.TrimSpace(line)) {
+	case "y", "yes":
+		return nil
+	}
+	return errors.New("aborted: nothing was removed")
 }
 
 // deprecated notes an old spelling once, on stderr so it never lands in

--- a/cmd/brig/profile_test.go
+++ b/cmd/brig/profile_test.go
@@ -63,8 +63,13 @@ func TestExportProfileToAFile(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !strings.Contains(string(blob), "name: claude-code") {
-		t.Errorf("the export is not a profile:\n%s", blob)
+	// The file and the profile in it agree: a destination is the name the
+	// exported profile carries, not only the name of the file it lands in.
+	if !strings.Contains(string(blob), "name: mine") {
+		t.Errorf("the export is not a profile called mine:\n%s", blob)
+	}
+	if strings.Contains(string(blob), "name: claude-code") {
+		t.Errorf("mine.yaml still declares the profile it was copied from:\n%s", blob)
 	}
 	if !strings.Contains(string(blob), "outrank Claude Code's subscription credential") {
 		t.Error("the destination file lost the comments")
@@ -252,16 +257,30 @@ func TestExportBareNameLandsInTheProfileDir(t *testing.T) {
 	if err != nil {
 		t.Fatalf("export did not write into the profile directory: %v", err)
 	}
-	if !strings.Contains(string(blob), "name: claude-code") {
-		t.Errorf("the export is not a profile:\n%s", blob)
+	if !strings.Contains(string(blob), "name: mine") {
+		t.Errorf("the export is not a profile called mine:\n%s", blob)
 	}
 	// And brig reads it back on the next load, which is the point of putting
-	// it there rather than wherever the user happened to be standing.
+	// it there rather than wherever the user happened to be standing. Under a
+	// name of its own it is a profile of your own, not an override: overriding
+	// the built-in is what exporting under the built-in's name does.
+	if err := profile.Load(profile.Dir()); err != nil {
+		t.Fatal(err)
+	}
+	if !profile.IsCustom("mine") {
+		t.Error("the exported file is not picked up as a profile of your own")
+	}
+	if profile.OverridesBuiltIn("claude-code") {
+		t.Error("an export under a new name shadowed the profile it was copied from")
+	}
+	if err := exportProfile([]string{"claude-code", "claude-code"}); err != nil {
+		t.Fatal(err)
+	}
 	if err := profile.Load(profile.Dir()); err != nil {
 		t.Fatal(err)
 	}
 	if !profile.OverridesBuiltIn("claude-code") {
-		t.Error("the exported file is not picked up as an override")
+		t.Error("an export under the built-in's own name is not picked up as an override")
 	}
 	// --json names the file after the format it is in.
 	if err := exportProfile([]string{"codex", "robot", "--json"}); err != nil {
@@ -356,7 +375,10 @@ func TestRemoveProfileTakesEveryFileDeclaringTheName(t *testing.T) {
 	}
 	_ = profile.Load(profile.Dir()) // duplicates are reported, not fatal
 
-	if err := removeProfile([]string{"codex"}); err != nil {
+	// -y because pinned.yaml is not the file the argument names, and rm asks
+	// before deleting one of those. The second file is the whole point here,
+	// so answering the question in advance is the way to reach the case.
+	if err := removeProfile([]string{"codex", "-y"}); err != nil {
 		t.Fatal(err)
 	}
 	if err := profile.Load(profile.Dir()); err != nil {
@@ -383,9 +405,10 @@ func TestRemoveProfileResolvesFileAndAlias(t *testing.T) {
 	if err := profile.Load(profile.Dir()); err != nil {
 		t.Fatal(err)
 	}
-	// By alias, not even by the profile's own name.
-	if err := removeProfile([]string{"claude"}); err != nil {
-		t.Fatalf("could not remove an override the CLI itself creates: %v", err)
+	// By alias, not even by the profile's own name -- which is a file the
+	// argument did not name, so the answer comes with it.
+	if err := removeProfile([]string{"claude", "-y"}); err != nil {
+		t.Fatalf("could not remove an override by alias: %v", err)
 	}
 	if _, err := os.Stat(pinned); !os.IsNotExist(err) {
 		t.Error("the override file is still there")
@@ -437,5 +460,238 @@ func TestListProfilesSeparatesImportableSecretsFromHandCreatedOnes(t *testing.T)
 	// vocabulary rather than brig's, and a listing is names.
 	if strings.Contains(out, "Some Service") {
 		t.Errorf("listing printed a source locator:\n%s", out)
+	}
+}
+
+// The recipe brig prints has to work as written: export the closest built-in
+// under a name of your own, edit it, run it, remove it by the name you chose.
+// Every step addresses that name, which is what did not work while the file
+// was called mytool.yaml and the profile inside it was still claude-code --
+// edit had no such profile to open, and rm reached the file only under the
+// name of the profile it was copied from. The run leg is script/smoke.sh,
+// which has a runtime to boot against; what a run needs from here is that the
+// name resolves to this file, with the settings it was copied from.
+func TestExportedProfileIsEditableAndRemovableByItsNewName(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("BRIG_PROFILE_DIR", dir)
+	if err := profile.Load(profile.Dir()); err != nil {
+		t.Fatal(err)
+	}
+	if err := exportProfile([]string{"claude-code", "mytool"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := profile.Load(profile.Dir()); err != nil {
+		t.Fatal(err)
+	}
+
+	p, ok := profile.Lookup("mytool")
+	if !ok {
+		t.Fatal("the exported profile is not there under the name it was exported as")
+	}
+	built, _ := profile.Lookup("claude-code")
+	if p.Name != "mytool" || p.Image != built.Image || p.GuestHome != built.GuestHome {
+		t.Errorf("mytool is not the profile it was copied from, renamed: %+v", p)
+	}
+	if path, ok := profile.Path("mytool"); !ok || path != filepath.Join(dir, "mytool.yaml") {
+		t.Errorf("Path(mytool) = %q, %v", path, ok)
+	}
+	// Renamed and nothing else: the comments are why anyone starts from an
+	// existing profile rather than a blank file.
+	blob, err := os.ReadFile(filepath.Join(dir, "mytool.yaml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(blob), "outrank Claude Code's subscription credential") {
+		t.Errorf("the rename cost the file its comments:\n%s", blob)
+	}
+
+	stubEditor(t, `printf '\n# tuned by hand\n' >> "$1"`)
+	if err := editProfile([]string{"mytool"}); err != nil {
+		t.Fatalf("editing the exported profile by its own name failed: %v", err)
+	}
+	if after, err := os.ReadFile(filepath.Join(dir, "mytool.yaml")); err != nil {
+		t.Fatal(err)
+	} else if !strings.Contains(string(after), "tuned by hand") {
+		t.Errorf("the edit is not on disk:\n%s", after)
+	}
+
+	// And out again by the same name, with nothing asked: this is the file the
+	// argument names.
+	if err := removeProfile([]string{"mytool"}); err != nil {
+		t.Fatalf("removing the exported profile by its own name failed: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "mytool.yaml")); !os.IsNotExist(err) {
+		t.Error("the file is still there after rm")
+	}
+}
+
+// rm resolves through the registry, so the file it deletes need not be the one
+// the argument spells. That is worth keeping -- it is what makes rm work on an
+// alias -- but it must not delete a file nobody named without a word: the bug
+// this guards was `brig profile rm claude-code` removing mytool.yaml, silently
+// and with exit 0.
+func TestRemoveProfileAsksBeforeDeletingAFileYouDidNotName(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("BRIG_PROFILE_DIR", dir)
+	pinned := filepath.Join(dir, "pinned.yaml")
+	blob := []byte("name: mytool\nimage: i\nguestHome: /home/x\nbinary: x\nmem: 1\ncpus: 1\n")
+	if err := os.WriteFile(pinned, blob, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := profile.Load(profile.Dir()); err != nil {
+		t.Fatal(err)
+	}
+	noAnswer(t)
+
+	err := removeProfile([]string{"mytool"})
+	if err == nil {
+		t.Fatal("rm deleted a file the argument did not name, without asking")
+	}
+	if !strings.Contains(err.Error(), "-y") || !strings.Contains(err.Error(), pinned) {
+		t.Errorf("the refusal names neither the file nor the way through: %v", err)
+	}
+	if _, statErr := os.Stat(pinned); statErr != nil {
+		t.Error("the file was removed anyway")
+	}
+
+	// -y is that question answered in advance, the way the secret verbs spell
+	// it.
+	if err := removeProfile([]string{"mytool", "-y"}); err != nil {
+		t.Fatalf("-y did not answer the question: %v", err)
+	}
+	if _, err := os.Stat(pinned); !os.IsNotExist(err) {
+		t.Error("-y left the file in place")
+	}
+}
+
+// Asking for help is not a mistake. The verbs parse their own flags, and the
+// flag package reports --help as an error, so without translating it here
+// `brig profile rm --help` answers a reasonable question with
+// `brig: flag: help requested` and exits 1. The secret group already answers
+// its own the other way.
+func TestProfileHelpPrintsUsageAndSucceeds(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("BRIG_PROFILE_DIR", dir)
+	if err := profile.Load(profile.Dir()); err != nil {
+		t.Fatal(err)
+	}
+	for _, args := range [][]string{
+		{"rm", "--help"}, {"rm", "-h"}, {"--help"}, {"-h"}, {"help"},
+	} {
+		out, err := captureStdout(t, func() error { return profileCmd(args) })
+		if err != nil {
+			t.Errorf("profile %v: %v", args, err)
+		}
+		if !strings.Contains(out, "brig profile rm") {
+			t.Errorf("profile %v printed no usage:\n%s", args, out)
+		}
+	}
+}
+
+// noAnswer gives a test a stdin of its own, closed: nothing to ask on, and an
+// answer that is not yes if anything asks anyway. `go test` usually hands the
+// binary /dev/null, but a test binary run from a terminal would otherwise sit
+// waiting for someone to type.
+func noAnswer(t *testing.T) {
+	t.Helper()
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	w.Close()
+	orig := os.Stdin
+	os.Stdin = r
+	t.Cleanup(func() { os.Stdin = orig; r.Close() })
+}
+
+// The same silent delete the confirmation exists to stop, reached through an
+// alias: `brig profile rm claude` resolves to claude-code, and a file called
+// claude.yaml has the stem the argument spells, so the file-name test alone
+// waves it through. What the person typed is not the profile brig found, which
+// is the whole condition.
+func TestRemoveProfileAsksWhenAnAliasResolvedElsewhere(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("BRIG_PROFILE_DIR", dir)
+	// The file is called claude.yaml and declares claude-code: the stem is the
+	// word typed, the profile inside it is not.
+	path := filepath.Join(dir, "claude.yaml")
+	blob := []byte("name: claude-code\nimage: docker.io/me/pinned:latest\n" +
+		"guestHome: /home/claude\nbinary: claude\nmem: 1\ncpus: 1\n")
+	if err := os.WriteFile(path, blob, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := profile.Load(profile.Dir()); err != nil {
+		t.Fatal(err)
+	}
+	noAnswer(t)
+
+	err := removeProfile([]string{"claude"})
+	if err == nil {
+		t.Fatal("rm deleted the file an alias resolved to, without asking")
+	}
+	if !strings.Contains(err.Error(), "-y") || !strings.Contains(err.Error(), path) {
+		t.Errorf("the refusal names neither the file nor the way through: %v", err)
+	}
+	if _, statErr := os.Stat(path); statErr != nil {
+		t.Error("the file was removed anyway")
+	}
+	// -y is the same answer given in advance, so the alias still works: this
+	// asks a question, it does not close the door.
+	if err := removeProfile([]string{"claude", "-y"}); err != nil {
+		t.Fatalf("-y did not answer the question: %v", err)
+	}
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Error("-y left the file in place")
+	}
+}
+
+// The message has to name every file the delete takes, not only the ones the
+// argument did not name. profile.Remove takes both files here, so a refusal
+// that names only pinned.yaml understates what was about to happen by one
+// file -- and that message is the only thing the person has to decide on.
+func TestRemoveProfileNamesEveryFileItWouldDelete(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("BRIG_PROFILE_DIR", dir)
+	blob := []byte("name: mytool\nimage: i\nguestHome: /home/x\nbinary: x\nmem: 1\ncpus: 1\n")
+	for _, base := range []string{"mytool.yaml", "pinned.yaml"} {
+		if err := os.WriteFile(filepath.Join(dir, base), blob, 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	_ = profile.Load(profile.Dir()) // duplicates are reported, not fatal
+	noAnswer(t)
+
+	err := removeProfile([]string{"mytool"})
+	if err == nil {
+		t.Fatal("rm deleted two files without asking")
+	}
+	for _, base := range []string{"mytool.yaml", "pinned.yaml"} {
+		if !strings.Contains(err.Error(), filepath.Join(dir, base)) {
+			t.Errorf("the refusal does not name %s: %v", base, err)
+		}
+	}
+}
+
+// Export writes the name into the file, so a destination that is an alias is a
+// profile that answers to a word already spoken for. Lookup prefers a registry
+// hit over an alias, so `brig profile export claude-code claude` would make
+// every `brig run claude` mean the copy, with the built-in reachable only
+// under its full name. Same collision as a reserved name, refused the same
+// way.
+func TestExportRefusesADestinationThatIsAnAlias(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("BRIG_PROFILE_DIR", dir)
+	if err := profile.Load(profile.Dir()); err != nil {
+		t.Fatal(err)
+	}
+	err := exportProfile([]string{"claude-code", "claude"})
+	if err == nil {
+		t.Fatal("export wrote a profile named after an alias")
+	}
+	if !strings.Contains(err.Error(), "claude-code") {
+		t.Errorf("the refusal does not say what the name collides with: %v", err)
+	}
+	if _, statErr := os.Stat(filepath.Join(dir, "claude.yaml")); !os.IsNotExist(statErr) {
+		t.Error("the file was written anyway")
 	}
 }

--- a/cmd/brig/secret.go
+++ b/cmd/brig/secret.go
@@ -174,7 +174,7 @@ func readSecret(out io.Writer, args []string) error {
 }
 
 func deleteSecret(out io.Writer, args []string) error {
-	name, yes, err := nameAndYes(args)
+	name, yes, err := nameAndYes("delete", "brig secret delete gh-token", args)
 	if err != nil {
 		return err
 	}
@@ -317,14 +317,18 @@ func readAnswer(r io.Reader) (string, error) {
 	return bufio.NewReader(io.LimitReader(r, maxAnswerBytes)).ReadString('\n')
 }
 
-// nameAndYes parses a delete's arguments: the one name, and the -y that says
-// the question has already been answered.
+// nameAndYes parses the arguments of a verb that takes one name and the -y
+// that says its question has already been answered.
 //
 // Same shape as nameAndFile, and for the same reason: `delete -y gh-token` and
 // `delete gh-token -y` are both lines people type, and Parse stops at the
 // first bare word.
-func nameAndYes(args []string) (name string, yes bool, err error) {
-	fs := flag.NewFlagSet("delete", flag.ContinueOnError)
+//
+// The verb and the example it prints are parameters because `brig profile rm`
+// asks a question of its own now, and every word of these messages is about
+// the command the person typed. Two copies of the loop below would drift.
+func nameAndYes(verb, example string, args []string) (name string, yes bool, err error) {
+	fs := flag.NewFlagSet(verb, flag.ContinueOnError)
 	fs.SetOutput(io.Discard)
 	fs.Usage = func() {}
 	fs.BoolVar(&yes, "y", false, "")
@@ -342,7 +346,7 @@ func nameAndYes(args []string) (name string, yes bool, err error) {
 			} else {
 				msg = rewriteFlagError(err).Error()
 			}
-			return "", false, fmt.Errorf("%s (delete takes -y)", msg)
+			return "", false, fmt.Errorf("%s (%s takes -y)", msg, verb)
 		}
 		if fs.NArg() == 0 {
 			break
@@ -352,11 +356,11 @@ func nameAndYes(args []string) (name string, yes bool, err error) {
 	}
 	switch len(words) {
 	case 0:
-		return "", false, errors.New("delete needs a name, for example `brig secret delete gh-token`")
+		return "", false, fmt.Errorf("%s needs a name, for example `%s`", verb, example)
 	case 1:
 		name = words[0]
 	default:
-		return "", false, fmt.Errorf("delete takes one name, not %q", words[1])
+		return "", false, fmt.Errorf("%s takes one name, not %q", verb, words[1])
 	}
 	return name, yes, nil
 }

--- a/docs/profiles.md
+++ b/docs/profiles.md
@@ -9,7 +9,7 @@ rather than from a blank file:
 
 ```bash
 brig profile export claude-code mine   # writes ~/.config/brig/mine.yaml
-brig profile edit mine                 # change name: to mine, and the image
+brig profile edit mine                 # change the image, and what it forwards
 brig run mine
 ```
 
@@ -17,10 +17,12 @@ The second word is a *name*, not a path: brig puts the file in your profile
 directory, which is the only place a profile file does anything. It writes
 nowhere else -- a destination with a `/` in it is refused, not honoured.
 
-Note that brig keys on the `name:` field inside the file, not on the file
-name, so a freshly exported `mine.yaml` still says `name: claude-code` and is
-still the claude-code profile until you change that line. Export says so when
-the two disagree.
+It is also the name the profile itself carries. brig keys on the `name:` field
+inside the file rather than on the file name, so export writes the name you
+gave it into the file: `mine.yaml` says `name: mine`, and every command that
+takes a profile takes `mine` from that point on. Nothing else in the file is
+touched, so the image, the guest home and the comments still describe the
+profile you copied -- that is what the edit in the second line is for.
 
 The exported file carries a header explaining every field, so you can edit it
 without coming back here. Once you have a profile of your own on disk,
@@ -59,7 +61,8 @@ A profile may be backed by more than one file, because a file need not be
 named after the profile inside it. Two files declaring one name is a mistake
 with no winner worth having -- which survives depends on where the names
 happen to sort -- so brig reports it and says which one won.
-`brig profile rm` takes all of them.
+`brig profile rm` takes all of them, after asking: a second file is by
+definition not the file you named.
 
 A file may take a built-in's name. That is deliberate: it is how you pin your
 own image for a profile brig already knows about, without inventing a second
@@ -88,6 +91,14 @@ comments and your ordering survive.
 and nowhere else, so a path -- or a typo that looks like one -- is refused
 rather than honoured. Wanting a copy elsewhere already has a spelling: export
 to stdout and redirect it, under the shell's rules rather than brig's.
+
+A destination that is already spoken for is refused too, because the
+destination is the name written into the file. `claude` is how brig spells
+`claude-code`, and a profile actually called `claude` wins the lookup over
+that alias, so `brig profile export claude-code claude` would make every
+`brig run claude` mean the copy and leave the built-in reachable only under
+its full name. A name a `reserved:` profile owns is refused for the same
+reason. Both say what the collision is; pick another name.
 
 Export writes YAML because a profile is a file a person edits, and YAML has
 comments. Use `brig profile export --json` if something downstream consumes
@@ -744,6 +755,17 @@ merged set, so it takes aliases and it finds the file whatever that file is
 called. If more than one file declares the name, it takes all of them --
 removing only the one that loaded would promote the other and leave the
 profile listed exactly as before.
+
+That resolution is why `rm` asks. `mytool.yaml` for `brig profile rm mytool`
+is the file you named, and it goes without a word. Anything else -- an alias,
+a second file declaring the same profile, a file renamed by hand -- is a file
+brig found and you did not type, so it is named and the delete waits for a
+`y`. `-y` answers in advance, the way `brig secret delete` spells it, and with
+no terminal to ask on `rm` refuses and says so rather than assuming yes:
+
+```bash
+brig profile rm claude -y   # the alias resolves to claude-code's file
+```
 
 Built-in profiles are compiled in, so there is nothing to remove -- import a
 profile of the same name to shadow one instead.

--- a/internal/profile/export_test.go
+++ b/internal/profile/export_test.go
@@ -143,3 +143,161 @@ func TestFirstHeaderLineIsAPrefixOfExportHeader(t *testing.T) {
 		t.Errorf("firstHeaderLine appears %d times in exportHeader, want 1:\n%s", got, exportHeader)
 	}
 }
+
+// Export under a name of the caller's choosing rewrites the profile's own
+// name and leaves the rest of the file alone. The rename is what makes the
+// documented recipe work -- export the closest profile under a name of your
+// own, edit it, run it -- and the rest of the file is what makes starting
+// from an existing profile worth doing at all.
+func TestExportAsRenamesTheProfileAndNothingElse(t *testing.T) {
+	reset(t)
+	p, ok := Lookup("claude-code")
+	if !ok {
+		t.Fatal("claude-code is missing")
+	}
+	blob, err := ExportAs(p, "mytool")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// It declares the name it was asked for, and reads back as that profile:
+	// brig keys on this field, so anything else is a file that cannot be
+	// addressed by the name it was written under.
+	got, err := Parse(blob)
+	if err != nil {
+		t.Fatalf("the renamed export does not parse: %v\n%s", err, blob)
+	}
+	if got.Name != "mytool" {
+		t.Errorf("name = %q, want mytool", got.Name)
+	}
+	if got.Image != p.Image || got.GuestHome != p.GuestHome {
+		t.Error("the rename changed more than the name")
+	}
+	// The other places the word appears in an export are a list entry's field
+	// and the header's field reference. Neither is the profile's name.
+	if !strings.Contains(string(blob), "- name: claude-credentials") {
+		t.Errorf("a secret's own name was rewritten:\n%s", blob)
+	}
+	if !strings.Contains(string(blob), "outrank Claude Code's subscription credential") {
+		t.Error("the rename cost the file its comments")
+	}
+	if got := strings.Count(string(blob), firstHeaderLine); got != 1 {
+		t.Errorf("the header appears %d times after a rename, want 1", got)
+	}
+	// The header explains the fields and says nothing about which profile this
+	// is, which is what keeps it true after a rename. A header that named the
+	// profile it was copied from would describe a file that no longer exists
+	// under that name.
+	header, _, _ := strings.Cut(string(blob), "\nname:")
+	if strings.Contains(header, p.Name) {
+		t.Errorf("the header still describes %s:\n%s", p.Name, header)
+	}
+	// The plain export is unchanged: nothing was asked to be renamed.
+	same, err := ExportAs(p, p.Name)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if plain, err := Export(p); err != nil || string(plain) != string(same) {
+		t.Errorf("exporting under the profile's own name rewrote the file: %v", err)
+	}
+}
+
+// A body with no top-level name: line to rewrite -- a profile of your own
+// written as JSON, or a flow mapping on one line -- still has to come out
+// declaring the name it was exported under. It loses its comments to the
+// marshaller, which is the price of a file the line-based rewrite cannot
+// reach, and a file that lied about its own name is not an alternative.
+func TestExportAsFallsBackWhenThereIsNoNameLineToRewrite(t *testing.T) {
+	reset(t)
+	dir := t.TempDir()
+	flow := []byte(`{name: flowagent, image: docker.io/me/f:latest, ` +
+		`guestHome: /home/f, binary: f, mem: 1, cpus: 1}`)
+	if err := os.WriteFile(filepath.Join(dir, "flowagent.yaml"), flow, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := Load(dir); err != nil {
+		t.Fatal(err)
+	}
+	p, ok := Lookup("flowagent")
+	if !ok {
+		t.Fatal("flowagent did not load")
+	}
+	blob, err := ExportAs(p, "renamed")
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := Parse(blob)
+	if err != nil {
+		t.Fatalf("the fallback export does not parse: %v\n%s", err, blob)
+	}
+	if got.Name != "renamed" {
+		t.Errorf("name = %q, want renamed", got.Name)
+	}
+	if got.Image != p.Image {
+		t.Errorf("the fallback lost the profile's settings: %+v", got)
+	}
+}
+
+// The JSON spelling carries no comments, so the rename is the field and
+// nothing else -- but it is still the same promise: the file declares the name
+// it was written under.
+func TestExportJSONAsRenames(t *testing.T) {
+	reset(t)
+	p, _ := Lookup("codex")
+	blob, err := ExportJSONAs(p, "robot")
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := Parse(blob)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Name != "robot" {
+		t.Errorf("name = %q, want robot", got.Name)
+	}
+	// The value it was called on is a copy: renaming an export must not rename
+	// the profile the registry is holding.
+	if p.Name != "codex" {
+		t.Errorf("ExportJSONAs renamed the caller's profile: %q", p.Name)
+	}
+}
+
+// A profile written on Windows, or edited by something that keeps CRLF, comes
+// back as it went in. The rename is a text edit on one line, and the export is
+// verbatim everywhere else -- so a line that arrived ending in \r\n has to
+// leave ending in \r\n. Rebuilding it with a bare \n leaves one LF line in a
+// CRLF file, which is a byte the export was never asked to change and enough
+// to make a diff of the two files noise.
+func TestExportAsKeepsTheLineEndingsItWasGiven(t *testing.T) {
+	reset(t)
+	dir := t.TempDir()
+	src := firstHeaderLine + " Edit it, then: brig profile import <this file>\r\n" +
+		"name: mytool\r\n" +
+		"image: docker.io/me/mine:latest\r\n" +
+		"guestHome: /home/mytool\r\n" +
+		"binary: mytool\r\n" +
+		"mem: 1\r\n" +
+		"cpus: 1\r\n"
+	if err := os.WriteFile(filepath.Join(dir, "mytool.yaml"), []byte(src), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := Load(dir); err != nil {
+		t.Fatal(err)
+	}
+	p, ok := Lookup("mytool")
+	if !ok {
+		t.Fatal("the CRLF profile did not load")
+	}
+	blob, err := ExportAs(p, "other")
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := strings.Replace(src, "name: mytool\r\n", "name: other\r\n", 1)
+	if string(blob) != want {
+		t.Errorf("the export is not the file it was given, renamed:\ngot  %q\nwant %q", blob, want)
+	}
+	// Stated separately because it is the failure someone reads in a diff: one
+	// line of a CRLF file ending differently from the rest.
+	if strings.Count(string(blob), "\n") != strings.Count(string(blob), "\r\n") {
+		t.Errorf("the rename left a bare LF among the CRLF lines:\n%q", blob)
+	}
+}

--- a/internal/profile/file.go
+++ b/internal/profile/file.go
@@ -501,6 +501,106 @@ func Export(p Profile) ([]byte, error) {
 	return append([]byte(exportHeader), body...), nil
 }
 
+// ExportAs renders a profile under a name of the caller's choosing, so a file
+// written as mytool.yaml declares the mytool profile rather than the one it
+// was copied from.
+//
+// Starting from the closest existing profile is the documented way to write
+// one, and the recipe brig prints for it stopped at its second step until this
+// existed: export wrote the file under the name you gave it while the profile
+// inside kept the name it came from, so `brig profile edit mytool` had no such
+// profile to open and the only command that could reach the file named a
+// different profile and deleted it without asking.
+//
+// The rename is a rewrite of one line rather than a re-serialisation of the
+// parsed struct, because the comments are the reason export writes YAML at
+// all: why a deny list is what it is, which credential outranks which. Setting
+// Name and marshalling would produce a correct profile with every one of those
+// sentences gone.
+//
+// An empty name, or the profile's own, renders unchanged -- that is the plain
+// `brig profile export claude-code` case, where nothing was asked to be
+// renamed.
+func ExportAs(p Profile, name string) ([]byte, error) {
+	blob, err := Export(p)
+	if err != nil {
+		return nil, err
+	}
+	if name == "" || name == p.Name {
+		return blob, nil
+	}
+	// Parsed again rather than trusted: the line-based rewrite below is a
+	// text edit on a format that has more than one way to write the same
+	// mapping, so the returned bytes have to be checked to actually declare
+	// the name they were asked for. A body it cannot find a top-level name in
+	// -- a profile of your own that was written as JSON, a flow mapping on one
+	// line -- falls through to marshalling, which loses the comments and is
+	// still better than a file that lies about its own name.
+	if renamed, ok := renameField(blob, name); ok {
+		if got, err := Parse(renamed); err == nil && got.Name == name {
+			return renamed, nil
+		}
+	}
+	p.Name = name
+	body, err := yaml.Marshal(p)
+	if err != nil {
+		return nil, err
+	}
+	return append([]byte(exportHeader), body...), nil
+}
+
+// renameField rewrites the value of the top-level name: line and leaves every
+// other byte of the file alone.
+//
+// Column 0 is the whole test, and it is what keeps the rewrite off the two
+// other places the word appears in an export: the `- name:` entries under
+// secrets:, env: and files:, which are indented, and the field reference in
+// the header, where every line starts with a #. Only the first match is
+// rewritten -- a second top-level name: is a duplicate key, which the parser
+// rejects on the way back out.
+//
+// Anything written after the value is kept, comment included: `name: mine
+// # keep in sync with the workspace` is a note someone wrote, and a rename is
+// not a reason to drop it. It may of course now be wrong, but so is deleting
+// it, and only one of those is visible to the person editing the file.
+//
+// The line's own terminator is kept too. Splitting on \n alone leaves the \r
+// of a CRLF file at the end of the line, and rebuilding the line without it
+// would put one LF line in the middle of a CRLF file -- a byte the export was
+// not asked to change, and enough to make a diff of before and after read as
+// two changes rather than one.
+func renameField(blob []byte, name string) ([]byte, bool) {
+	lines := bytes.Split(blob, []byte("\n"))
+	for i, line := range lines {
+		body, eol := line, []byte(nil)
+		if bytes.HasSuffix(body, []byte("\r")) {
+			body, eol = body[:len(body)-1], []byte("\r")
+		}
+		key, rest, ok := bytes.Cut(body, []byte(":"))
+		if !ok || string(key) != "name" {
+			continue
+		}
+		renamed := append([]byte("name: "+name), trailingComment(rest)...)
+		lines[i] = append(renamed, eol...)
+		return bytes.Join(lines, []byte("\n")), true
+	}
+	return nil, false
+}
+
+// trailingComment is what a value line carries after its value, from the
+// whitespace that separates the two so the alignment someone chose survives
+// the rename.
+func trailingComment(rest []byte) []byte {
+	i := bytes.IndexByte(rest, '#')
+	if i < 0 {
+		return nil
+	}
+	for i > 0 && (rest[i-1] == ' ' || rest[i-1] == '\t') {
+		i--
+	}
+	return rest[i:]
+}
+
 // ExportJSON renders a profile as JSON, for anything generating or consuming
 // profiles programmatically.
 func ExportJSON(p Profile) ([]byte, error) {
@@ -509,6 +609,15 @@ func ExportJSON(p Profile) ([]byte, error) {
 		return nil, err
 	}
 	return append(blob, '\n'), nil
+}
+
+// ExportJSONAs is ExportAs for the JSON spelling. JSON carries no comments, so
+// there is nothing to preserve and the name is simply set before marshalling.
+func ExportJSONAs(p Profile, name string) ([]byte, error) {
+	if name != "" {
+		p.Name = name
+	}
+	return ExportJSON(p)
 }
 
 // IsCustom reports whether a name is served by a file rather than by an

--- a/internal/profile/registry.go
+++ b/internal/profile/registry.go
@@ -232,6 +232,19 @@ func Lookup(name string) (Profile, bool) {
 	return Profile{}, false
 }
 
+// Alias reports the profile a short spelling stands for, and whether the word
+// is a spelling at all.
+//
+// Export asks, because it writes the name into the file it creates. Lookup
+// prefers a registry hit over an alias, so a profile actually called claude
+// takes every `brig run claude` from claude-code, which is the profile that
+// word has always meant -- and the built-in stays reachable only under its
+// full name, by someone who has worked out what happened.
+func Alias(name string) (string, bool) {
+	canonical, ok := aliases[name]
+	return canonical, ok
+}
+
 // All returns every profile, in name order. Copies, as Lookup returns.
 func All() []Profile {
 	out := make([]Profile, 0, len(registry))

--- a/script/smoke.sh
+++ b/script/smoke.sh
@@ -548,9 +548,38 @@ grep -q 'metered path' "$WORK/codex.yaml" 2>/dev/null \
 ls "$BRIG_PROFILE_DIR" | grep -q -- '--json' \
   && bad "a file was written for a mistyped flag" \
   || ok "no file is written for a mistyped flag"
-# rm resolves the name inside the file, not the file name: bare.yaml declares
-# codex, so that is what removes it.
-"$WORK/brig" profile rm codex > /dev/null 2>&1
+# The destination is the name written into the file, and a profile of that name
+# wins the lookup over an alias -- so exporting onto one would take every
+# `brig run claude` from claude-code.
+"$WORK/brig" profile export claude-code claude > /dev/null 2>&1 \
+  && bad "export wrote a profile named after an alias" \
+  || ok "export refuses a destination that is an alias"
+[ -f "$BRIG_PROFILE_DIR/claude.yaml" ] \
+  && bad "the aliased destination was written anyway" \
+  || ok "no file is written for an aliased destination"
+# Asking for help is not a mistake, though the flag package calls it an error.
+"$WORK/brig" profile rm --help > "$WORK/rmhelp.out" 2>&1 \
+  && ok "profile rm --help exits 0" \
+  || bad "profile rm --help exits 0: $(cat "$WORK/rmhelp.out")"
+grep -q 'brig profile rm' "$WORK/rmhelp.out" \
+  && ok "profile rm --help prints the usage" \
+  || bad "profile rm --help prints the usage: $(cat "$WORK/rmhelp.out")"
+# rm resolves the name inside the file, not the file name: rename what
+# bare.yaml declares, and codex is the word that reaches it. Nothing is deleted
+# for that word without a question first, though -- the file it would take is
+# not the file anyone named, and stdin here has nobody on it to ask.
+sed 's/^name: bare$/name: codex/' "$BRIG_PROFILE_DIR/bare.yaml" > "$WORK/bare.yaml"
+cp "$WORK/bare.yaml" "$BRIG_PROFILE_DIR/bare.yaml"
+"$WORK/brig" profile rm codex < /dev/null > "$WORK/rm.out" 2>&1 \
+  && bad "rm deleted a file nobody named, without asking" \
+  || ok "rm refuses to delete a file you did not name with no terminal to ask on"
+grep -q 'bare.yaml' "$WORK/rm.out" \
+  && ok "rm names the file it would delete" \
+  || bad "rm names the file it would delete: $(cat "$WORK/rm.out")"
+[ -f "$BRIG_PROFILE_DIR/bare.yaml" ] \
+  && ok "the file nobody named is still there" \
+  || bad "the file nobody named was deleted anyway"
+"$WORK/brig" profile rm codex -y < /dev/null > /dev/null 2>&1
 [ -f "$BRIG_PROFILE_DIR/bare.yaml" ] \
   && bad "rm did not resolve the profile inside the file" \
   || ok "rm resolves the profile a file declares, not its file name"
@@ -559,14 +588,16 @@ ls "$BRIG_PROFILE_DIR" | grep -q -- '--json' \
 # profile in it. brig says which won, and rm takes both -- removing only the
 # winner would promote the other and leave the profile listed.
 "$WORK/brig" profile export codex dup > /dev/null 2>&1
-sed 's/^name: codex$/name: dupagent/' "$BRIG_PROFILE_DIR/dup.yaml" > "$WORK/dup2.yaml"
+sed 's/^name: dup$/name: dupagent/' "$BRIG_PROFILE_DIR/dup.yaml" > "$WORK/dup2.yaml"
 cp "$WORK/dup2.yaml" "$BRIG_PROFILE_DIR/dup.yaml"
 cp "$WORK/dup2.yaml" "$BRIG_PROFILE_DIR/dupother.yaml"
 "$WORK/brig" profiles > "$WORK/dup.out" 2>&1
 grep -q 'duplicate profile name' "$WORK/dup.out" \
   && ok "two files claiming one profile are reported" \
   || bad "two files claiming one profile are reported: $(cat "$WORK/dup.out")"
-"$WORK/brig" profile rm dupagent > /dev/null 2>&1
+# -y: neither file is named after the profile they both declare, and rm asks
+# before deleting a file the argument did not name.
+"$WORK/brig" profile rm dupagent -y < /dev/null > /dev/null 2>&1
 { [ -f "$BRIG_PROFILE_DIR/dup.yaml" ] || [ -f "$BRIG_PROFILE_DIR/dupother.yaml" ]; } \
   && bad "rm left a file still declaring the profile" \
   || ok "rm takes every file declaring the profile"
@@ -606,6 +637,34 @@ EDITOR="$WORK/bin/fake-editor" "$WORK/brig" profile edit mine > /dev/null 2>&1 \
 grep -q 'edited by the smoke test' "$BRIG_PROFILE_DIR/mine.yaml" \
   && ok "profile edit saves what the editor wrote" \
   || bad "profile edit saves what the editor wrote"
+
+# The recipe brig prints, end to end: export the closest built-in under a name
+# of your own, edit it, run it, remove it by the name you chose. Every step
+# addresses the name the person picked, which is why export writes that name
+# into the file rather than leaving the profile called what it was copied from.
+"$WORK/brig" profile export claude-code mytool > /dev/null 2>&1
+grep -q '^name: mytool$' "$BRIG_PROFILE_DIR/mytool.yaml" 2>/dev/null \
+  && ok "export writes the name it was given into the file" \
+  || bad "export writes the name it was given into the file"
+grep -q 'outrank' "$BRIG_PROFILE_DIR/mytool.yaml" 2>/dev/null \
+  && ok "a renamed export still carries the comments" \
+  || bad "a renamed export still carries the comments"
+EDITOR="$WORK/bin/fake-editor" "$WORK/brig" profile edit mytool > /dev/null 2>&1 \
+  && ok "the exported profile edits under the name it was exported as" \
+  || bad "the exported profile edits under the name it was exported as"
+: > "$STUB_LOG"
+"$WORK/brig" run mytool -w "$WORK/ws-mytool" -p hi > /dev/null 2>&1
+grep -q -- '--name brig-mytool' "$STUB_LOG" \
+  && ok "the exported profile runs under the name it was exported as" \
+  || bad "the exported profile runs under the name it was exported as"
+grep -q -- '-- claude -p hi' "$STUB_LOG" \
+  && ok "the run is the profile it was copied from, renamed" \
+  || bad "the run is the profile it was copied from, renamed"
+"$WORK/brig" profile rm mytool < /dev/null > /dev/null 2>&1
+[ -f "$BRIG_PROFILE_DIR/mytool.yaml" ] \
+  && bad "rm did not remove the profile under the name it was exported as" \
+  || ok "rm removes the profile under the name it was exported as, asking nothing"
+"$WORK/brig" reset > /dev/null 2>&1
 
 # The old spellings keep working for one release, and say so.
 "$WORK/brig" agents > "$WORK/dep.out" 2>&1


### PR DESCRIPTION
## Summary

brig prints a recipe for a profile of your own: export the closest built-in
under a new name, edit it, run it. Run literally, step two failed. Export wrote
the file under the new name while the profile inside kept the name it was
exported from, so `edit` and `rm` could not find it by the name you chose, and
the only command that removed it was one naming a different profile, which
deleted without asking.

Now the recipe runs end to end, and `rm` asks before deleting a file whose
profile name does not match the argument.

Seen on the built binary:

```
$ brig profile export claude-code mytool
wrote claude-code as mytool -> .../brig/mytool.yaml
its image, guest home and comments still describe claude-code
$ brig profile edit mytool
.../brig/mytool.yaml updated
$ brig run mytool          # resolves the profile; fails only on the absent runtime
$ brig profile rm mytool
removed .../brig/mytool.yaml
```

## Related issues

Closes #40

## Changes

- `internal/profile/file.go`: `ExportAs` / `ExportJSONAs` rewrite the one
  top-level `name:` line in the exported bytes and keep everything else byte for
  byte. Export hands back the profile's source bytes with a comment header, not
  a re-marshalled struct, so setting `Name` and marshalling was not an option:
  it would have produced a correct profile with every comment gone, which is the
  reason export writes YAML at all.
- The export path writes the destination stem as the name, refuses a
  destination that collides with a reserved profile, and prints that the image,
  guest home and comments still describe the source. The stale "change name: to
  X" hint is gone.
- `confirmRemoveProfile`: a file whose stem equals the argument is removed
  silently; anything else, an alias, a second file declaring the name, a
  hand-renamed file, is named on stderr and waits for `y`. `-y` answers ahead,
  and no terminal is a refusal that names the flag. The secret verbs' confirm
  parser was generalised so both share it; `brig secret delete` is unchanged.
- Tests for export, edit, run and rm under a new name, the confirmation, the
  rename mechanics and JSON, plus the full recipe in smoke.

## Checklist

- [x] `make all` passes (vet, test, build)
- [x] `script/smoke.sh` passes
- [x] I have added or updated tests covering the change
- [x] I have run `go test ./... -race`, if the change touches concurrency, subprocesses or the daemon
- [x] I have exercised the change against a real runtime (`brig run <agent>`), if it touches the run, exec or credential path
- [ ] ~~I have updated the affected docs~~ (README and docs/profiles.md are updated)

The last box: the recipe was run end to end on the built binary here, through
`run`, which failed only on the absent runtime rather than on the profile name.
A real boot was not needed to prove the fix.

## Credentials and the sandbox boundary

The rm change touches safety in the small: a destructive command no longer
deletes a file the user did not name without asking. No credential path is
affected.
