### PR TITLE
fix(verify): verify the kernel a sandbox boots, not only its image

### DIFF
--- a/README.md
+++ b/README.md
@@ -366,6 +366,14 @@ repository *and* the workflow file, so a signature from anywhere else fails.
 | `cosign` not installed | **warning**, boots. "Could not check" is not "failed" |
 | image under `ghcr.io/brig-sh/`, signature does **not** verify | **stops and asks** `[y/N]`. With no terminal it refuses |
 
+Most profiles boot a kernel and an initrd brig downloads rather than their own
+image, and the initrd carries the in-guest agent. That bundle is checked the
+same way, against its own signing identity, under the same setting: a signature
+that does not verify stops the boot, a bundle brig does not publish warns, and
+`BRIG_VERIFY=require` refuses anything unchecked. The kernel is the more
+privileged of the two, so verifying the image alone was never the whole
+guarantee.
+
 `BRIG_VERIFY=require` refuses anything that cannot be positively verified,
 third-party images included. `BRIG_VERIFY=off` skips the check.
 [docs/security.md](docs/security.md) explains the reasoning, and what brig does

--- a/internal/runtime/bootfetch.go
+++ b/internal/runtime/bootfetch.go
@@ -19,6 +19,12 @@ const bootAssetsRepo = "ghcr.io/nofireai/hull-assets"
 // amd64 box boots an amd64 guest -- so GOOS-GOARCH is the right key.
 // BRIG_BOOT_ASSETS_REF overrides it whole, which is how a version gets pinned
 // or a mirror gets used.
+// BootAssetsRef is the bundle this host would boot, exported so the layer that
+// owns BRIG_VERIFY can name what it is checking. The fetch happens deep inside
+// a runtime adapter, but whether to trust what is fetched is a policy question
+// and belongs where the other one is answered.
+func BootAssetsRef() string { return bootAssetsRef() }
+
 func bootAssetsRef() string {
 	if r := os.Getenv("BRIG_BOOT_ASSETS_REF"); r != "" {
 		return r

--- a/internal/verify/verify.go
+++ b/internal/verify/verify.go
@@ -92,6 +92,30 @@ func DefaultPolicy() Policy {
 	}
 }
 
+// BootAssetsPolicy matches the boot bundle: the kernel and the initrd a
+// genericBoot profile starts, which carry the in-guest agent.
+//
+// A separate policy rather than a second registry on the image one, because
+// the two are separate trust roots. The bundle is published by another
+// repository, under another registry prefix, by another workflow, and running
+// it through DefaultPolicy would land on NotOurs -- a check that inspects
+// nothing and reports success, which is worse than no check because it reads
+// like one.
+//
+// The identity here was read off the signature the published bundle carries
+// rather than written from the repository layout, because a regexp that names
+// a workflow which does not sign anything fails every boot, and one that is
+// too loose passes signatures nobody meant to trust. Anchored at both ends and
+// with the dots escaped, for the reason DefaultPolicy gives.
+func BootAssetsPolicy() Policy {
+	return Policy{
+		Registry: "ghcr.io/nofireai/",
+		Identity: `^https://github\.com/NOFireAI/hull-assets/\.github/workflows/build-assets\.yml@refs/heads/main$`,
+		Issuer:   "https://token.actions.githubusercontent.com",
+		Cosign:   "cosign",
+	}
+}
+
 // Outcome is what the check concluded.
 type Outcome int
 

--- a/internal/verify/verify_test.go
+++ b/internal/verify/verify_test.go
@@ -310,3 +310,33 @@ func TestParseModeStrictRefusesATypo(t *testing.T) {
 		t.Error("ParseModeStrict(requrie) did not refuse a typo")
 	}
 }
+
+// The boot assets are a separate trust root from the guest images. They are
+// published by another repository, under another registry prefix, by another
+// workflow, so the image policy would refuse them as NotOurs and check
+// nothing. The identity below was read off the signature the published bundle
+// actually carries, not written from the repository layout.
+func TestBootAssetsPolicyPinsItsOwnRepoAndWorkflow(t *testing.T) {
+	p := BootAssetsPolicy()
+	for _, want := range []string{
+		"NOFireAI/hull-assets",
+		`build-assets\.yml`,
+		"token.actions.githubusercontent.com",
+	} {
+		if !strings.Contains(p.Identity+p.Issuer, want) {
+			t.Errorf("policy does not pin %q: %s %s", want, p.Identity, p.Issuer)
+		}
+	}
+	if !strings.HasPrefix(p.Identity, "^") || !strings.HasSuffix(p.Identity, "$") {
+		t.Errorf("identity regexp is not anchored at both ends: %s", p.Identity)
+	}
+	// The bundle lives under a different prefix from the images, so a policy
+	// carrying the image prefix would call the bundle NotOurs and check
+	// nothing at all -- a check that always passes.
+	if p.Registry == DefaultPolicy().Registry {
+		t.Error("the boot assets share the image registry prefix, so one policy would check both")
+	}
+	if !strings.HasPrefix("ghcr.io/nofireai/hull-assets:linux-amd64", p.Registry) {
+		t.Errorf("the published bundle is not under the policy's prefix %q", p.Registry)
+	}
+}

--- a/internal/wrap/run.go
+++ b/internal/wrap/run.go
@@ -236,6 +236,13 @@ func (c *Config) EnsureRunning(set creds.Set) error {
 	if err := c.verifyImage(); err != nil {
 		return err
 	}
+	// And the kernel the sandbox boots, for a profile that boots a downloaded
+	// bundle rather than its own image. Checked here, beside the image, so the
+	// two refusals happen at the same point in the boot and under the same
+	// setting.
+	if err := c.verifyBootAssets(); err != nil {
+		return err
+	}
 
 	// The share below is a path, and the runtime resolves it again on its own
 	// time -- after the image pull, after the VM starts. PrepareWorkspace

--- a/internal/wrap/verify.go
+++ b/internal/wrap/verify.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/brig-sh/brig/internal/runtime"
 	"github.com/brig-sh/brig/internal/verify"
 )
 
@@ -204,4 +205,72 @@ func (c *Config) confirm(question string) bool {
 		return true
 	}
 	return false
+}
+
+// verifyBootAssets checks the kernel and initrd a genericBoot profile starts.
+//
+// brig verified the guest image and not the kernel that runs it, which is the
+// more privileged of the two: the initrd carries the in-guest agent, and six
+// of the eight shipped profiles boot a bundle rather than their own image, so
+// this is the ordinary path rather than an edge case. The bundle is signed;
+// the check was simply never made.
+//
+// It is a trust root of its own, so it uses its own policy: another
+// repository, another registry prefix, another workflow. Running it through
+// the image policy would land on NotOurs, which inspects nothing and reports
+// success -- worse than no check, because it reads like one.
+//
+// The modes are the image's modes, so a reader has one rule to learn rather
+// than two. Nothing is pinned from the result: the bundle is fetched by oras
+// or by hull, neither of which brig hands a digest to, so what this buys is a
+// refusal before the boot rather than a pinned download. Naming the digest in
+// the report is the next step, and it needs the fetchers to take one.
+func (c *Config) verifyBootAssets() error {
+	if c.Verify == verify.Off || !c.Profile.GenericBoot {
+		return nil
+	}
+	ref := runtime.BootAssetsRef()
+	// Its own identity and registry, but the same cosign binary: which tool to
+	// run is a fact about the machine, set once by BRIG_COSIGN_BIN, and not
+	// something each trust root should answer differently. Hardcoding it here
+	// also made this unstubbable, so the check reached the real registry from a
+	// unit test.
+	policy := verify.BootAssetsPolicy()
+	policy.Cosign = c.VerifyPolicy.Cosign
+	res := policy.Verify(ref, "")
+
+	switch res.Outcome {
+	case verify.Verified:
+		c.warnf("boot assets %s: signature verified", ref)
+		return nil
+
+	case verify.NotOurs:
+		// The bundle was pointed somewhere else, with BRIG_BOOT_ASSETS_REF or a
+		// mirror. brig has nothing to check there and says so rather than
+		// implying it checked.
+		if c.Verify == verify.Require {
+			return fmt.Errorf("refusing to boot: the boot assets at %s are not published "+
+				"by brig, so their signature cannot be checked (BRIG_VERIFY=require)", ref)
+		}
+		c.warnf("boot assets %s are not published by brig, so nothing was checked "+
+			"about the kernel this sandbox boots", ref)
+		return nil
+
+	case verify.NoTooling, verify.Unresolved:
+		// Could not check, rather than failed. It follows the image's rule: a
+		// warning by default, a refusal under require.
+		if c.Verify == verify.Require {
+			return fmt.Errorf("refusing to boot: the boot assets at %s could not be "+
+				"verified (%s) (BRIG_VERIFY=require)", ref, res.Message())
+		}
+		c.warnf("the boot assets at %s could not be verified: %s", ref, res.Message())
+		return nil
+
+	default:
+		// A signature that is present and wrong on the kernel brig is about to
+		// boot. This one stops whatever the mode, short of off: there is no
+		// reading of a bad signature here that is worth a prompt.
+		return fmt.Errorf("refusing to boot: the boot assets at %s failed verification (%s). "+
+			"Set BRIG_VERIFY=off to boot them regardless", ref, res.Detail)
+	}
 }

--- a/internal/wrap/verify_test.go
+++ b/internal/wrap/verify_test.go
@@ -2,11 +2,13 @@ package wrap
 
 import (
 	"bytes"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
+	"github.com/brig-sh/brig/internal/creds"
 	"github.com/brig-sh/brig/internal/runtime"
 	"github.com/brig-sh/brig/internal/ttytest"
 	"github.com/brig-sh/brig/internal/verify"
@@ -25,6 +27,17 @@ type verifyRuntime struct {
 func (v verifyRuntime) Kind() string                       { return "hull" }
 func (v verifyRuntime) PinsDigest() bool                   { return v.pins }
 func (v verifyRuntime) LocalDigest(string) (string, error) { return v.local, nil }
+
+// The little that EnsureRunning asks before it reaches the checks. Nothing is
+// running and removing is a no-op, which is the state a first boot starts in.
+// Run is deliberately absent: a test that got that far would be booting, and
+// every case here is meant to refuse before then.
+func (v verifyRuntime) Running(string) bool { return false }
+func (v verifyRuntime) Remove(string) error { return nil }
+
+// Stops the boot at the point a real runtime would start doing work, so a
+// test can drive EnsureRunning through the checks without booting anything.
+func (v verifyRuntime) Run(runtime.RunSpec) error { return errors.New("stub runtime: not booting") }
 
 func verifyConfig(t *testing.T, image string, mode verify.Mode) *Config {
 	t.Helper()
@@ -377,5 +390,62 @@ func TestEveryVerifyRefusalNamesAWayForward(t *testing.T) {
 		if !strings.Contains(err.Error(), "BRIG_VERIFY=off") {
 			t.Errorf("%s: the refusal names no way forward: %v", tc.what, err)
 		}
+	}
+}
+
+// A genericBoot profile boots a kernel and an initrd brig downloads, and the
+// initrd carries the in-guest agent. brig verified the image and not the
+// kernel that runs it, which is the more privileged of the two. The bundle is
+// signed, so there was a check to make and brig was not making it.
+func TestGenericBootVerifiesTheBundle(t *testing.T) {
+	// Require refuses what it cannot check, which is the cheapest way to prove
+	// the bundle is checked at all: with no cosign there is nothing to check,
+	// so a profile that boots a bundle must refuse and a profile that does not
+	// must proceed.
+	boots := verifyConfig(t, "ghcr.io/brig-sh/claude-code:arm64", verify.Require)
+	boots.Runtime = verifyRuntime{pins: false}
+	boots.Profile.GenericBoot = true
+	err := boots.verifyBootAssets()
+	if err == nil {
+		t.Error("a genericBoot profile booted a bundle that could not be checked")
+	}
+
+	// A profile that boots its own image has no bundle, so there is nothing to
+	// check and nothing to refuse.
+	plain := verifyConfig(t, "ghcr.io/brig-sh/claude-code:arm64", verify.Require)
+	plain.Runtime = verifyRuntime{pins: false}
+	plain.Profile.GenericBoot = false
+	if err := plain.verifyBootAssets(); err != nil {
+		t.Errorf("a profile with no bundle was refused: %v", err)
+	}
+
+	// Off means off, for the bundle as for the image.
+	skipped := verifyConfig(t, "ghcr.io/brig-sh/claude-code:arm64", verify.Off)
+	skipped.Runtime = verifyRuntime{pins: false}
+	skipped.Profile.GenericBoot = true
+	if err := skipped.verifyBootAssets(); err != nil {
+		t.Errorf("BRIG_VERIFY=off still checked the bundle: %v", err)
+	}
+}
+
+// And the check is actually reached on the way to a boot. Calling
+// verifyBootAssets directly proves what it decides, not that anything asks it:
+// with the call removed from EnsureRunning every test above still passed, which
+// is the whole failure mode this pins.
+func TestEnsureRunningVerifiesTheBundleBeforeBooting(t *testing.T) {
+	// Warn rather than Require, because under Require the image check refuses
+	// first and the run never reaches the bundle. What is being pinned is that
+	// the bundle is looked at on the way to a boot, and under Warn that shows
+	// up as a line about it rather than as a refusal.
+	c := verifyConfig(t, "ghcr.io/brig-sh/claude-code:arm64", verify.Warn)
+	c.Runtime = verifyRuntime{pins: false}
+	c.Profile.GenericBoot = true
+	c.Workspace = t.TempDir()
+	c.Cwd = c.Workspace
+
+	_ = c.EnsureRunning(creds.Set{})
+
+	if said := c.Err.(*bytes.Buffer).String(); !strings.Contains(said, "boot assets") {
+		t.Errorf("the run never looked at the kernel it was about to boot:\n%s", said)
 	}
 }


### PR DESCRIPTION
Six of the eight shipped profiles boot a kernel and initrd brig downloads, and the initrd carries the in-guest agent. brig verified the image and never checked the bundle. The kernel is the more privileged of the two.

The bundle is signed. Nothing read the signature: `bootfetch.go:39` is a plain `oras pull`, and `grep 'verify\.'` on that file returns nothing.

## Its own trust root

Another repo, another registry prefix, another workflow. Through the image policy it lands on `NotOurs` — inspects nothing, reports success. Worse than no check, because it reads like one.

The identity in `BootAssetsPolicy` was read off the signature the published bundle carries, not inferred from the repo layout. Both published bundles verify against it.

## Behaviour

Same modes as the image, so there is one rule to learn.

| situation | result |
| --- | --- |
| verifies | one line, boots |
| signature present and wrong | stops, short of `BRIG_VERIFY=off` |
| bundle not published by brig | warns; refused under `require` |
| cosign missing / registry unreachable | warns; refused under `require` |

Nothing is pinned: neither `oras` nor `hull` takes a digest today, so this buys a refusal before the boot, not a pinned download.

## Verified on real boots

```
brig: image ...claude-code-stock:latest: signature verified, booting
brig: boot assets ghcr.io/nofireai/hull-assets:darwin-arm64: signature verified
```

Refusal path, bundle pointed elsewhere under `require`:
```
brig: refusing to boot: the boot assets at docker.io/library/busybox:latest are not
published by brig, so their signature cannot be checked (BRIG_VERIFY=require)
```

## Two things the tests caught

- **cosign was hardcoded** — ignored `BRIG_COSIGN_BIN`, and made the check unstubbable, so the first test silently hit the real registry.
- **The wiring needed its own test.** With the call removed from `EnsureRunning`, every test about what the check *decides* still passed.

Closes #28
