### PR TITLE
fix(runtime): move the sandbox network off 10.87.0.0/24

### DIFF
--- a/docs/manual-tests/runtime-stdin.md
+++ b/docs/manual-tests/runtime-stdin.md
@@ -21,7 +21,7 @@ brig-claude-code
 
 $ hull ps
 ID                STATUS   EXIT  PID    IP         CREATED
-brig-claude-code  running  -     34585  10.87.0.2  2026-08-17 18:34:19
+brig-claude-code  running  -     34585  198.18.0.2  2026-08-17 18:34:19
 ```
 
 The sandbox came up on the first attempt; no image-pull or boot problems, so

--- a/docs/runtimes.md
+++ b/docs/runtimes.md
@@ -79,8 +79,16 @@ hull exec [-t] [--cwd <dir>] [-u <user>] [--env <NAME>]... <name> -- <cmd>...
 hull stop <name>
 hull rm <name>
 hull network-gateway --socket <path> --qemu-socket <path>.qemu
-     --subnet 10.87.0.0/24 --gateway-ip 10.87.0.1   # internal/runtime/gateway.go
+     --subnet 198.18.0.0/24 --gateway-ip 198.18.0.1   # internal/runtime/gateway.go
 ```
+
+brig picks that subnet from 198.18.0.0/15, the range RFC 2544 reserves for
+network benchmarking: it is never routed on the public internet and almost
+nothing claims it, so a sandbox network is unlikely to collide with something
+the workspace needs to reach. The alternatives are all crowded -- 10.0.0.0/8 by
+corporate VPNs and cloud VPCs, 172.16.0.0/12 by Docker, 192.168.0.0/16 by home
+routers and by vmnet on macOS, and 100.64.0.0/10 by Tailscale. The sibling
+198.19.0.0/16 is left alone because OrbStack uses it.
 
 `hull exec` is the whole exec path: the reachability probe, the captured read,
 the credential written over stdin and the terminal handover all build the same

--- a/docs/security.md
+++ b/docs/security.md
@@ -560,7 +560,7 @@ guest is whatever the runtime allows, and there is no per-sandbox policy yet.
 It does not isolate one sandbox from another. Sandboxes share a network, not
 just a host: brig asks every runtime for its shared network, unconditionally
 and with no setting to say otherwise. On the `hvi` hypervisor that is one
-gateway serving every sandbox on `10.87.0.0/24`, with brig handing out the
+gateway serving every sandbox on `198.18.0.0/24`, with brig handing out the
 addresses on it; on `vz` and on Linux it is the runtime's own shared network.
 Members of one virtual network can reach each other, which is what makes two
 sandboxes able to talk at all -- and it means two agents you gave *different*

--- a/internal/runtime/gateway.go
+++ b/internal/runtime/gateway.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"syscall"
 	"time"
 )
@@ -25,12 +26,26 @@ const (
 	gatewayReadyTimeout = 10 * time.Second
 	gatewayPollInterval = 100 * time.Millisecond
 
-	// The virtual network the gateway serves. hull defaults to exactly this,
-	// but brig passes it explicitly: brig also hands out the addresses on it,
+	// The virtual network the gateway serves. brig passes it explicitly rather
+	// than leaning on hull's default: brig also hands out the addresses on it,
 	// and an allocator working from a different subnet than the gateway is a
-	// failure nobody would find quickly.
-	gatewaySubnet = "10.87.0.0/24"
-	gatewayAddr   = "10.87.0.1"
+	// failure nobody would find quickly. formatGatewayCIDR derives guest
+	// addresses from this rather than repeating it, so the two cannot drift.
+	//
+	// 198.18.0.0/15 is the range RFC 2544 reserves for network benchmarking.
+	// It is never routed on the public internet and almost nothing claims it,
+	// which is the property that matters here: a sandbox network that collides
+	// with something real takes the workspace's own traffic with it. The
+	// obvious candidates all lose. 10.0.0.0/8 is where corporate VPNs and
+	// cloud VPCs live, and the previous 10.87.0.0/24 sat one octet from
+	// Podman's default 10.88.0.0/16. 172.16.0.0/12 is Docker's, which walks up
+	// from 172.17 as networks are created. 192.168.0.0/16 is home routers, and
+	// on macOS vmnet already uses 192.168.64.0/24. 100.64.0.0/10 looks unused
+	// until you notice Tailscale lives there.
+	//
+	// The sibling 198.19.0.0/16 is left alone: OrbStack uses it.
+	gatewaySubnet = "198.18.0.0/24"
+	gatewayAddr   = "198.18.0.1"
 	gatewayPrefix = 24
 
 	// Guests start at .2. The gateway is the network address plus one, which
@@ -52,7 +67,20 @@ func gatewaySocket() (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("no home directory to place the gateway socket in: %w", err)
 	}
-	return filepath.Join(home, ".brig", "gateway.sock"), nil
+	// The network the gateway serves is part of the name. ensureGateway reuses
+	// whatever is already listening here without asking what it serves, so a
+	// gateway left over from a different subnet would be reused for guests
+	// that are not on it: brig would hand out an address the process on the
+	// other end does not route, and the sandbox would come up with no network
+	// and nothing pointing at the cause. A different network is a different
+	// socket, which also lets sandboxes from before a subnet move keep the
+	// gateway they were booted against until they are removed.
+	return filepath.Join(home, ".brig", "gateway-"+socketTag(gatewaySubnet)+".sock"), nil
+}
+
+// socketTag turns a subnet into something that can sit in a filename.
+func socketTag(subnet string) string {
+	return strings.NewReplacer("/", "_", ".", "-").Replace(subnet)
 }
 
 // qemuGatewaySocket mirrors hull's own derivation. hull takes the control

--- a/internal/runtime/gateway_test.go
+++ b/internal/runtime/gateway_test.go
@@ -1,0 +1,43 @@
+package runtime
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// The socket a gateway is reached on names the network it serves, because
+// ensureGateway reuses whatever is already listening there without asking what
+// it is serving. Moving the subnet while a gateway from the old one is still
+// running would otherwise reuse it: brig would hand new guests an address on
+// the new network while the process on the other end still routed the old one,
+// and the sandbox would come up with no working network and nothing to point
+// at. A subnet in the name means a different network is a different socket.
+func TestGatewaySocketNamesTheSubnet(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+	t.Setenv("BRIG_GATEWAY_SOCK", "")
+
+	sock, err := gatewaySocket()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(filepath.Base(sock), socketTag(gatewaySubnet)) {
+		t.Errorf("the socket name does not carry the subnet %s: %s", gatewaySubnet, sock)
+	}
+	// The property that matters: a different network is a different socket, so
+	// a gateway serving the old one is never picked up for guests on the new.
+	if socketTag("10.87.0.0/24") == socketTag(gatewaySubnet) {
+		t.Error("two different subnets produce the same socket name")
+	}
+	// And the tag has to survive being a filename.
+	if strings.ContainsAny(socketTag(gatewaySubnet), "/") {
+		t.Errorf("the socket tag is not filename-safe: %s", socketTag(gatewaySubnet))
+	}
+	// An explicit override still wins, unchanged: it is how a test, or someone
+	// running two brigs, points at a gateway of their own.
+	t.Setenv("BRIG_GATEWAY_SOCK", filepath.Join(dir, "mine.sock"))
+	if sock, err = gatewaySocket(); err != nil || filepath.Base(sock) != "mine.sock" {
+		t.Errorf("BRIG_GATEWAY_SOCK was not honoured: %s (%v)", sock, err)
+	}
+}

--- a/internal/runtime/gatewayip.go
+++ b/internal/runtime/gatewayip.go
@@ -3,6 +3,7 @@ package runtime
 import (
 	"encoding/json"
 	"fmt"
+	"net/netip"
 	"os"
 	"path/filepath"
 	"sort"
@@ -129,6 +130,12 @@ func lowestFreeHost(assigned map[string]int) (int, error) {
 		"Remove some sandboxes with `brig rm`", gatewaySubnet, len(names), names)
 }
 
+// formatGatewayCIDR is the address for a guest, built from the subnet the
+// gateway serves rather than from a second copy of its octets. The two used to
+// be independent literals, which is one edit away from handing every guest an
+// address on a network nothing routes.
 func formatGatewayCIDR(host int) string {
-	return fmt.Sprintf("10.87.0.%d/%d", host, gatewayPrefix)
+	base := netip.MustParsePrefix(gatewaySubnet).Addr().As4()
+	base[3] = byte(host)
+	return fmt.Sprintf("%s/%d", netip.AddrFrom4(base), gatewayPrefix)
 }

--- a/internal/runtime/gatewayip_test.go
+++ b/internal/runtime/gatewayip_test.go
@@ -1,6 +1,7 @@
 package runtime
 
 import (
+	"net/netip"
 	"os"
 	"path/filepath"
 	"strings"
@@ -112,5 +113,36 @@ func TestLowestFreeHostReportsAFullNetwork(t *testing.T) {
 		t.Fatal("expected a full network to be reported")
 	} else if !strings.Contains(err.Error(), "brig rm") {
 		t.Errorf("error does not say how to free one: %v", err)
+	}
+}
+
+// The addresses handed out must come from the subnet the gateway is told to
+// serve. They were two independent literals, so moving one and not the other
+// gave every guest an address on a network nothing was routing -- the failure
+// the subnet comment warns about, and one that shows up as "the sandbox has no
+// network" rather than as anything pointing here.
+func TestHandedOutAddressesSitInTheServedSubnet(t *testing.T) {
+	net, err := netip.ParsePrefix(gatewaySubnet)
+	if err != nil {
+		t.Fatalf("gatewaySubnet %q does not parse: %v", gatewaySubnet, err)
+	}
+	for _, host := range []int{firstGuestHost, 17, lastGuestHost} {
+		cidr := formatGatewayCIDR(host)
+		addr, err := netip.ParsePrefix(cidr)
+		if err != nil {
+			t.Fatalf("formatGatewayCIDR(%d) = %q, which does not parse: %v", host, cidr, err)
+		}
+		if !net.Contains(addr.Addr()) {
+			t.Errorf("guest address %s is outside the served subnet %s", cidr, gatewaySubnet)
+		}
+		if addr.Bits() != net.Bits() {
+			t.Errorf("guest address %s has prefix /%d, the subnet is /%d", cidr, addr.Bits(), net.Bits())
+		}
+	}
+	// The gateway's own address has to be on it too, and hull derives it as
+	// the network address plus one.
+	gw, err := netip.ParseAddr(gatewayAddr)
+	if err != nil || !net.Contains(gw) {
+		t.Errorf("gateway address %s is not in %s (%v)", gatewayAddr, gatewaySubnet, err)
 	}
 }

--- a/internal/runtime/hull_test.go
+++ b/internal/runtime/hull_test.go
@@ -35,7 +35,7 @@ func TestRunArgsDefaultsStayOffTheCommandLine(t *testing.T) {
 }
 
 func TestRunArgsRootfsTypeAndGateway(t *testing.T) {
-	got := argv(t, RunSpec{Name: "s", Image: "img", RootfsType: "block"}, "hvi", "shared", "/tmp/gw.sock", "10.87.0.2/24")
+	got := argv(t, RunSpec{Name: "s", Image: "img", RootfsType: "block"}, "hvi", "shared", "/tmp/gw.sock", "198.18.0.2/24")
 	if !strings.Contains(got, "--rootfs-type block") {
 		t.Errorf("rootfs type not passed: %s", got)
 	}
@@ -46,7 +46,7 @@ func TestRunArgsRootfsTypeAndGateway(t *testing.T) {
 	if !strings.Contains(got, "--gateway-sock /tmp/gw.sock") {
 		t.Errorf("gateway socket not passed: %s", got)
 	}
-	if !strings.Contains(got, "--gateway-cidr 10.87.0.2/24") {
+	if !strings.Contains(got, "--gateway-cidr 198.18.0.2/24") {
 		t.Errorf("gateway CIDR not passed alongside the socket: %s", got)
 	}
 }
@@ -58,7 +58,7 @@ func TestRunArgsGatewayFlagsTravelTogether(t *testing.T) {
 		name, sock, cidr string
 	}{
 		{name: "neither"},
-		{name: "both", sock: "/tmp/gw.sock", cidr: "10.87.0.7/24"},
+		{name: "both", sock: "/tmp/gw.sock", cidr: "198.18.0.7/24"},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			got := argv(t, RunSpec{Name: "s", Image: "img"}, "hvi", "shared", tt.sock, tt.cidr)


### PR DESCRIPTION
## What this does

Moves the sandbox network from `10.87.0.0/24` to `198.18.0.0/24`.

`10.87` sat one octet from Podman's default `10.88.0.0/16`, and `10.0.0.0/8` generally is where corporate VPNs and cloud VPCs live. A sandbox network that collides with one of those takes the workspace's own traffic with it, and the symptom is a host the agent cannot reach for reasons that look nothing like a networking choice brig made.

## Why this range

`198.18.0.0/15` is what RFC 2544 reserves for network benchmarking: never routed on the public internet, and almost nothing claims it. Every obvious alternative was already taken on a normal development machine, checked rather than assumed:

| range | who has it |
| --- | --- |
| `100.64.0.0/10` | Tailscale |
| `172.17/16`, `172.18/16` | Docker, walking upward as networks are created |
| `192.168.17/25` | the LAN |
| `192.168.64/24` | vmnet, which is what the `vz` sandboxes use |
| `10.88.0.0/16` | Podman, one octet from where brig was |

The sibling `198.19.0.0/16` is left alone because OrbStack uses it.

It also leaves room for what #15 needs next: per-sandbox `198.18.N.0/24` carved from the `/16`, rather than every sandbox sharing one `/24`.

## Two things that would have gone wrong

**The guest address was a second copy of the subnet.** `gatewaySubnet` said `10.87.0.0/24` and `formatGatewayCIDR` independently formatted `10.87.0.%d`. Moving one and not the other hands every guest an address on a network nothing routes, which shows up as "the sandbox has no network" and points nowhere near the cause. The guest address is now derived from the subnet, and a test asserts every handed-out address falls inside the served prefix.

**A gateway from the old subnet would have been reused.** `ensureGateway` reuses whatever is already listening on the socket without asking what it serves. Your running sandboxes keep a gateway alive, so after an upgrade brig would hand new guests a `198.18` address while that process still routed `10.87`. The socket name now carries the network, so a different subnet is a different socket. Sandboxes booted before the move keep the gateway they were booted against until they are removed, instead of losing their network on upgrade.

## Verified on a real boot

```
ip=198.18.0.4::198.18.0.1:255.255.255.0:...
--net-gateway ~/.brig/gateway-198-18-0-0_24.sock.qemu
```

and from inside the guest:

```
addr:   198.18.0.4/24
route:  default via 198.18.0.1 dev eth0
egress: HTTP 404      (reached api.anthropic.com)
dns:    resolves
```

Three sandboxes already running on the old subnet stayed up throughout, on their own gateway, with both sockets present side by side.

## Note on hull

hull's own default is still `10.87.0.0/24`. brig passes `--subnet` and `--gateway-ip` explicitly so this does not depend on hull changing, but the default is worth moving there too for a bare `hull network-gateway`.

Refs #15
