### PR TITLE
feat(wrap): give a sandbox a network posture, and add an offline mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,8 @@ so an agent flag spelled like one of brig's still reaches the agent.
 | `--cpus N` | guest vCPUs |
 | `-d, --detach` | with `run`: start the sandbox, print its name, exit |
 | `--skills` | seed your own `~/.claude` skills and plugins into the workspace |
+| `--network MODE` | `shared` or `offline` (or `BRIG_NETWORK`) |
+| `--offline` | shorthand for `--network offline`: no route out of the sandbox |
 
 Each flag overrides the corresponding `BRIG_*` setting, which overrides the
 profile.
@@ -633,6 +635,7 @@ Booleans are shell-style: anything except `0` is on.
 | `BRIG_CPUS` | per profile (4) | Guest vCPUs |
 | `BRIG_READY_TIMEOUT` | `30` | Seconds to wait for the in-guest agent after the runtime reports the sandbox running. The two are not the same moment |
 | `BRIG_TITLE` | per profile | Window title, for a graphical agent |
+| `BRIG_NETWORK` | per profile (`shared`) | `shared` or `offline`. `offline` boots the sandbox with no route out: the agent runs, the workspace is there, nothing leaves. Same as `--network`; `--offline` is shorthand for `--network offline`. An unrecognised value refuses the run |
 | `BRIG_SKILLS` | `0` | Seed the profile's `hostConfigDir`/`projectPaths` into the workspace -- for Claude Code, `~/.claude/skills` and `~/.claude/plugins`. Same as `--skills`; see [Your own skills in the guest](#your-own-skills-in-the-guest) |
 
 ### Credentials

--- a/cmd/brig/hygiene_test.go
+++ b/cmd/brig/hygiene_test.go
@@ -100,3 +100,32 @@ func TestLsAndResetRefuseArguments(t *testing.T) {
 		}
 	}
 }
+
+// --network takes a value and --offline is its shorthand for one posture. The
+// pair exists because "offline" is the word the request is usually phrased in,
+// and a flag that reads like the sentence is worth two lines of plumbing.
+func TestParseNetworkAndOffline(t *testing.T) {
+	o, profileName, _, err := parse([]string{"--network", "offline", "claude"})
+	if err != nil {
+		t.Fatalf("--network offline: %v", err)
+	}
+	if profileName != "claude" {
+		t.Errorf("profile = %q, want claude", profileName)
+	}
+	if o.load.Network != "offline" {
+		t.Errorf("network = %q, want offline", o.load.Network)
+	}
+
+	if o, _, _, err = parse([]string{"--offline", "claude"}); err != nil {
+		t.Fatalf("--offline: %v", err)
+	}
+	if o.load.Network != "offline" {
+		t.Errorf("--offline gave network %q, want offline", o.load.Network)
+	}
+
+	// Saying both, and disagreeing, is a mistake worth naming rather than a
+	// silent precedence puzzle.
+	if _, _, _, err = parse([]string{"--offline", "--network", "shared", "claude"}); err == nil {
+		t.Error("--offline with --network shared was accepted")
+	}
+}

--- a/cmd/brig/main.go
+++ b/cmd/brig/main.go
@@ -71,6 +71,9 @@ flags (before the agent's own arguments; -- ends brig's parsing):
                          envelope before the agent starts
       --skills           project your own ~/.claude skills and plugins into
                          the guest, read-only (or BRIG_SKILLS=1)
+      --network MODE     shared or offline (or BRIG_NETWORK)
+      --offline          shorthand for --network offline: the agent runs, the
+                         workspace is there, nothing leaves
 
 Workspaces persist. The sandbox keeps running between commands, so a second
 run is immediate; state lives in the workspace on the host either way.
@@ -347,6 +350,7 @@ type options struct {
 	nameGiven bool
 	detach    bool
 	quiet     bool
+	offline   bool
 }
 
 // brigFlags is what brig owns on a run line. Everything else on that line
@@ -366,6 +370,8 @@ var brigFlags = []struct {
 	{long: "cpus", value: true},
 	{long: "detach", short: "d"},
 	{long: "skills"},
+	{long: "network", value: true},
+	{long: "offline"},
 	{long: "quiet", short: "q"},
 }
 
@@ -489,6 +495,12 @@ func parse(args []string) (o options, profileName string, tail []string, err err
 		// Opt-in, and only ever opt-in: this hands the guest the user's real
 		// skills and plugins, read-only.
 		{"skills", "", func(n string) { fs.BoolVar(&o.load.Skills, n, false, "") }},
+		// The posture this run takes: shared or offline. Refused by name later
+		// if it is neither, in the one place every source of it is resolved.
+		{"network", "", func(n string) { fs.StringVar(&o.load.Network, n, "", "") }},
+		// Sugar for --network offline, which is the word the request is usually
+		// phrased in.
+		{"offline", "", func(n string) { fs.BoolVar(&o.offline, n, false, "") }},
 		// Suppresses the execution envelope on run and create, for a script or
 		// a returning session that has already seen it.
 		{"quiet", "q", func(n string) { fs.BoolVar(&o.quiet, n, false, "") }},
@@ -531,6 +543,17 @@ func parse(args []string) (o options, profileName string, tail []string, err err
 	o.nameGiven = seen(fs, "name", "n")
 	if o.nameGiven && o.load.Name == "" {
 		return options{}, "", nil, errors.New("--name needs a session name, for example `--name foo`")
+	}
+	// --offline is shorthand for one --network value, so the two agreeing is
+	// fine and the two disagreeing is a mistake worth naming: a silent winner
+	// would leave the run with a posture the line does not read like.
+	if o.offline {
+		if o.load.Network != "" && o.load.Network != "offline" {
+			return options{}, "", nil, fmt.Errorf(
+				"--offline and --network %s ask for different things; --offline is --network offline",
+				o.load.Network)
+		}
+		o.load.Network = "offline"
 	}
 	return o, profileName, tail, nil
 }

--- a/docs/profiles.md
+++ b/docs/profiles.md
@@ -126,6 +126,7 @@ with the same parser and neither has to guess.
 | `staleCredentialFiles` | no | Paths an older wrapper used to write a credential into. brig never does, so finding one is worth a warning rather than a deletion |
 | `headless` | no | The agent supports a non-interactive run |
 | `guiTitle` | no | Window title, for a `kind: gui` profile |
+| `network` | no | the sandbox's network posture: `shared` (the default: one network for every sandbox on this host) or `offline` (no route out at all). `BRIG_NETWORK`, `--network` and `--offline` win over it |
 | `hypervisor` | no | macOS backend to boot on: `vz` (the default, and the only one with a graphical console), `hvi` or `qemu`. `BRIG_HYPERVISOR` wins over it. Ignored on Linux, where the shim decides |
 | `runtimeBin` | no | The runtime binary to drive instead of the one on `PATH`, `~` expanded. Unlike every other field this is about your machine rather than the workload, so it does not travel usefully to anyone else -- it is how you pin a profile to a build you are working on without exporting a variable in every shell. `BRIG_RUNTIME_BIN` wins over it |
 | `rootfsType` | no | How the guest root reaches the VM: `block`, `virtiofs` or `9pfs`. Left unset the runtime picks its own default, which is what a profile that only runs an agent wants. Set `block` when the sandbox installs packages and needs a real writable disk rather than a share sized to the image |

--- a/internal/profile/file.go
+++ b/internal/profile/file.go
@@ -166,6 +166,11 @@ func (p Profile) Validate() error {
 	default:
 		return fmt.Errorf("hypervisor %q is not one of vz, hvi or qemu", p.Hypervisor)
 	}
+	switch p.Network {
+	case "", "shared", "offline":
+	default:
+		return fmt.Errorf("network %q is not one of shared or offline", p.Network)
+	}
 	switch p.RootfsType {
 	case "", "block", "virtiofs", "9pfs":
 	default:

--- a/internal/profile/file_test.go
+++ b/internal/profile/file_test.go
@@ -295,3 +295,21 @@ func TestLoadIgnoresAMissingDirectory(t *testing.T) {
 		t.Errorf("a missing directory was an error: %v", err)
 	}
 }
+
+// The network field is an enum, checked at load like hypervisor: a typo must
+// not travel to a boot whose posture nobody meant.
+func TestValidateChecksTheNetworkEnum(t *testing.T) {
+	base := Profile{Name: "x", Image: "i", GuestHome: "/home/x", Binary: "x", Mem: 1, CPUs: 1}
+	for _, ok := range []string{"", "shared", "offline"} {
+		p := base
+		p.Network = ok
+		if err := p.Validate(); err != nil {
+			t.Errorf("network %q was rejected: %v", ok, err)
+		}
+	}
+	p := base
+	p.Network = "airgapped"
+	if err := p.Validate(); err == nil {
+		t.Error("network \"airgapped\" was accepted")
+	}
+}

--- a/internal/profile/profile.go
+++ b/internal/profile/profile.go
@@ -177,6 +177,18 @@ type Profile struct {
 	// than whichever the host defaults to -- hvi for its introspection, say.
 	// Ignored on Linux, where the shim decides.
 	Hypervisor string `json:"hypervisor,omitempty"`
+	// Network is the posture this workload wants: shared or offline. Empty
+	// means shared, which is what every sandbox has had until now: one network
+	// for every sandbox on the host. Whether the sandboxes on it can reach
+	// each other is the backend's answer rather than brig's, and it is not the
+	// same answer everywhere -- see docs/security.md. offline is a sandbox
+	// with no route out at all: the agent runs, the workspace is there,
+	// nothing leaves.
+	//
+	// A profile states it when the workload's posture is a property of the
+	// work rather than of the run: a formatter that only ever touches the
+	// workspace has no business holding a route to the internet.
+	Network string `json:"network,omitempty"`
 	// RuntimeBin is the runtime binary to drive instead of the one on PATH.
 	//
 	// Unlike every other field this one is about your machine rather than the

--- a/internal/wrap/config.go
+++ b/internal/wrap/config.go
@@ -91,6 +91,10 @@ type Config struct {
 	// VerifyPolicy is what counts as ours.
 	Verify       verify.Mode
 	VerifyPolicy verify.Policy
+	// Network is the posture this run was resolved to. Held here so the
+	// envelope, the report and the spec handed to the runtime cannot disagree
+	// about what a reader was told.
+	Network Network
 	// BootDigest is the registry digest verifyDigest resolved and checked, set
 	// only on a runtime that boots by digest. EnsureRunning hands it to the
 	// runtime so the object that boots is the object that verified; empty means
@@ -133,6 +137,9 @@ type Options struct {
 	// plugins) read-only into the guest. Off unless asked for: it is the
 	// user's real config, and handing it to a sandbox should be a decision.
 	Skills bool
+	// Network is the posture asked for on the command line, and beats both the
+	// setting and the profile. Empty means nothing was asked for.
+	Network string
 }
 
 // Load resolves the configuration for one invocation.
@@ -254,6 +261,21 @@ func Load(t profile.Profile, o Options, rt runtime.Runtime) (*Config, error) {
 		strictErr = err
 	}
 
+	// Flag beats setting beats profile, the order every other setting follows.
+	// Resolved once here so the envelope row and the spec cannot disagree. The
+	// source travels with the value so a refusal names what was actually typed.
+	netValue, netSource := o.Network, "--network"
+	if netValue == "" {
+		netValue, netSource = env.String("NETWORK", ""), env.settingName("NETWORK")
+	}
+	if netValue == "" {
+		netValue, netSource = t.Network, "the profile's network:"
+	}
+	network, err := ParseNetworkStrict(netValue, netSource)
+	if err != nil && strictErr == nil {
+		strictErr = err
+	}
+
 	c := &Config{
 		Profile:        t,
 		Runtime:        rt,
@@ -275,6 +297,7 @@ func Load(t profile.Profile, o Options, rt runtime.Runtime) (*Config, error) {
 		GitHosts:       env.Fields("GIT_HOSTS", []string{"github.com"}),
 		GitIdentity:    env.Bool("GIT_IDENTITY", true),
 		TrustWorkspace: strict("TRUST_WORKSPACE", true),
+		Network:        network,
 		Verify:         verifyMode,
 		VerifyPolicy:   verifyPolicy(env),
 		AllowRefs:      strict("ALLOW_REFS", false),

--- a/internal/wrap/env.go
+++ b/internal/wrap/env.go
@@ -116,6 +116,15 @@ func (e Env) setting(key string) string {
 	return "BRIG_" + key
 }
 
+// settingName is setting without the value, for a message that quotes the
+// value itself and would otherwise print it twice.
+func (e Env) settingName(key string) string {
+	if name, _, ok := e.getNamed(key); ok {
+		return name
+	}
+	return "BRIG_" + key
+}
+
 // Int reads a setting as a number, falling back on anything unparseable
 // rather than failing the run over a typo in a tuning knob.
 func (e Env) Int(key string, fallback int) int {

--- a/internal/wrap/envelope.go
+++ b/internal/wrap/envelope.go
@@ -62,6 +62,10 @@ func (c *Config) envelope(set creds.Set) []envelopeRow {
 		// verify-mode row will carry, so it is deliberately not folded in here.
 		envelopeRow{"IMAGE", fmt.Sprintf("%s (pull %s)", c.Image, c.Pull)},
 		envelopeRow{"CREDENTIALS", c.credentialLine(set)},
+		// The posture, said out loud. It decides what the agent can reach, and
+		// until it appeared here the only way to know was to remember which
+		// setting the run was started with.
+		envelopeRow{"NETWORK", c.Network.Line()},
 	)
 	return rows
 }

--- a/internal/wrap/envelope_test.go
+++ b/internal/wrap/envelope_test.go
@@ -167,3 +167,32 @@ func TestEnvelopeUnderReportsAMalformedFileRefAndTheRunThenFails(t *testing.T) {
 		t.Error("a malformed file ref was written rather than failing the run")
 	}
 }
+
+// The posture is a fact about the sandbox, so it belongs in the block that
+// names the boundary rather than in a setting a reader has to go looking for.
+func TestEnvelopeNamesTheNetworkPosture(t *testing.T) {
+	for _, tc := range []struct{ posture, want string }{
+		{"shared", "shared"},
+		{"offline", "offline"},
+	} {
+		c := envelopeConfig()
+		c.Network = Network(tc.posture)
+		block := &bytes.Buffer{}
+		c.renderEnvelope(block, creds.Set{})
+		got := block.String()
+		if !strings.Contains(got, "NETWORK") {
+			t.Fatalf("%s: no NETWORK row:\n%s", tc.posture, got)
+		}
+		if !strings.Contains(got, tc.want) {
+			t.Errorf("%s: the row does not name the posture:\n%s", tc.posture, got)
+		}
+	}
+	// Offline says what it means for the reader, not only the word.
+	c := envelopeConfig()
+	c.Network = NetOffline
+	block := &bytes.Buffer{}
+	c.renderEnvelope(block, creds.Set{})
+	if !strings.Contains(block.String(), "no egress") {
+		t.Errorf("the offline row does not say what it costs:\n%s", block.String())
+	}
+}

--- a/internal/wrap/load_test.go
+++ b/internal/wrap/load_test.go
@@ -159,3 +159,78 @@ func TestVerifyAndSkillsFailClosedOnATypo(t *testing.T) {
 		})
 	}
 }
+
+// BRIG_NETWORK decides the sandbox's network posture, so it is a security
+// switch: an unrecognised value refuses the load naming the valid words, the
+// same contract BRIG_VERIFY keeps.
+func TestNetworkFailsClosedOnATypo(t *testing.T) {
+	t.Setenv("BRIG_NETWORK", "maybe")
+	pr, ok := profile.Lookup("claude-code")
+	if !ok {
+		t.Fatal("no claude-code profile")
+	}
+	if _, err := Load(pr, Options{}, nil); err == nil {
+		t.Fatal("BRIG_NETWORK=maybe did not refuse the load")
+	}
+}
+
+// Precedence is flag over env over profile over default, the order every other
+// setting keeps.
+func TestNetworkPrecedence(t *testing.T) {
+	pr, ok := profile.Lookup("claude-code")
+	if !ok {
+		t.Fatal("no claude-code profile")
+	}
+	// Default: shared.
+	c, err := Load(pr, Options{}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if c.Network != "shared" {
+		t.Errorf("default network = %q, want shared", c.Network)
+	}
+	// Profile beats default.
+	pp := pr
+	pp.Network = "offline"
+	if c, err = Load(pp, Options{}, nil); err != nil || c.Network != "offline" {
+		t.Errorf("profile network: got %q, %v", c.Network, err)
+	}
+	// Env beats profile.
+	t.Setenv("BRIG_NETWORK", "shared")
+	if c, err = Load(pp, Options{}, nil); err != nil || c.Network != "shared" {
+		t.Errorf("env network: got %q, %v", c.Network, err)
+	}
+	// Flag beats env.
+	if c, err = Load(pp, Options{Network: "offline"}, nil); err != nil || c.Network != "offline" {
+		t.Errorf("flag network: got %q, %v", c.Network, err)
+	}
+}
+
+// The refusal names the source the value came from. Someone who typed a flag
+// and is told about an environment variable goes looking for a variable they
+// never set, which is the same misreporting the security switches were fixed
+// for in #27.
+func TestNetworkRefusalNamesWhatWasTyped(t *testing.T) {
+	pr, ok := profile.Lookup("claude-code")
+	if !ok {
+		t.Fatal("no claude-code profile")
+	}
+	_, err := Load(pr, Options{Network: "wat"}, nil)
+	if err == nil {
+		t.Fatal("--network wat was accepted")
+	}
+	if !strings.Contains(err.Error(), "--network") {
+		t.Errorf("a flag refusal does not name the flag: %v", err)
+	}
+	if strings.Contains(err.Error(), "BRIG_NETWORK") {
+		t.Errorf("a flag refusal blames the environment variable: %v", err)
+	}
+
+	t.Setenv("BRIG_NETWORK", "wat")
+	if _, err = Load(pr, Options{}, nil); err == nil {
+		t.Fatal("BRIG_NETWORK=wat was accepted")
+	}
+	if !strings.Contains(err.Error(), "BRIG_NETWORK") {
+		t.Errorf("a setting refusal does not name the setting: %v", err)
+	}
+}

--- a/internal/wrap/network.go
+++ b/internal/wrap/network.go
@@ -1,0 +1,73 @@
+package wrap
+
+import "fmt"
+
+// Network is the posture a sandbox runs with.
+type Network string
+
+const (
+	// NetShared is one network for every sandbox on the host. What brig has
+	// always done, and still the default. Whether the sandboxes on it can
+	// reach each other is the backend's answer, not brig's: on Linux they can,
+	// on both macOS backends they cannot. See docs/security.md.
+	NetShared Network = "shared"
+	// NetOffline is a sandbox with no route out. The agent runs, the workspace
+	// is mounted, nothing leaves.
+	NetOffline Network = "offline"
+)
+
+// ParseNetworkStrict reads a posture and refuses anything it does not
+// recognise. source is how the value reached brig -- a flag, a setting, a
+// profile field -- and it is named in the refusal, because being told about
+// BRIG_NETWORK when you typed --network sends you looking for a variable you
+// never set.
+//
+// Strict for the same reason the security switches are: this decides whether a
+// sandbox can reach the network at all, so a typo must stop the run rather
+// than quietly pick a posture nobody asked for. The empty string is the unset
+// case and keeps the default.
+func ParseNetworkStrict(s, source string) (Network, error) {
+	switch s {
+	case "":
+		return NetShared, nil
+	case string(NetShared):
+		return NetShared, nil
+	case string(NetOffline):
+		return NetOffline, nil
+	default:
+		return NetShared, fmt.Errorf("%s %q is not a posture: use shared or offline", source, s)
+	}
+}
+
+// RuntimeNet is the word the runtime adapters take for this posture. The two
+// vocabularies are deliberately separate: "offline" is what a person asks for,
+// "none" is what a runtime is told.
+func (n Network) RuntimeNet() string {
+	if n == NetOffline {
+		return "none"
+	}
+	return "shared"
+}
+
+// Line is the posture as a reader is told it, with the consequence spelled
+// out: "offline" on its own is a word, and what a reader needs is what it
+// costs them.
+//
+// Beside RuntimeNet deliberately. A posture has two vocabularies, the
+// runtime's and the reader's, and keeping both on the type means a posture
+// added later cannot pick up one translation and quietly miss the other.
+//
+// The shared line describes the topology and stops there. Whether one sandbox
+// can actually reach another on that network is a property of the backend, not
+// of this setting. On both macOS backends they cannot: a packet capture shows
+// an ARP broadcast crossing between guests on hvi, and the unicast reply not
+// crossing back, so neither guest ever learns the other's address. On Linux
+// they can. A row claiming either would be false somewhere, so it claims what
+// is true everywhere: these sandboxes are on one network rather than each on
+// its own.
+func (n Network) Line() string {
+	if n == NetOffline {
+		return "offline (no egress)"
+	}
+	return "shared (one network for every sandbox on this host)"
+}

--- a/internal/wrap/run.go
+++ b/internal/wrap/run.go
@@ -270,7 +270,7 @@ func (c *Config) EnsureRunning(set creds.Set) error {
 		Image:  c.Image,
 		Digest: c.BootDigest,
 		Pull:   c.Pull,
-		Net:    "shared",
+		Net:    c.Network.RuntimeNet(),
 		Mem:    c.Mem,
 		CPUs:   c.CPUs,
 		// The workspace, which is the guest's home. The host's agent

--- a/internal/wrap/run_test.go
+++ b/internal/wrap/run_test.go
@@ -78,3 +78,19 @@ func TestEnsureRunningRefusesBeforePreparingTheWorkspace(t *testing.T) {
 		t.Errorf("the workspace was prepared before the refusal: marker present (%v)", statErr)
 	}
 }
+
+// The posture the run resolved to is the posture the runtime is told about.
+// Net was a hardcoded "shared" for the whole life of the field, so nothing
+// downstream had ever seen anything else.
+func TestRunSpecCarriesTheResolvedNetwork(t *testing.T) {
+	for _, tc := range []struct{ posture, want string }{
+		{"shared", "shared"},
+		{"offline", "none"},
+	} {
+		c := testConfig(t, t.TempDir(), t.TempDir())
+		c.Network = Network(tc.posture)
+		if got := c.Network.RuntimeNet(); got != tc.want {
+			t.Errorf("%s: runtime net = %q, want %q", tc.posture, got, tc.want)
+		}
+	}
+}

--- a/script/smoke.sh
+++ b/script/smoke.sh
@@ -232,6 +232,36 @@ grep -q '^argv: run ' "$STUB_LOG" \
   && bad "a second run booted a second sandbox" \
   || ok "a running sandbox is reused, not rebooted"
 
+echo "== network =="
+# The posture the run resolved to is the posture the runtime is told about.
+# Net was a hardcoded "shared" for the whole life of the field, so this is the
+# check that the resolved value actually travels.
+"$WORK/brig" reset > /dev/null 2>&1
+: > "$STUB_LOG"
+"$WORK/brig" run claude --offline -d > "$WORK/off.out" 2>&1
+grep -q -- '--net none' "$STUB_LOG" \
+  && ok "--offline reaches the runtime as --net none" \
+  || bad "--offline reaches the runtime as --net none -- got: $(grep '^argv: run' "$STUB_LOG")"
+grep -q '^NETWORK .*offline' "$WORK/off.out" \
+  && ok "the envelope says the sandbox is offline" \
+  || bad "the envelope says the sandbox is offline -- got: $(cat "$WORK/off.out")"
+
+"$WORK/brig" reset > /dev/null 2>&1
+: > "$STUB_LOG"
+"$WORK/brig" run claude -d > "$WORK/on.out" 2>&1
+grep -q -- '--net shared' "$STUB_LOG" \
+  && ok "a default run still asks for the shared network" \
+  || bad "a default run still asks for the shared network -- got: $(grep '^argv: run' "$STUB_LOG")"
+grep -q '^NETWORK .*shared' "$WORK/on.out" \
+  && ok "the envelope names the shared posture" \
+  || bad "the envelope names the shared posture -- got: $(cat "$WORK/on.out")"
+
+# A posture brig does not know must stop the run rather than pick one.
+out="$(BRIG_NETWORK=airgapped "$WORK/brig" env claude 2>&1)"; rc=$?
+[ "$rc" != 0 ] && ok "an unknown BRIG_NETWORK refuses the run" \
+  || bad "an unknown BRIG_NETWORK started anyway: $out"
+"$WORK/brig" reset > /dev/null 2>&1
+
 echo "== denylist =="
 : > "$STUB_LOG"
 out="$(ANTHROPIC_API_KEY=sk-metered BRIG_FORWARD_ENV='ANTHROPIC_API_KEY GH_TOKEN' \


### PR DESCRIPTION
## What this does

Gives a sandbox a network posture, and adds an offline mode. First step of #15.

`RunSpec.Net` has been the literal string `shared` since the field existed, written once at the only place a spec is built. Both runtime adapters already understood `none`, and neither had ever been sent it, so there was no way to run an agent with no route out. Nothing in any report said what a sandbox could reach either.

## The control

A profile states `network: shared` or `network: offline`. `BRIG_NETWORK` (and `BRIG_<AGENT>_NETWORK`) overrides the profile, `--network` overrides that, and `--offline` is shorthand for `--network offline`. Precedence is flag over setting over profile, the order every other setting follows, and it is resolved once so the envelope row and the spec handed to the runtime cannot disagree.

`--offline` together with `--network shared` is refused rather than settled by a precedence rule the reader cannot see.

`offline` reaches the runtime as `--net none` on hull and `--network none` on nerdctl.

## Failing closed

The posture decides whether a sandbox can reach the network at all, so it reads through a strict parser like the security switches and `BRIG_VERIFY`: an unrecognised value refuses the run instead of picking a posture nobody asked for.

The refusal names the source the value came from:

```
$ brig info claude --network wat
brig: --network "wat" is not a posture: use shared or offline

$ BRIG_NETWORK=wat brig info claude
brig: BRIG_NETWORK "wat" is not a posture: use shared or offline
```

Being told about `BRIG_NETWORK` when you typed a flag sends you looking for a variable you never set, which is the misreporting #27 fixed for the security switches.

## In the envelope

```
NETWORK      shared (one network for every sandbox on this host)
NETWORK      offline (no egress)
```

That is the row the envelope's own comment has been reserving since it was written. The posture is a fact about the sandbox, so it belongs in the block that names the boundary rather than in a setting a reader has to go looking for.

## What this does not do

This adds a posture, not separation. Whether two sandboxes on `shared` can reach each other turns out to be a property of the backend, and it is not the same answer everywhere:

| backend | can one sandbox reach another? |
| --- | --- |
| `hvi` on macOS | no |
| `vz` on macOS | no |
| Linux | **yes** |

That was measured after this PR was opened (#94), and it is why the envelope row says only what is true everywhere: these sandboxes are on one network rather than each on its own. An earlier draft of the row claimed they could reach each other, which is false on both macOS backends.

Closing the Linux gap is the next slice (#95). The egress allowlist is after it, gated on hull growing a gateway filter (brig-sh/hull#19).

## Tests

Profile enum validation; strict refusal and its source naming; precedence across flag, setting, profile and default; posture-to-runtime mapping; the `NETWORK` envelope row for both postures; `--offline`/`--network` conflict.

Smoke covers the line the unit tests cannot: that the resolved posture actually reaches the runtime. `--offline` must produce `--net none` in the stub's argv log and a default run must still produce `--net shared`. Restoring the old hardcode fails that check, which is the point of it.

Refs #15

