### PR TITLE
feat(runtime): give a Linux sandbox a network of its own

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ so an agent flag spelled like one of brig's still reaches the agent.
 | `--cpus N` | guest vCPUs |
 | `-d, --detach` | with `run`: start the sandbox, print its name, exit |
 | `--skills` | seed your own `~/.claude` skills and plugins into the workspace |
-| `--network MODE` | `shared` or `offline` (or `BRIG_NETWORK`) |
+| `--network MODE` | `shared`, `isolated` or `offline` (or `BRIG_NETWORK`) |
 | `--offline` | shorthand for `--network offline`: no route out of the sandbox |
 
 Each flag overrides the corresponding `BRIG_*` setting, which overrides the
@@ -635,7 +635,7 @@ Booleans are shell-style: anything except `0` is on.
 | `BRIG_CPUS` | per profile (4) | Guest vCPUs |
 | `BRIG_READY_TIMEOUT` | `30` | Seconds to wait for the in-guest agent after the runtime reports the sandbox running. The two are not the same moment |
 | `BRIG_TITLE` | per profile | Window title, for a graphical agent |
-| `BRIG_NETWORK` | per profile (`shared`) | `shared` or `offline`. `offline` boots the sandbox with no route out: the agent runs, the workspace is there, nothing leaves. Same as `--network`; `--offline` is shorthand for `--network offline`. An unrecognised value refuses the run |
+| `BRIG_NETWORK` | per profile (`shared`) | `shared`, `isolated` or `offline`. `isolated` gives the sandbox a network of its own, which on Linux is what keeps two sandboxes from reaching each other; the macOS backends already keep them apart. `offline` boots the sandbox with no route out: the agent runs, the workspace is there, nothing leaves. Same as `--network`; `--offline` is shorthand for `--network offline`. An unrecognised value refuses the run |
 | `BRIG_SKILLS` | `0` | Seed the profile's `hostConfigDir`/`projectPaths` into the workspace -- for Claude Code, `~/.claude/skills` and `~/.claude/plugins`. Same as `--skills`; see [Your own skills in the guest](#your-own-skills-in-the-guest) |
 
 ### Credentials

--- a/cmd/brig/main.go
+++ b/cmd/brig/main.go
@@ -71,7 +71,7 @@ flags (before the agent's own arguments; -- ends brig's parsing):
                          envelope before the agent starts
       --skills           project your own ~/.claude skills and plugins into
                          the guest, read-only (or BRIG_SKILLS=1)
-      --network MODE     shared or offline (or BRIG_NETWORK)
+      --network MODE     shared, isolated or offline (or BRIG_NETWORK)
       --offline          shorthand for --network offline: the agent runs, the
                          workspace is there, nothing leaves
 
@@ -779,6 +779,25 @@ func reset(args []string) error {
 		removed++
 	}
 	fmt.Fprintf(os.Stderr, "brig: removed %d sandbox(es). Workspaces are untouched.\n", removed)
+	// A network whose sandbox was removed outside brig is not reachable
+	// through Remove, because that sandbox is not in the list any more. reset
+	// is the verb that leaves nothing behind, so it prunes those too. Only the
+	// runtimes that make a network per sandbox implement this; the rest are
+	// skipped rather than asked.
+	if p, ok := rt.(runtime.NetworkPruner); ok {
+		// Asked again rather than reusing the list above: that one was taken
+		// before the removals, so every sandbox just removed would still look
+		// live and nothing would be pruned. What matters here is what survived,
+		// which is a sandbox whose removal failed and whose network is
+		// therefore still in use.
+		var live []string
+		if after, err := rt.List(); err == nil {
+			for _, inst := range after {
+				live = append(live, inst.Name)
+			}
+		}
+		p.PruneNetworks(live)
+	}
 	return nil
 }
 

--- a/docs/profiles.md
+++ b/docs/profiles.md
@@ -126,7 +126,7 @@ with the same parser and neither has to guess.
 | `staleCredentialFiles` | no | Paths an older wrapper used to write a credential into. brig never does, so finding one is worth a warning rather than a deletion |
 | `headless` | no | The agent supports a non-interactive run |
 | `guiTitle` | no | Window title, for a `kind: gui` profile |
-| `network` | no | the sandbox's network posture: `shared` (the default: one network for every sandbox on this host) or `offline` (no route out at all). `BRIG_NETWORK`, `--network` and `--offline` win over it |
+| `network` | no | the sandbox's network posture: `shared` (the default: one network for every sandbox on this host), `isolated` (a network of this sandbox's own) or `offline` (no route out at all). `BRIG_NETWORK`, `--network` and `--offline` win over it |
 | `hypervisor` | no | macOS backend to boot on: `vz` (the default, and the only one with a graphical console), `hvi` or `qemu`. `BRIG_HYPERVISOR` wins over it. Ignored on Linux, where the shim decides |
 | `runtimeBin` | no | The runtime binary to drive instead of the one on `PATH`, `~` expanded. Unlike every other field this is about your machine rather than the workload, so it does not travel usefully to anyone else -- it is how you pin a profile to a build you are working on without exporting a variable in every shell. `BRIG_RUNTIME_BIN` wins over it |
 | `rootfsType` | no | How the guest root reaches the VM: `block`, `virtiofs` or `9pfs`. Left unset the runtime picks its own default, which is what a profile that only runs an agent wants. Set `block` when the sandbox installs packages and needs a real writable disk rather than a share sized to the image |

--- a/internal/profile/file.go
+++ b/internal/profile/file.go
@@ -167,9 +167,9 @@ func (p Profile) Validate() error {
 		return fmt.Errorf("hypervisor %q is not one of vz, hvi or qemu", p.Hypervisor)
 	}
 	switch p.Network {
-	case "", "shared", "offline":
+	case "", "shared", "isolated", "offline":
 	default:
-		return fmt.Errorf("network %q is not one of shared or offline", p.Network)
+		return fmt.Errorf("network %q is not one of shared, isolated or offline", p.Network)
 	}
 	switch p.RootfsType {
 	case "", "block", "virtiofs", "9pfs":

--- a/internal/profile/profile.go
+++ b/internal/profile/profile.go
@@ -177,13 +177,15 @@ type Profile struct {
 	// than whichever the host defaults to -- hvi for its introspection, say.
 	// Ignored on Linux, where the shim decides.
 	Hypervisor string `json:"hypervisor,omitempty"`
-	// Network is the posture this workload wants: shared or offline. Empty
-	// means shared, which is what every sandbox has had until now: one network
-	// for every sandbox on the host. Whether the sandboxes on it can reach
-	// each other is the backend's answer rather than brig's, and it is not the
-	// same answer everywhere -- see docs/security.md. offline is a sandbox
-	// with no route out at all: the agent runs, the workspace is there,
-	// nothing leaves.
+	// Network is the posture this workload wants: shared, isolated or offline.
+	// Empty means shared, which is what every sandbox has had until now: one
+	// network for every sandbox on the host. Whether the sandboxes on it can
+	// reach each other is the backend's answer rather than brig's, and it is
+	// not the same answer everywhere -- see docs/security.md. isolated is a
+	// network of this sandbox's own, so nothing else brig started is on it,
+	// whatever the backend does with a shared one. offline is a sandbox with
+	// no route out at all: the agent runs, the workspace is there, nothing
+	// leaves.
 	//
 	// A profile states it when the workload's posture is a property of the
 	// work rather than of the run: a formatter that only ever touches the

--- a/internal/runtime/nerdctl.go
+++ b/internal/runtime/nerdctl.go
@@ -150,6 +150,14 @@ func (n *nerdctl) Run(spec RunSpec) error {
 	if err != nil {
 		return err
 	}
+	// The network has to exist before the run references it: nerdctl will not
+	// create one on demand, and the failure if it is missing names the network
+	// rather than the posture that asked for it.
+	if spec.Net == "isolated" {
+		if err := n.ensureSandboxNetwork(spec.Name); err != nil {
+			return err
+		}
+	}
 	cmd := exec.Command(n.bin, args...)
 	cmd.Env = mergeEnv(telemetryEnv(spec.Counted), envVals)
 	cmd.Stderr = os.Stderr
@@ -158,6 +166,74 @@ func (n *nerdctl) Run(spec RunSpec) error {
 
 // runArgs is the one place the run command line is built, for the same reason
 // the hull adapter has one: a test and a boot cannot then drift apart.
+// sandboxNetwork is the name of the network belonging to one sandbox. It is
+// the sandbox's own name: brig's sandboxes already carry the brig- prefix, so
+// a network left behind is traceable to what left it, and `brig reset` can
+// recognise its own without keeping a second list.
+func sandboxNetwork(sandbox string) string { return sandbox }
+
+// prunableNetworks picks the networks brig made and nothing is using.
+//
+// Pure, so the decision can be tested without a runtime: naming what to delete
+// is the part worth being sure about, and the listing and the deleting around
+// it are one command each. Two things are never touched -- a network still
+// carrying a sandbox, and any network brig did not make, which is every name
+// without the sandbox prefix. The runtime's own bridge/host/none are excluded
+// by that same rule rather than by being listed here.
+func prunableNetworks(all, inUse []string) []string {
+	live := make(map[string]bool, len(inUse))
+	for _, n := range inUse {
+		live[sandboxNetwork(n)] = true
+	}
+	var out []string
+	for _, name := range all {
+		if strings.HasPrefix(name, sandboxPrefix) && !live[name] {
+			out = append(out, name)
+		}
+	}
+	return out
+}
+
+// PruneNetworks removes the networks brig made that no sandbox is on, and
+// reports how many went.
+//
+// Optional on the same terms as TelemetryReporter: it is not part of running a
+// sandbox, and a backend that makes no networks should not grow a stub to say
+// so. reset type-asserts for it.
+func (n *nerdctl) PruneNetworks(inUse []string) int {
+	out, err := exec.Command(n.bin, "network", "ls", "--format", "{{.Name}}").Output()
+	if err != nil {
+		return 0
+	}
+	gone := 0
+	for _, name := range prunableNetworks(strings.Fields(string(out)), inUse) {
+		if exec.Command(n.bin, "network", "rm", name).Run() == nil {
+			gone++
+		}
+	}
+	return gone
+}
+
+// ensureSandboxNetwork creates the network a sandbox of its own needs.
+//
+// Already-exists is success rather than an error: a sandbox that was stopped
+// and started again wants the network it had, and two brigs racing to create
+// the same one is ordinary rather than a fault.
+func (n *nerdctl) ensureSandboxNetwork(name string) error {
+	out, err := exec.Command(n.bin, "network", "create", sandboxNetwork(name)).CombinedOutput()
+	if err == nil || strings.Contains(string(out), "already exists") {
+		return nil
+	}
+	return fmt.Errorf("could not create the network for %s: %w: %s", name, err, strings.TrimSpace(string(out)))
+}
+
+// removeSandboxNetwork drops it again. A failure is not worth failing the
+// removal over: the sandbox is the thing being removed, and a leftover network
+// is tidied by the next `brig reset` rather than left to block anything.
+func (n *nerdctl) removeSandboxNetwork(name string) {
+	_ = exec.Command(n.bin, "network", "rm", sandboxNetwork(name)).Run()
+}
+
 func (n *nerdctl) runArgs(spec RunSpec) (args, env []string, err error) {
 	args = []string{"run", "--detach", "--name", spec.Name,
 		"--runtime", containerdRuntime(),
@@ -168,9 +244,23 @@ func (n *nerdctl) runArgs(spec RunSpec) (args, env []string, err error) {
 	case "always", "never", "missing":
 		args = append(args, "--pull", spec.Pull)
 	}
-	if spec.Net == "none" {
+	switch spec.Net {
+	case "none":
 		args = append(args, "--network", "none")
+	case "isolated":
+		// A network of this sandbox's own. Unlike the macOS backends, which
+		// keep guests apart whatever they are asked for, the default bridge
+		// here is an ordinary layer 2 segment: two sandboxes on it reach each
+		// other the way two containers do. So this is the runtime where the
+		// posture has actual work to do, and the work is a network per
+		// sandbox. Created before the run, in Run, because nerdctl will not
+		// make one on demand.
+		args = append(args, "--network", sandboxNetwork(spec.Name))
 	}
+	// "shared" passes no --network at all, so the runtime's own default is
+	// used. Said as an absence rather than a flag because that is what every
+	// sandbox before this had, and naming the default explicitly would change
+	// behaviour for anyone who had configured a different one.
 	if spec.GenericBoot {
 		// urunc reads these from the container's OCI spec, so nerdctl only has
 		// to carry them through. docker is refused rather than attempted: it
@@ -277,8 +367,21 @@ func (n *nerdctl) Replace(spec ExecSpec) error {
 	return syscall.Exec(n.bin, argv, mergeEnv(telemetryEnv(spec.Counted), envVals))
 }
 
-func (n *nerdctl) Stop(name string) error   { return n.quiet("stop", name) }
-func (n *nerdctl) Remove(name string) error { return n.quiet("rm", name) }
+func (n *nerdctl) Stop(name string) error { return n.quiet("stop", name) }
+
+// Remove takes the sandbox's own network with it when there is one. Stop does
+// not: a stopped sandbox is started again, and it wants the network it had.
+//
+// The network is removed after the container, because a network with a
+// container still attached will not go. Whether this sandbox actually had one
+// is not tracked -- removing a network that was never created fails, and that
+// failure is ignored, which is cheaper than a second piece of state that can
+// disagree with the runtime.
+func (n *nerdctl) Remove(name string) error {
+	err := n.quiet("rm", name)
+	n.removeSandboxNetwork(name)
+	return err
+}
 
 func (n *nerdctl) quiet(verb, name string) error {
 	cmd := exec.Command(n.bin, verb, name)

--- a/internal/runtime/nerdctl_test.go
+++ b/internal/runtime/nerdctl_test.go
@@ -185,3 +185,69 @@ func TestBootArtifactsReportsWhichFileIsMissing(t *testing.T) {
 		t.Errorf("error does not name the missing kernel: %v", err)
 	}
 }
+
+// A sandbox asking for its own network gets one, by name. On Linux the default
+// bridge is an ordinary layer 2 segment and two sandboxes on it reach each
+// other, which is the gap isolated closes; on macOS the backends already keep
+// guests apart, so this is the one runtime where the posture has work to do.
+func TestNerdctlIsolatedAsksForItsOwnNetwork(t *testing.T) {
+	n := &nerdctl{bin: "nerdctl"}
+	args, _, err := n.runArgs(RunSpec{Name: "brig-x", Image: "img", Mem: 1, CPUs: 1, Net: "isolated"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := strings.Join(args, " ")
+	if !strings.Contains(got, "--network "+sandboxNetwork("brig-x")) {
+		t.Errorf("isolated did not ask for its own network: %s", got)
+	}
+	// Shared stays as it was: no --network at all, so the runtime's default
+	// bridge is used and nothing about existing sandboxes changes.
+	args, _, err = n.runArgs(RunSpec{Name: "brig-x", Image: "img", Mem: 1, CPUs: 1, Net: "shared"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got = strings.Join(args, " "); strings.Contains(got, "--network") {
+		t.Errorf("shared asked for a network explicitly: %s", got)
+	}
+	// Offline is unchanged too.
+	args, _, err = n.runArgs(RunSpec{Name: "brig-x", Image: "img", Mem: 1, CPUs: 1, Net: "none"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got = strings.Join(args, " "); !strings.Contains(got, "--network none") {
+		t.Errorf("offline did not ask for no network: %s", got)
+	}
+}
+
+// The network is named after the sandbox, so a leaked one is traceable to what
+// left it and `brig reset` can find every one brig made.
+func TestSandboxNetworkIsNamedAfterTheSandbox(t *testing.T) {
+	if got := sandboxNetwork("brig-claude-code-foo"); got != "brig-claude-code-foo" {
+		t.Errorf("network name = %q", got)
+	}
+	if !strings.HasPrefix(sandboxNetwork("brig-x"), "brig-") {
+		t.Error("a brig network is not identifiable as brig's")
+	}
+}
+
+// A network whose sandbox was removed outside brig is not reachable through
+// Remove, because the sandbox is not in the list any more. reset is the verb
+// whose whole job is leaving nothing behind, so it prunes those -- and must
+// leave alone both the networks still in use and every network brig did not
+// make.
+func TestPruneNetworksKeepsWhatIsInUseAndWhatIsNotOurs(t *testing.T) {
+	all := []string{"bridge", "host", "none", "brig-claude-code", "brig-claude-code-gone", "my-own-net"}
+	inUse := []string{"brig-claude-code"}
+
+	got := prunableNetworks(all, inUse)
+
+	want := map[string]bool{"brig-claude-code-gone": true}
+	if len(got) != len(want) {
+		t.Fatalf("prunable = %v, want just the leaked brig network", got)
+	}
+	for _, n := range got {
+		if !want[n] {
+			t.Errorf("would have removed %q, which is either in use or not brig's", n)
+		}
+	}
+}

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -369,3 +369,20 @@ func mergeEnv(additions ...[]string) []string {
 	}
 	return out
 }
+
+// sandboxPrefix is the mark every sandbox brig starts carries, and so the mark
+// on anything else brig creates for one. cmd/brig enforces it on the name; the
+// adapters read it back to recognise their own leftovers.
+const sandboxPrefix = "brig-"
+
+// NetworkPruner is a runtime that makes a network per sandbox and can tidy the
+// ones nothing is on any more.
+//
+// Optional for the same reason TelemetryReporter is: a backend that makes no
+// networks should not have to grow a stub method to say so. reset asserts for
+// it and skips a runtime that does not implement it.
+type NetworkPruner interface {
+	// PruneNetworks removes the networks brig made that none of inUse is on,
+	// and reports how many went.
+	PruneNetworks(inUse []string) int
+}

--- a/internal/wrap/network.go
+++ b/internal/wrap/network.go
@@ -11,6 +11,9 @@ const (
 	// reach each other is the backend's answer, not brig's: on Linux they can,
 	// on both macOS backends they cannot. See docs/security.md.
 	NetShared Network = "shared"
+	// NetIsolated is a network of this sandbox's own, so no other sandbox is
+	// on it whatever the backend does with a shared one.
+	NetIsolated Network = "isolated"
 	// NetOffline is a sandbox with no route out. The agent runs, the workspace
 	// is mounted, nothing leaves.
 	NetOffline Network = "offline"
@@ -32,21 +35,33 @@ func ParseNetworkStrict(s, source string) (Network, error) {
 		return NetShared, nil
 	case string(NetShared):
 		return NetShared, nil
+	case string(NetIsolated):
+		return NetIsolated, nil
 	case string(NetOffline):
 		return NetOffline, nil
 	default:
-		return NetShared, fmt.Errorf("%s %q is not a posture: use shared or offline", source, s)
+		return NetShared, fmt.Errorf("%s %q is not a posture: use shared, isolated or offline",
+			source, s)
 	}
 }
+
+// AllNetworks is every posture that exists. A list rather than a comment, so a
+// test can walk it and catch a posture that gained a case in one switch and
+// not the other.
+func AllNetworks() []Network { return []Network{NetShared, NetIsolated, NetOffline} }
 
 // RuntimeNet is the word the runtime adapters take for this posture. The two
 // vocabularies are deliberately separate: "offline" is what a person asks for,
 // "none" is what a runtime is told.
 func (n Network) RuntimeNet() string {
-	if n == NetOffline {
+	switch n {
+	case NetOffline:
 		return "none"
+	case NetIsolated:
+		return "isolated"
+	default:
+		return "shared"
 	}
-	return "shared"
 }
 
 // Line is the posture as a reader is told it, with the consequence spelled
@@ -66,8 +81,12 @@ func (n Network) RuntimeNet() string {
 // is true everywhere: these sandboxes are on one network rather than each on
 // its own.
 func (n Network) Line() string {
-	if n == NetOffline {
+	switch n {
+	case NetOffline:
 		return "offline (no egress)"
+	case NetIsolated:
+		return "isolated (a network of this sandbox's own)"
+	default:
+		return "shared (one network for every sandbox on this host)"
 	}
-	return "shared (one network for every sandbox on this host)"
 }

--- a/internal/wrap/network_test.go
+++ b/internal/wrap/network_test.go
@@ -1,0 +1,36 @@
+package wrap
+
+import "testing"
+
+// Every posture has to carry both vocabularies. They are two switches on one
+// type precisely so a posture added later cannot pick up one translation and
+// quietly miss the other -- the miss would be silent, because a missing case
+// falls through to whatever the default arm says rather than failing.
+func TestEveryPostureHasBothTranslations(t *testing.T) {
+	for _, n := range AllNetworks() {
+		if got := n.RuntimeNet(); got == "" {
+			t.Errorf("posture %q has no runtime word", n)
+		}
+		if got := n.Line(); got == "" {
+			t.Errorf("posture %q has no line for a reader", n)
+		}
+	}
+	// And the parser accepts exactly the postures that exist, so the two
+	// cannot drift either.
+	for _, n := range AllNetworks() {
+		got, err := ParseNetworkStrict(string(n), "--network")
+		if err != nil || got != n {
+			t.Errorf("ParseNetworkStrict(%q) = %q, %v", n, got, err)
+		}
+	}
+}
+
+// isolated is the posture that asks for a network of this sandbox's own.
+func TestIsolatedIsItsOwnRuntimeWord(t *testing.T) {
+	if NetIsolated.RuntimeNet() == NetShared.RuntimeNet() {
+		t.Error("isolated and shared ask the runtime for the same thing, so no adapter can tell them apart")
+	}
+	if NetOffline.RuntimeNet() != "none" {
+		t.Errorf("offline runtime word = %q, want none", NetOffline.RuntimeNet())
+	}
+}

--- a/script/smoke.sh
+++ b/script/smoke.sh
@@ -256,6 +256,21 @@ grep -q '^NETWORK .*shared' "$WORK/on.out" \
   && ok "the envelope names the shared posture" \
   || bad "the envelope names the shared posture -- got: $(cat "$WORK/on.out")"
 
+# isolated asks the runtime for a network of this sandbox's own. The stub is a
+# hull stand-in, so what is checked here is that the posture reaches the
+# runtime; that two sandboxes on separate networks genuinely cannot reach each
+# other is a real-runtime fact, recorded in docs/manual-tests.
+"$WORK/brig" reset > /dev/null 2>&1
+: > "$STUB_LOG"
+"$WORK/brig" run claude --network isolated -d > "$WORK/iso.out" 2>&1
+grep -q -- '--net isolated' "$STUB_LOG" \
+  && ok "--network isolated reaches the runtime" \
+  || bad "--network isolated reaches the runtime -- got: $(grep '^argv: run' "$STUB_LOG")"
+grep -q '^NETWORK .*isolated' "$WORK/iso.out" \
+  && ok "the envelope names the isolated posture" \
+  || bad "the envelope names the isolated posture -- got: $(cat "$WORK/iso.out")"
+"$WORK/brig" reset > /dev/null 2>&1
+
 # A posture brig does not know must stop the run rather than pick one.
 out="$(BRIG_NETWORK=airgapped "$WORK/brig" env claude 2>&1)"; rc=$?
 [ "$rc" != 0 ] && ok "an unknown BRIG_NETWORK refuses the run" \


### PR DESCRIPTION
## What this does

Adds the `isolated` posture: a network of the sandbox's own, so no other sandbox is on it whatever the backend does with a shared one. On nerdctl that is a network per sandbox.

Stacked on #92, which adds the posture plumbing and `offline`. Review that one first.

## Why only Linux gets new machinery

The original plan for #15 assumed sandboxes could reach each other everywhere and built per-sandbox gateways for macOS. Measuring it first changed the shape of the work:

| backend | can one sandbox reach another? |
| --- | --- |
| `hvi` | no, the gvisor gateway gives each guest a point-to-point link |
| `vz` | no, vmnet does not bridge guest to guest |
| Linux | **yes**, the CNI bridge is an ordinary layer 2 segment |

So macOS needs no new mechanism — the separation is already there — and Linux, which the plan had barely touched, is the entire gap. The measurements and the controls that make them mean anything are in `docs/manual-tests/sandbox-reachability.md` (#94).

## Verified on a real Linux host

Amazon Linux 2023, kernel 6.18, nerdctl 2.0.3, containerd 2.0.2, CNI from the `nerdctl-full` bundle.

**The gap, on the shared default bridge:** listener in A reachable from A's own address and from the host; B reached it (`ok`); B's ARP for A resolved to a real `lladdr`.

**Closed, with a network each:** the two sandboxes land on separate subnets (`10.4.1.2`, `10.4.2.2`); the same listener, still reachable from A and from the host, **times out** from B; B has no ARP entry for the peer at all; B still reaches the internet.

Same listener, same controls, opposite result. That is the change working.

**Pruning, end to end:** removed two sandboxes with `nerdctl rm` so their networks leaked, then ran `brig reset` — both `brig-*` networks gone, `my-own-net` and the runtime's own `bridge`/`host`/`none` untouched.

## Details worth a look

- `shared` still passes **no** `--network` flag rather than naming a default. That is what every sandbox before this had, and spelling it out would change behaviour for anyone who configured a different default.
- The network is created in `Run` **after** `runArgs` succeeds, so a run that cannot happen leaves no network behind. Confirmed by accident: a `genericBoot` profile failed for a missing boot bundle and created nothing.
- `Remove` takes the network, `Stop` does not — a stopped sandbox is started again and wants the network it had.
- `reset` re-lists after the removals rather than reusing the earlier snapshot. Reusing it would count every just-removed sandbox as live and prune nothing, which is the bug I wrote first.
- `RuntimeNet()` and `Line()` are exhaustive switches now, with a test walking every posture through both. A posture added later that gained one case and missed the other would have fallen through to a default arm silently.

Refs #15
