### PR TITLE
docs(security): say per backend whether a sandbox can reach another

### DIFF
--- a/README.md
+++ b/README.md
@@ -675,7 +675,7 @@ Removed: `BRIG_CREDENTIALS_CMD` ran a command of yours on every boot to read the
 | `BRIG_RUNTIME` | `hull` on macOS, `nerdctl` elsewhere | Which backend to drive |
 | `BRIG_RUNTIME_BIN` | first of `hull` / `nerdctl`, `docker` on PATH | Path to that binary |
 | `BRIG_HYPERVISOR` | `vz` | Hypervisor backend, macOS only: `vz`, `hvi` or `qemu`. Only `vz` has a graphical console, so a GUI profile is refused on the others |
-| `BRIG_GATEWAY_SOCK` | `~/.brig/gateway.sock` | Control socket of the user-mode network gateway. `hvi` has no egress without one, so brig starts a shared gateway there and joins every sandbox to it |
+| `BRIG_GATEWAY_SOCK` | `~/.brig/gateway-<subnet>.sock` | Control socket of the user-mode network gateway. `hvi` has no egress without one, so brig starts a shared gateway there and joins every sandbox to it. The default name carries the network it serves, so a gateway left from a different subnet is never reused for guests that are not on it |
 | `BRIG_BOOT_ASSETS` | whatever `hull assets dir` reports on macOS, `$XDG_DATA_HOME/brig/assets` (default `~/.local/share/brig/assets`) on Linux | Directory holding the host kernel and `container-initrd` used to boot a profile marked `genericBoot`. The kernel is named `Image` on arm64 and `bzImage` on x86_64. Set it and brig uses what is there, unchanged; leave it unset and brig downloads the pair on first use (hull on macOS, `oras` on Linux) |
 | `BRIG_BOOT_ASSETS_REF` | `ghcr.io/nofireai/hull-assets:<os>-<arch>` | The bundle brig fetches when the boot assets are missing. Override to pin a version or use a mirror |
 | `BRIG_ROOTFS_TYPE` | profile's `rootfsType` | How the guest root reaches the VM: `block`, `virtiofs` or `9pfs` |

--- a/docs/manual-tests/sandbox-reachability.md
+++ b/docs/manual-tests/sandbox-reachability.md
@@ -1,0 +1,98 @@
+# Manual test: can one sandbox reach another?
+
+`docs/security.md` said, under "Things brig does not claim", that sandboxes
+share a broadcast domain and that each can reach whatever the other is
+listening on. Nothing measured it. This is the measurement, and it says the
+claim was true on one of the three backends and false on the other two.
+
+CI cannot run any of it: `ci.yml` is Linux-only and never boots a VM, so the
+macOS half has no machine-verifiable form at all, and the Linux half needs a
+real containerd rather than the stub `script/smoke.sh` drives.
+
+## The method, and why it is shaped this way
+
+Two sandboxes on the same network. A listener bound to `0.0.0.0` in the first,
+then a connection attempted from the second.
+
+A failed connection on its own proves nothing: a closed port, a listener bound
+to loopback, or a wrong address all look the same from the far end. So every
+run below first proves the listener is reachable **from off the guest** --
+from the host, and from the guest's own non-loopback address -- and only then
+tries the peer. Without those two controls a negative result is not evidence.
+They earned it: on Linux the first attempt used `httpd`, which is absent from
+the image, and the controls caught the broken listener before it could be
+read as isolation.
+
+The ARP entry on the far side is the second signal. `FAILED` means the peer
+never answered at layer 2; a resolved `lladdr` means it did.
+
+## macOS, `hvi`
+
+Host: macOS 26.x, Apple Silicon, hull 0.1.0-rc21, `claude-code-stock`.
+Sandboxes `10.87.0.4` and `10.87.0.5` on the shared `/24` of the day.
+
+| check | result |
+| --- | --- |
+| listener in A, via A's own address | HTTP 200 |
+| host to A | not run on this backend |
+| **B to A** | **failed to connect** |
+| B's ARP for A | `FAILED` |
+| B's own egress | HTTP 404 from `api.anthropic.com`, so B's network works |
+| A's access log | only A's own request; B's never arrived |
+
+## macOS, `vz`
+
+Same host. vmnet DHCP put the sandboxes on `192.168.64.7` and `192.168.64.8`.
+
+| check | result |
+| --- | --- |
+| listener in A, via A's own address | HTTP 200 |
+| **host to A** | **HTTP 200**, logged as `192.168.64.1` |
+| **B to A** | **failed to connect**, twice |
+| B's ARP for A | `FAILED` |
+| B's own egress | HTTP 404 from `api.anthropic.com` |
+| A's access log | two entries, A's own and the host's; nothing from B |
+
+The host request is what makes this conclusive rather than suggestive. The
+listener is provably reachable from outside the guest, so the peer's failure
+is not a firewall in the guest, a bad bind, or a closed port.
+
+## Linux, nerdctl
+
+Host: Amazon Linux 2023, kernel 6.18.41, x86_64, root, no user-mode
+networking. nerdctl 2.0.3, containerd 2.0.2, the CNI plugins from the
+`nerdctl-full` bundle, `alpine`.
+
+Two containers started with **no `--network` flag**, which is exactly what
+brig passes in the shared case (`internal/runtime/nerdctl.go`), so they land
+on the default bridge `nerdctl0`, `10.4.0.0/24`, at `.3` and `.4`.
+
+| check | result |
+| --- | --- |
+| listener in A (`nc`), via A's own address | `ok` |
+| **host to A** | `ok` |
+| **B to A** | **`ok` -- it reached the listener** |
+| B's ARP for A | `lladdr 52:40:33:73:d9:98 ... REACHABLE` |
+| B's own network | internet reachable, bridge gateway reachable |
+
+## Offline
+
+`--network none`, which is what `brig --offline` becomes on this runtime,
+gives a guest with only `lo`, zero routes and no egress. The same image on the
+default bridge has `eth0` and reaches the internet. Checked on Linux here and
+on both macOS backends when `--offline` was added.
+
+## What it means
+
+The backends do not agree, so no single sentence covers them:
+
+| backend | can one sandbox reach another? | why |
+| --- | --- | --- |
+| `hvi` | no | the gvisor gateway gives each guest a point-to-point link and NATs outbound; there is no segment between guests |
+| `vz` | no | vmnet does not bridge guest to guest in the mode hull uses |
+| Linux | yes | the CNI bridge is an ordinary layer 2 segment |
+
+On macOS the separation is a property of the backends rather than something
+brig asks for, so it holds today and nothing enforces that it keeps holding.
+That is what the regression test alongside this file is for. On Linux it is
+absent and has to be built.

--- a/docs/manual-tests/sandbox-reachability.md
+++ b/docs/manual-tests/sandbox-reachability.md
@@ -1,98 +1,102 @@
 # Manual test: can one sandbox reach another?
 
-`docs/security.md` said, under "Things brig does not claim", that sandboxes
-share a broadcast domain and that each can reach whatever the other is
-listening on. Nothing measured it. This is the measurement, and it says the
-claim was true on one of the three backends and false on the other two.
+`docs/security.md` said that sandboxes share a broadcast domain, and that each
+one can reach what the other listens on. Nothing measured it. This file is the
+measurement. The claim is true on Linux and false on both macOS backends.
 
-CI cannot run any of it: `ci.yml` is Linux-only and never boots a VM, so the
-macOS half has no machine-verifiable form at all, and the Linux half needs a
-real containerd rather than the stub `script/smoke.sh` drives.
+CI cannot run any of this. `ci.yml` runs on Linux only and never boots a VM.
 
-## The method, and why it is shaped this way
+## Result
 
-Two sandboxes on the same network. A listener bound to `0.0.0.0` in the first,
-then a connection attempted from the second.
+| backend | can one sandbox reach another? |
+| --- | --- |
+| `hvi` on macOS | no |
+| `vz` on macOS | no |
+| Linux, shared network | **yes** |
+| Linux, `--network isolated` | no |
 
-A failed connection on its own proves nothing: a closed port, a listener bound
-to loopback, or a wrong address all look the same from the far end. So every
-run below first proves the listener is reachable **from off the guest** --
-from the host, and from the guest's own non-loopback address -- and only then
-tries the peer. Without those two controls a negative result is not evidence.
-They earned it: on Linux the first attempt used `httpd`, which is absent from
-the image, and the controls caught the broken listener before it could be
-read as isolation.
+## Method
 
-The ARP entry on the far side is the second signal. `FAILED` means the peer
-never answered at layer 2; a resolved `lladdr` means it did.
+Two sandboxes run on one network. Sandbox A listens on `0.0.0.0`. Sandbox B
+connects to A.
+
+A failed connection alone proves nothing. A closed port, a listener on
+loopback, and a wrong address all look the same to B. Each run below first
+proves that the listener answers from outside the guest. Only then does B try.
+
+These controls are not ceremony. On Linux the first attempt used `httpd`, which
+the image does not contain. The controls caught the dead listener before anyone
+read it as isolation.
 
 ## macOS, `hvi`
 
-Host: macOS 26.x, Apple Silicon, hull 0.1.0-rc21, `claude-code-stock`.
-Sandboxes `10.87.0.4` and `10.87.0.5` on the shared `/24` of the day.
+hull 0.1.0-rc21, `claude-code-stock`, sandboxes at `10.87.0.4` and `10.87.0.5`.
 
-| check | result |
+A packet capture on both guests, with a raw `AF_PACKET` socket, shows the
+mechanism:
+
+| where | what it saw |
 | --- | --- |
-| listener in A, via A's own address | HTTP 200 |
-| host to A | not run on this backend |
-| **B to A** | **failed to connect** |
-| B's ARP for A | `FAILED` |
-| B's own egress | HTTP 404 from `api.anthropic.com`, so B's network works |
-| A's access log | only A's own request; B's never arrived |
+| A | `3x ARP who-has 10.87.0.4 tell 10.87.0.5` |
+| A | `7x ARP reply` sent back to B |
+| A | no TCP at all |
+| B | its own 3 ARP requests, and no reply |
+
+So the guests do share a broadcast domain. B's ARP broadcast reaches A, and A
+answers. The gateway does not forward the unicast reply back to B. B never
+learns the MAC address of A, so B never sends a SYN, and A receives no TCP.
+
+The host cannot reach the guest either, because the gvisor gateway runs in user
+space and the host has no route to that subnet. This is why the capture matters
+here: the usual host control is not available on this backend.
 
 ## macOS, `vz`
 
-Same host. vmnet DHCP put the sandboxes on `192.168.64.7` and `192.168.64.8`.
+Same host. vmnet gave the sandboxes `192.168.64.7` and `192.168.64.8`.
 
 | check | result |
 | --- | --- |
-| listener in A, via A's own address | HTTP 200 |
+| A to its own address | HTTP 200 |
 | **host to A** | **HTTP 200**, logged as `192.168.64.1` |
-| **B to A** | **failed to connect**, twice |
-| B's ARP for A | `FAILED` |
-| B's own egress | HTTP 404 from `api.anthropic.com` |
-| A's access log | two entries, A's own and the host's; nothing from B |
+| **B to A** | **no connection**, twice |
+| B's ARP entry for A | `FAILED` |
+| B to the internet | HTTP 404 from `api.anthropic.com` |
+| access log of A | one entry from A, one from the host, none from B |
 
-The host request is what makes this conclusive rather than suggestive. The
-listener is provably reachable from outside the guest, so the peer's failure
-is not a firewall in the guest, a bad bind, or a closed port.
+The host reaches the listener, so the failure at B is not a firewall in the
+guest, a bad bind, or a closed port.
 
-## Linux, nerdctl
+## Linux
 
-Host: Amazon Linux 2023, kernel 6.18.41, x86_64, root, no user-mode
-networking. nerdctl 2.0.3, containerd 2.0.2, the CNI plugins from the
-`nerdctl-full` bundle, `alpine`.
+Amazon Linux 2023, kernel 6.18.41, x86_64, root, no user-mode network. nerdctl
+2.0.3, containerd 2.0.2, CNI from the `nerdctl-full` bundle, `alpine`.
 
-Two containers started with **no `--network` flag**, which is exactly what
-brig passes in the shared case (`internal/runtime/nerdctl.go`), so they land
-on the default bridge `nerdctl0`, `10.4.0.0/24`, at `.3` and `.4`.
+Two containers start with no `--network` flag, which is what brig passes for
+the shared posture. Both land on the default bridge `nerdctl0`, `10.4.0.0/24`.
 
-| check | result |
-| --- | --- |
-| listener in A (`nc`), via A's own address | `ok` |
-| **host to A** | `ok` |
-| **B to A** | **`ok` -- it reached the listener** |
-| B's ARP for A | `lladdr 52:40:33:73:d9:98 ... REACHABLE` |
-| B's own network | internet reachable, bridge gateway reachable |
+| check | shared network | `--network isolated` |
+| --- | --- | --- |
+| A to its own address | `ok` | `ok` |
+| host to A | `ok` | `ok` |
+| **B to A** | **`ok`** | **timeout** |
+| B's ARP entry for A | `REACHABLE` | none |
+| B to the internet | `ok` | `ok` |
+| subnets | one, `10.4.0.0/24` | two, `10.4.1.0/24` and `10.4.2.0/24` |
+
+The isolated column is the same test with a network for each sandbox. brig
+creates that network in `Run` and removes it in `Remove`.
 
 ## Offline
 
-`--network none`, which is what `brig --offline` becomes on this runtime,
-gives a guest with only `lo`, zero routes and no egress. The same image on the
-default bridge has `eth0` and reaches the internet. Checked on Linux here and
-on both macOS backends when `--offline` was added.
+`--network none` gives a guest with `lo` only, no route, and no egress. The
+same image on the default bridge has `eth0` and reaches the internet. This is
+true on Linux and on both macOS backends.
 
 ## What it means
 
-The backends do not agree, so no single sentence covers them:
+On macOS the separation is real, but it is a property of the backend. brig
+asks for a shared network and gets guests that cannot address each other. No
+test in brig would notice if a runtime change removed this.
 
-| backend | can one sandbox reach another? | why |
-| --- | --- | --- |
-| `hvi` | no | the gvisor gateway gives each guest a point-to-point link and NATs outbound; there is no segment between guests |
-| `vz` | no | vmnet does not bridge guest to guest in the mode hull uses |
-| Linux | yes | the CNI bridge is an ordinary layer 2 segment |
-
-On macOS the separation is a property of the backends rather than something
-brig asks for, so it holds today and nothing enforces that it keeps holding.
-That is what the regression test alongside this file is for. On Linux it is
-absent and has to be built.
+On Linux the separation does not exist by default. `--network isolated` adds
+it.

--- a/docs/runtimes.md
+++ b/docs/runtimes.md
@@ -176,7 +176,12 @@ beyond them:
   (`internal/wrap/secretfiles.go`).
 - `network-gateway`, for the `hvi` backend. That backend has no egress of its
   own, so brig starts one shared gateway and joins every sandbox to it, and
-  hands out the addresses on that network itself.
+  hands out the addresses on that network itself. Sharing a gateway is not the
+  same as sharing a segment: the gateway gives each guest a point-to-point
+  link and translates outbound traffic, so guests reach the internet through
+  it and not each other. See
+  [security.md](security.md#things-brig-does-not-claim) for what that means per
+  backend, which is not the same answer on Linux.
 
 Six of the eight shipped profiles ask for `hvi` and set `genericBoot: true`
 (`internal/profile/specs`), so the default macOS path needs the `hvi` binary

--- a/docs/runtimes.md
+++ b/docs/runtimes.md
@@ -176,10 +176,10 @@ beyond them:
   (`internal/wrap/secretfiles.go`).
 - `network-gateway`, for the `hvi` backend. That backend has no egress of its
   own, so brig starts one shared gateway and joins every sandbox to it, and
-  hands out the addresses on that network itself. Sharing a gateway is not the
-  same as sharing a segment: the gateway gives each guest a point-to-point
-  link and translates outbound traffic, so guests reach the internet through
-  it and not each other. See
+  hands out the addresses on that network itself. Guests on one gateway share a
+  broadcast domain but cannot address each other: the gateway carries an ARP
+  broadcast between them and does not carry the unicast reply, so neither
+  learns the other's MAC address. See
   [security.md](security.md#things-brig-does-not-claim) for what that means per
   backend, which is not the same answer on Linux.
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -557,18 +557,30 @@ it.
 It does not sandbox the agent from the network. Outbound traffic from the
 guest is whatever the runtime allows, and there is no per-sandbox policy yet.
 
-It does not isolate one sandbox from another. Sandboxes share a network, not
-just a host: brig asks every runtime for its shared network, unconditionally
-and with no setting to say otherwise. On the `hvi` hypervisor that is one
-gateway serving every sandbox on `198.18.0.0/24`, with brig handing out the
-addresses on it; on `vz` and on Linux it is the runtime's own shared network.
-Members of one virtual network can reach each other, which is what makes two
-sandboxes able to talk at all -- and it means two agents you gave *different*
-credentials sit on one broadcast domain, each able to reach whatever the other
-is listening on. That is a real hole in the narrow-blast-radius argument
-above: the radius is narrow per workspace and per token, not per sandbox. If
-it matters that two agents cannot reach each other, run them on separate
-hosts.
+It does not promise that one sandbox cannot reach another, and what actually
+happens depends on the backend. brig asks every runtime for its shared
+network, unconditionally and with no setting to say otherwise, so this is a
+property of what the runtime does with that request rather than of anything
+brig arranges. Measured, in
+[docs/manual-tests/sandbox-reachability.md](manual-tests/sandbox-reachability.md):
+
+| backend | can one sandbox reach another? |
+| --- | --- |
+| `hvi` on macOS | no. The gvisor gateway gives each guest a point-to-point link and translates outbound traffic; there is no segment between guests for one to reach another on |
+| `vz` on macOS | no. vmnet does not bridge guest to guest in the mode hull uses |
+| Linux | **yes.** The CNI bridge is an ordinary layer 2 segment, and two sandboxes on it reach each other the way two containers do |
+
+So on Linux, two agents you gave *different* credentials sit on one broadcast
+domain, each able to reach whatever the other is listening on. That is a real
+hole in the narrow-blast-radius argument above: there the radius is narrow per
+workspace and per token, not per sandbox. If it matters that two agents cannot
+reach each other, run them on separate hosts, or on macOS.
+
+On macOS the separation is real but incidental: it falls out of how the
+backends move packets, not from anything brig asks for, and nothing today
+would notice if a runtime change took it away. Treat it as a property that
+holds rather than a guarantee brig makes. #15 is the work that turns it into
+one, and that closes the Linux gap.
 
 It does not filter what the agent writes to your terminal. `brig` hands the
 tty over with `syscall.Exec` and is gone before the agent produces a byte,

--- a/docs/security.md
+++ b/docs/security.md
@@ -557,17 +557,16 @@ it.
 It does not sandbox the agent from the network. Outbound traffic from the
 guest is whatever the runtime allows, and there is no per-sandbox policy yet.
 
-It does not promise that one sandbox cannot reach another, and what actually
-happens depends on the backend. brig asks every runtime for its shared
-network, unconditionally and with no setting to say otherwise, so this is a
-property of what the runtime does with that request rather than of anything
-brig arranges. Measured, in
-[docs/manual-tests/sandbox-reachability.md](manual-tests/sandbox-reachability.md):
+It does not promise that one sandbox cannot reach another. What happens
+depends on the backend. brig asks every runtime for its shared network, with
+no setting to say otherwise. What the runtime then does with that request is
+the runtime's own behaviour, not brig's. The measurements are in
+[docs/manual-tests/sandbox-reachability.md](manual-tests/sandbox-reachability.md).
 
 | backend | can one sandbox reach another? |
 | --- | --- |
-| `hvi` on macOS | no. The gvisor gateway gives each guest a point-to-point link and translates outbound traffic; there is no segment between guests for one to reach another on |
-| `vz` on macOS | no. vmnet does not bridge guest to guest in the mode hull uses |
+| `hvi` on macOS | no. A packet capture in both guests shows why: an ARP broadcast from one guest does reach the other, and the other answers, but the gateway does not forward that unicast reply back. The first guest never learns the second's MAC address, so it never sends a packet, and the second guest sees no TCP at all |
+| `vz` on macOS | no. vmnet does not carry traffic from one guest to another in the mode hull uses |
 | Linux | **yes.** The CNI bridge is an ordinary layer 2 segment, and two sandboxes on it reach each other the way two containers do |
 
 So on Linux, two agents you gave *different* credentials sit on one broadcast
@@ -576,11 +575,12 @@ hole in the narrow-blast-radius argument above: there the radius is narrow per
 workspace and per token, not per sandbox. If it matters that two agents cannot
 reach each other, run them on separate hosts, or on macOS.
 
-On macOS the separation is real but incidental: it falls out of how the
-backends move packets, not from anything brig asks for, and nothing today
-would notice if a runtime change took it away. Treat it as a property that
-holds rather than a guarantee brig makes. #15 is the work that turns it into
-one, and that closes the Linux gap.
+On macOS the separation is real, but it is a property of the backend rather
+than something brig asks for. brig asks for a shared network and gets guests
+that cannot address each other. No test in brig would notice if a runtime
+change removed it. Treat it as a property that holds, not as a guarantee brig
+makes. On Linux, `--network isolated` gives a sandbox a network of its own and
+closes the gap.
 
 It does not filter what the agent writes to your terminal. `brig` hands the
 tty over with `syscall.Exec` and is gone before the agent produces a byte,


### PR DESCRIPTION
## What this fixes

`docs/security.md` claimed sandboxes share a broadcast domain and that each can reach what the other listens on, with "run them on separate hosts" as the advice. Nothing had measured it.

Measured now, it is true on one backend of three.

| backend | can one sandbox reach another? |
| --- | --- |
| `hvi` on macOS | no |
| `vz` on macOS | no |
| Linux | **yes** |

So the advice was wrong for the platform brig mostly runs on, and the hole it warns about is real only on Linux.

## The packet capture, and what it corrected

A failed connection and an ARP entry are inference. A raw `AF_PACKET` capture in both guests on `hvi` shows the mechanism, and it is not what the first draft of this PR said:

| where | what it saw |
| --- | --- |
| A | `3x ARP who-has 10.87.0.4 tell 10.87.0.5` |
| A | `7x ARP reply` sent back to B |
| A | no TCP at all |
| B | its own 3 requests, and no reply |

The guests **do** share a broadcast domain. B's ARP broadcast reaches A and A answers. The gateway does not carry the unicast reply back, so B never learns A's MAC address, never sends a SYN, and A sees no TCP.

The first draft said "there is no segment between guests". That is wrong. The capture is the reason to know it, and `security.md` and `runtimes.md` now say what the packets show.

The capture also explains why `hvi` has no host-side control: the gvisor gateway runs in user space and the host has no route to the guest subnet. On `vz` the host **can** reach the listener (HTTP 200, logged as `192.168.64.1`), which is what makes the peer's failure there conclusive.

## Controls

A failed connection alone proves nothing: a closed port, a loopback bind, and a wrong address look identical from the far end. Every run first proves the listener answers from outside the guest.

They are not ceremony. On Linux the first attempt used `httpd`, which the image does not contain, and the controls caught the dead listener before it could be read as isolation.

## The doc

`docs/manual-tests/sandbox-reachability.md` is written in simple english: sentences under the descriptive limit, one topic per paragraph, results as tables. It says the same things in about a third fewer words.

CI cannot run any of it. `ci.yml` runs on Linux only and never boots a VM.

## Also

- `docs/runtimes.md` said brig "joins every sandbox to" one shared gateway, which reads as mutual reachability.
- The README's `BRIG_GATEWAY_SOCK` row still named `~/.brig/gateway.sock`; that path moved when the subnet did in #93.

Refs #15
