### PR TITLE
fix(verify): say whose policy checked the image, and stop advising the check off

### DIFF
--- a/cmd/brigd/daemon_test.go
+++ b/cmd/brigd/daemon_test.go
@@ -430,7 +430,9 @@ func TestACleanColdBootWarnsAboutNothing(t *testing.T) {
 	t.Setenv("BRIG_WORKSPACE", filepath.Join(shortDir(t), "ws"))
 	// The image check is the other thing that speaks on a cold boot, and with
 	// no cosign on this machine it has something true to say. Off, so what is
-	// left in the buffer is the narration this test is about.
+	// left in the buffer is the narration this test is about -- and off says
+	// so itself, which is a warning a client should get: it is a control the
+	// user turned off, not something the run did along the way.
 	t.Setenv("BRIG_VERIFY", "off")
 
 	socket := filepath.Join(shortDir(t), "brigd.sock")
@@ -440,8 +442,17 @@ func TestACleanColdBootWarnsAboutNothing(t *testing.T) {
 	if !resp.OK {
 		t.Fatalf("the sandbox did not come up: %+v", resp)
 	}
-	if len(resp.Warnings) != 0 {
-		t.Errorf("a boot with nothing wrong with it warned anyway: %q", resp.Warnings)
+	// What this test is about: narration is not a warning. A boot that went
+	// perfectly used to come back reporting "starting sandbox ..." as a
+	// warning about itself, which is the confusion Config.Progress exists to
+	// end. Anything a client is told here has to be something to act on.
+	for _, w := range resp.Warnings {
+		if strings.Contains(w, "starting sandbox") || strings.Contains(w, "workspace ") {
+			t.Errorf("progress narration came back as a warning: %q", w)
+		}
+		if !strings.Contains(w, "BRIG_VERIFY") {
+			t.Errorf("a boot with nothing wrong with it warned anyway: %q", w)
+		}
 	}
 }
 

--- a/internal/verify/verify.go
+++ b/internal/verify/verify.go
@@ -116,6 +116,33 @@ func BootAssetsPolicy() Policy {
 	}
 }
 
+// Replaced reports whether this policy differs from the one brig ships.
+//
+// Three settings can replace it: which prefix counts as ours, which
+// certificate identity is accepted, and which issuer vouched for it. Any of
+// them turns the check into a different question, and one of them --
+// an identity expression matching every certificate -- turns it into no
+// question at all while still succeeding. A reader cannot act on "verified"
+// without knowing which policy said so, so the answer travels with the result.
+//
+// Cosign is deliberately not compared: which binary runs the check is a fact
+// about the machine, not about what is being trusted.
+//
+// brig ships more than one policy -- images and boot assets are separate trust
+// roots -- so this asks whether the policy is any of the shipped ones rather
+// than whether it is the image one. Comparing against the image policy alone
+// would have the boot-assets policy report itself as replaced, which is the
+// opposite of true.
+func (p Policy) Replaced() bool {
+	for _, shipped := range []Policy{DefaultPolicy(), BootAssetsPolicy()} {
+		if p.Registry == shipped.Registry && p.Identity == shipped.Identity &&
+			p.Issuer == shipped.Issuer {
+			return false
+		}
+	}
+	return true
+}
+
 // Outcome is what the check concluded.
 type Outcome int
 
@@ -144,6 +171,10 @@ const (
 
 // Result carries the outcome and the detail worth printing.
 type Result struct {
+	// Policy is the policy that reached this conclusion, so the message can
+	// say whether it was the one brig ships. Without it a replaced check
+	// reports itself in the same words as a real one.
+	Policy  Policy
 	Outcome Outcome
 	Image   string
 	// Digest is the registry digest the reference resolved to, and -- for a
@@ -167,6 +198,15 @@ func (r Result) Message() string {
 	case Verified:
 		// Naming the digest is the point of this whole path: the line vouches
 		// for the bytes that boot, not for a tag that can move under them.
+		//
+		// Under a policy the user replaced it vouches for less, and says so in
+		// different words. The same sentence for both would let a check that
+		// accepts every certificate read exactly like one that accepts one.
+		if r.Policy.Replaced() {
+			return fmt.Sprintf("image %s: matched the replaced trust policy, booting %s "+
+				"(BRIG_VERIFY_REGISTRY, BRIG_VERIFY_IDENTITY or BRIG_VERIFY_ISSUER is set, "+
+				"so this is not brig's own check)", r.Image, r.Digest)
+		}
 		return fmt.Sprintf("image %s: signature verified, booting %s", r.Image, r.Digest)
 	case NotOurs:
 		return fmt.Sprintf("image %s is not published by brig-sh, so there is no "+
@@ -222,10 +262,10 @@ func normalizeRef(ref string) string {
 func (p Policy) Image(ref string) Result {
 	subject := normalizeRef(ref)
 	if !strings.HasPrefix(subject, p.Registry) {
-		return Result{Outcome: NotOurs, Image: ref}
+		return Result{Policy: p, Outcome: NotOurs, Image: ref}
 	}
 	if _, err := lookPath(p.Cosign); err != nil {
-		return Result{Outcome: NoTooling, Image: ref}
+		return Result{Policy: p, Outcome: NoTooling, Image: ref}
 	}
 	out, err := run(p.Cosign,
 		"verify",
@@ -234,9 +274,9 @@ func (p Policy) Image(ref string) Result {
 		subject,
 	)
 	if err != nil {
-		return Result{Outcome: Failed, Image: ref, Detail: firstLine(out, err)}
+		return Result{Policy: p, Outcome: Failed, Image: ref, Detail: firstLine(out, err)}
 	}
-	return Result{Outcome: Verified, Image: ref}
+	return Result{Policy: p, Outcome: Verified, Image: ref}
 }
 
 // Verify resolves the reference to a registry digest, verifies that digest,
@@ -269,13 +309,13 @@ func (p Policy) Verify(ref, localDigest string) Result {
 	// timeout, and bought a pin brig could not vouch for. The tag path never
 	// charged for an image it had nothing to say about, and neither does this.
 	if !ours {
-		return Result{Outcome: NotOurs, Image: ref}
+		return Result{Policy: p, Outcome: NotOurs, Image: ref}
 	}
 
 	// cosign resolves the digest as well as the signature here, so its absence
 	// stops both halves at once, exactly as it does for Image.
 	if _, err := lookPath(p.Cosign); err != nil {
-		return Result{Outcome: NoTooling, Image: ref, Ours: ours}
+		return Result{Policy: p, Outcome: NoTooling, Image: ref, Ours: ours}
 	}
 
 	// Resolve the reference to a digest BEFORE the check. A registry that cannot
@@ -283,7 +323,7 @@ func (p Policy) Verify(ref, localDigest string) Result {
 	// it must not read like a bad signature, so it lands on Unresolved.
 	digest, err := p.resolveDigest(ref)
 	if err != nil {
-		return Result{Outcome: Unresolved, Image: ref, Ours: ours, Detail: err.Error()}
+		return Result{Policy: p, Outcome: Unresolved, Image: ref, Ours: ours, Detail: err.Error()}
 	}
 
 	// The signature check, on the digest rather than the tag.
@@ -294,7 +334,7 @@ func (p Policy) Verify(ref, localDigest string) Result {
 		refWithDigest(ref, digest),
 	)
 	if verr != nil {
-		return Result{Outcome: Failed, Image: ref, Digest: digest, Ours: ours, Detail: firstLine(out, verr)}
+		return Result{Policy: p, Outcome: Failed, Image: ref, Digest: digest, Ours: ours, Detail: firstLine(out, verr)}
 	}
 
 	// The copy on disk must be the object we just resolved -- and, for our own
@@ -302,9 +342,9 @@ func (p Policy) Verify(ref, localDigest string) Result {
 	// thing in the registry and another in the store, which is the case this
 	// path exists to catch.
 	if localDigest != "" && localDigest != digest {
-		return Result{Outcome: Mismatch, Image: ref, Digest: digest, Local: localDigest, Ours: ours}
+		return Result{Policy: p, Outcome: Mismatch, Image: ref, Digest: digest, Local: localDigest, Ours: ours}
 	}
-	return Result{Outcome: Verified, Image: ref, Digest: digest, Ours: ours}
+	return Result{Policy: p, Outcome: Verified, Image: ref, Digest: digest, Ours: ours}
 }
 
 // resolveDigest asks cosign for the digest the registry serves for ref.

--- a/internal/verify/verify_test.go
+++ b/internal/verify/verify_test.go
@@ -340,3 +340,43 @@ func TestBootAssetsPolicyPinsItsOwnRepoAndWorkflow(t *testing.T) {
 		t.Errorf("the published bundle is not under the policy's prefix %q", p.Registry)
 	}
 }
+
+// A policy the user replaced cannot report itself in the same words as the one
+// brig ships. The settings that replace it accept anything, including an
+// identity expression that matches every certificate, and with that set brig
+// printed the identical "signature verified" line it prints for a real check.
+// The sentence a reader acts on has to differ when the thing it describes does.
+func TestAReplacedPolicyDoesNotSayTheSameThing(t *testing.T) {
+	shipped := DefaultPolicy()
+	if shipped.Replaced() {
+		t.Error("the shipped policy reports itself as replaced")
+	}
+	// brig ships more than one: the boot assets are their own trust root, and
+	// a policy that is shipped must not read as one the user swapped in.
+	if BootAssetsPolicy().Replaced() {
+		t.Error("the shipped boot-assets policy reports itself as replaced")
+	}
+
+	for what, p := range map[string]Policy{
+		"identity": {Registry: shipped.Registry, Identity: `.*`, Issuer: shipped.Issuer},
+		"registry": {Registry: "ghcr.io/someone/", Identity: shipped.Identity, Issuer: shipped.Issuer},
+		"issuer":   {Registry: shipped.Registry, Identity: shipped.Identity, Issuer: "https://example.com"},
+	} {
+		if !p.Replaced() {
+			t.Errorf("a policy with a replaced %s does not report itself as replaced", what)
+		}
+		res := Result{Outcome: Verified, Image: "ghcr.io/brig-sh/x:1", Digest: "sha256:abc", Policy: p}
+		if got := res.Message(); strings.Contains(got, "signature verified, booting") {
+			t.Errorf("a replaced %s printed the unqualified success line: %s", what, got)
+		}
+		if got := res.Message(); !strings.Contains(got, "replaced") {
+			t.Errorf("a replaced %s does not say the policy was replaced: %s", what, got)
+		}
+	}
+
+	// And the shipped policy still says exactly what it always said.
+	res := Result{Outcome: Verified, Image: "ghcr.io/brig-sh/x:1", Digest: "sha256:abc", Policy: shipped}
+	if got := res.Message(); !strings.Contains(got, "signature verified, booting") {
+		t.Errorf("the shipped policy stopped saying it verified: %s", got)
+	}
+}

--- a/internal/wrap/status.go
+++ b/internal/wrap/status.go
@@ -1,6 +1,7 @@
 package wrap
 
 import (
+	"github.com/brig-sh/brig/internal/verify"
 	"strings"
 
 	"github.com/brig-sh/brig/internal/creds"
@@ -28,6 +29,7 @@ func (c *Config) Status(set creds.Set) {
 		c.sayf("runtime unavailable (no runtime found on PATH)")
 	}
 	c.sayf("image %s (pull %s)", c.Image, c.Pull)
+	c.reportVerify()
 
 	names := credentialNames(set)
 	if len(names) == 0 {
@@ -284,3 +286,24 @@ func orUnset(s string) string {
 
 // nowMilli is split out so tests can reason about expiry without a clock.
 var nowMilli = defaultNowMilli
+
+// reportVerify says whether the image is checked before it boots, and whose
+// policy said so.
+//
+// Always, rather than on exception. The two states worth knowing -- checking
+// is off, and the policy is not brig's -- were both silent: verifyImage
+// returned before any output when off, and a replaced policy printed the same
+// success line as the shipped one. A reader who has to notice an absence to
+// learn either of those is not being told.
+func (c *Config) reportVerify() {
+	switch {
+	case c.Verify == verify.Off:
+		c.sayf("image verification: off (BRIG_VERIFY=off), so nothing is checked before it boots")
+	case c.VerifyPolicy.Replaced():
+		c.sayf("image verification: %s, against a replaced trust policy "+
+			"(BRIG_VERIFY_REGISTRY, BRIG_VERIFY_IDENTITY or BRIG_VERIFY_ISSUER is set, "+
+			"so this is not brig's own check)", c.Verify)
+	default:
+		c.sayf("image verification: %s, against brig's own trust policy", c.Verify)
+	}
+}

--- a/internal/wrap/status_test.go
+++ b/internal/wrap/status_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/brig-sh/brig/internal/profile"
 	"github.com/brig-sh/brig/internal/runtime"
 	"github.com/brig-sh/brig/internal/secret"
+	"github.com/brig-sh/brig/internal/verify"
 )
 
 // fakeRuntime answers the two questions a status report asks. The interface is
@@ -314,4 +315,47 @@ func TestStatusReportsTheImportedLogin(t *testing.T) {
 		"guest login: claude-credentials, imported from keychain:Claude Code-credentials (EXPIRED)\n") {
 		t.Errorf("an expired login was not reported:\n%s", got)
 	}
+}
+
+// brig info is where a user asks what a sandbox is about to be handed, and the
+// verify mode decides whether any of it was checked. It was not in the report
+// at all, so no command would tell a user that checking was off or that the
+// policy had been replaced.
+func TestStatusReportsTheVerifyMode(t *testing.T) {
+	t.Run("off", func(t *testing.T) {
+		c := bindingConfig(t, "")
+		c.Runtime = fakeRuntime{}
+		c.Verify = verify.Off
+		out := &bytes.Buffer{}
+		c.Out = out
+		c.Status(creds.Set{})
+		if got := out.String(); !strings.Contains(got, "off") || !strings.Contains(got, "verif") {
+			t.Errorf("the report does not say verification is off:\n%s", got)
+		}
+	})
+	t.Run("replaced policy", func(t *testing.T) {
+		c := bindingConfig(t, "")
+		c.Runtime = fakeRuntime{}
+		c.Verify = verify.Warn
+		c.VerifyPolicy = verify.DefaultPolicy()
+		c.VerifyPolicy.Identity = `.*`
+		out := &bytes.Buffer{}
+		c.Out = out
+		c.Status(creds.Set{})
+		if got := out.String(); !strings.Contains(got, "replaced") {
+			t.Errorf("the report does not say the trust policy was replaced:\n%s", got)
+		}
+	})
+	t.Run("shipped policy", func(t *testing.T) {
+		c := bindingConfig(t, "")
+		c.Runtime = fakeRuntime{}
+		c.Verify = verify.Warn
+		c.VerifyPolicy = verify.DefaultPolicy()
+		out := &bytes.Buffer{}
+		c.Out = out
+		c.Status(creds.Set{})
+		if got := out.String(); strings.Contains(got, "replaced") {
+			t.Errorf("the shipped policy is reported as replaced:\n%s", got)
+		}
+	})
 }

--- a/internal/wrap/verify.go
+++ b/internal/wrap/verify.go
@@ -32,6 +32,11 @@ import (
 // path is owed the difference. See runtime.Runtime.PinsDigest.
 func (c *Config) verifyImage() error {
 	if c.Verify == verify.Off {
+		// Said out loud rather than passed over in silence. This was the only
+		// state no command mentioned: the check returned here, before any
+		// output, so a sandbox booted unchecked and nothing on screen said so.
+		// The quietest path was the one that most needed a line.
+		c.warnf("BRIG_VERIFY=off, so the guest image is not checked before it boots")
 		return nil
 	}
 	if c.Runtime.PinsDigest() {
@@ -67,8 +72,14 @@ func (c *Config) verifyTag() error {
 			return errors.New("refusing to boot an image that failed verification")
 		}
 		if !c.confirm("Boot it anyway?") {
-			return errors.New("aborted: the image failed verification. " +
-				"Pull it again, or set BRIG_VERIFY=off if you know why it fails")
+			// Not "turn the check off". A signature that is present and does
+			// not check out is the one outcome with no innocent reading, and
+			// disabling the control that caught it is not a remedy. Pulling
+			// again fixes a stale or truncated copy; naming a digest the user
+			// has checked themselves is the deliberate way past it.
+			return errors.New("aborted: the image failed verification. Pull it again " +
+				"(BRIG_PULL=always), or set BRIG_IMAGE to a digest you have checked " +
+				"yourself")
 		}
 		return nil
 	}
@@ -170,8 +181,14 @@ func (c *Config) verifyDigest() error {
 			return errors.New("refusing to boot an image that failed verification")
 		}
 		if !c.confirm("Boot it anyway?") {
-			return errors.New("aborted: the image failed verification. " +
-				"Pull it again, or set BRIG_VERIFY=off if you know why it fails")
+			// Not "turn the check off". A signature that is present and does
+			// not check out is the one outcome with no innocent reading, and
+			// disabling the control that caught it is not a remedy. Pulling
+			// again fixes a stale or truncated copy; naming a digest the user
+			// has checked themselves is the deliberate way past it.
+			return errors.New("aborted: the image failed verification. Pull it again " +
+				"(BRIG_PULL=always), or set BRIG_IMAGE to a digest you have checked " +
+				"yourself")
 		}
 		return nil
 	}

--- a/internal/wrap/verify_test.go
+++ b/internal/wrap/verify_test.go
@@ -39,6 +39,21 @@ func (v verifyRuntime) Remove(string) error { return nil }
 // test can drive EnsureRunning through the checks without booting anything.
 func (v verifyRuntime) Run(runtime.RunSpec) error { return errors.New("stub runtime: not booting") }
 
+// namesAWayForward reports whether a refusal leaves the reader something to do.
+//
+// The requirement is that an abort is not a dead end, not that it names one
+// particular setting. For a signature that failed, "turn the check off" was
+// dropped deliberately (#29): disabling the control that caught it is not a
+// remedy, and pulling again or naming a digest you checked yourself is.
+func namesAWayForward(msg string) bool {
+	for _, remedy := range []string{"BRIG_VERIFY=off", "BRIG_PULL=always", "BRIG_IMAGE"} {
+		if strings.Contains(msg, remedy) {
+			return true
+		}
+	}
+	return false
+}
+
 func verifyConfig(t *testing.T, image string, mode verify.Mode) *Config {
 	t.Helper()
 	c := testConfig(t, t.TempDir(), t.TempDir())
@@ -225,8 +240,15 @@ func TestVerifyOffChecksNothing(t *testing.T) {
 	if err := c.verifyImage(); err != nil {
 		t.Fatalf("BRIG_VERIFY=off still checked: %v", err)
 	}
-	if said := c.Err.(*bytes.Buffer).String(); said != "" {
-		t.Errorf("BRIG_VERIFY=off still said something: %q", said)
+	// It says one thing, and only that: verification is off. Before #29 it
+	// said nothing at all, which made the one state worth announcing the
+	// quietest one.
+	said := c.Err.(*bytes.Buffer).String()
+	if !strings.Contains(said, "BRIG_VERIFY=off") {
+		t.Errorf("BRIG_VERIFY=off did not say so: %q", said)
+	}
+	if strings.Contains(said, "verified") || strings.Contains(said, "cosign") {
+		t.Errorf("BRIG_VERIFY=off still checked something: %q", said)
 	}
 }
 
@@ -256,8 +278,8 @@ func TestVerifyRefusesAFailedSignatureWithNoTerminal(t *testing.T) {
 	}
 	// Whatever the refusal was -- no terminal, or an answer of no -- it names
 	// the setting that lets a caller proceed deliberately.
-	if !strings.Contains(err.Error(), "BRIG_VERIFY=off") {
-		t.Errorf("the refusal did not name the override: %v", err)
+	if !namesAWayForward(err.Error()) {
+		t.Errorf("the refusal leaves the reader nothing to do: %v", err)
 	}
 	said := c.Err.(*bytes.Buffer).String()
 	if !strings.Contains(said, "DID NOT VERIFY") {
@@ -311,8 +333,8 @@ func TestVerifyDoesNotAskWhenTheCallerHasNoTerminal(t *testing.T) {
 	if err == nil {
 		t.Fatal("a failed signature was booted on a terminal the caller does not have")
 	}
-	if !strings.Contains(err.Error(), "BRIG_VERIFY=off") {
-		t.Errorf("the refusal did not name the override: %v", err)
+	if !namesAWayForward(err.Error()) {
+		t.Errorf("the refusal leaves the reader nothing to do: %v", err)
 	}
 	said := c.Err.(*bytes.Buffer).String()
 	if strings.Contains(said, "Boot it anyway?") {
@@ -387,7 +409,7 @@ func TestEveryVerifyRefusalNamesAWayForward(t *testing.T) {
 		if err == nil {
 			t.Fatalf("%s: booted rather than refusing", tc.what)
 		}
-		if !strings.Contains(err.Error(), "BRIG_VERIFY=off") {
+		if !namesAWayForward(err.Error()) {
 			t.Errorf("%s: the refusal names no way forward: %v", tc.what, err)
 		}
 	}
@@ -447,5 +469,52 @@ func TestEnsureRunningVerifiesTheBundleBeforeBooting(t *testing.T) {
 
 	if said := c.Err.(*bytes.Buffer).String(); !strings.Contains(said, "boot assets") {
 		t.Errorf("the run never looked at the kernel it was about to boot:\n%s", said)
+	}
+}
+
+// The advice for a signature that failed is not "stop checking". A bad
+// signature on an image claiming to be ours is the one outcome the verify
+// package describes as having no innocent reading, and the remedy on offer was
+// to disable the control that caught it. Pulling again is a real remedy, and
+// so is naming a digest the user has checked themselves.
+func TestAFailedSignatureIsNotToldToDisableTheCheck(t *testing.T) {
+	for _, tc := range []struct {
+		what string
+		pins bool
+	}{
+		{"the digest path", true},
+		{"the tag path", false},
+	} {
+		c := verifyConfig(t, "ghcr.io/brig-sh/claude-code:arm64", verify.Warn)
+		c.Runtime = verifyRuntime{pins: tc.pins}
+		// Present, and always exits non-zero: a signature that is there and
+		// does not check out, rather than a tool that is missing.
+		c.VerifyPolicy.Cosign = "false"
+		err := c.verifyImage()
+		if err == nil {
+			continue // this path could not reach Failed; the other one covers it
+		}
+		if strings.Contains(err.Error(), "BRIG_VERIFY=off") && strings.Contains(err.Error(), "failed verification") {
+			t.Errorf("%s: a failed signature is told to turn the check off: %v", tc.what, err)
+		}
+	}
+}
+
+// Verification being off is the one state no command mentioned. verifyImage
+// returned before reaching any output, so a sandbox booted with no check and
+// nothing said about it -- the quietest possible version of the loudest
+// possible fact.
+func TestVerifyOffSaysSo(t *testing.T) {
+	c := verifyConfig(t, "ghcr.io/brig-sh/claude-code:arm64", verify.Off)
+	c.Runtime = verifyRuntime{pins: false}
+	if err := c.verifyImage(); err != nil {
+		t.Fatalf("BRIG_VERIFY=off refused a boot: %v", err)
+	}
+	said := c.Err.(*bytes.Buffer).String()
+	if !strings.Contains(said, "BRIG_VERIFY=off") {
+		t.Errorf("nothing said verification was off:\n%s", said)
+	}
+	if !strings.Contains(said, "not checked") && !strings.Contains(said, "unchecked") {
+		t.Errorf("the line does not say what it costs:\n%s", said)
 	}
 }


### PR DESCRIPTION
Three settings replace the image trust policy (`BRIG_VERIFY_REGISTRY`, `BRIG_VERIFY_IDENTITY`, `BRIG_VERIFY_ISSUER`) and nothing printed when any was set. An identity regexp matching every certificate printed the line a real check prints:

```
$ BRIG_VERIFY_IDENTITY='.*' brig create claude
brig: image ...claude-code-stock:latest: signature verified, booting
```

Now it says `matched the replaced trust policy` and names the settings that could have changed it. The shipped policy is unchanged. `Result` carries the policy that reached it; the cosign binary is deliberately not compared, being a fact about the machine rather than about what is trusted.

## Two more

**`BRIG_VERIFY=off` said nothing.** The check returned before any output, so a sandbox booted unchecked with nothing on screen. It announces itself on every boot now, and `brig info` reports mode and policy source whatever the mode is.

**A failed signature was told to disable the check.** That is the one outcome with no innocent reading, and the remedy on offer was turning off the control that caught it. Now: pull again (`BRIG_PULL=always`), or set `BRIG_IMAGE` to a digest you checked yourself.

## Worth review

Three existing tests — one of them mine from last week — asserted a refusal names `BRIG_VERIFY=off`, which contradicts removing it. The requirement they encode is that an abort is not a dead end, not that it names one setting, so they assert that via `namesAWayForward`. It is the one place I loosened an existing security assertion.

`TestACleanColdBootWarnsAboutNothing` used `BRIG_VERIFY=off` for a quiet boot; off is no longer quiet. It now asserts what it guarded: narration does not come back as a warning.

## Verified

All three acceptance criteria on real boots: replaced policy no longer prints the unqualified line, shipped policy unchanged, off announces itself.

Closes #29
