### PR TITLE
fix(session): refuse a session-name collision, do not share

### DIFF
--- a/cmd/brig/main.go
+++ b/cmd/brig/main.go
@@ -238,9 +238,10 @@ func run(args []string) error {
 	if err != nil {
 		return err
 	}
-	// A ten-character slug is a tight budget, so two long names can slug the
-	// same and share one sandbox. Say which directory a run actually uses
-	// whenever the slug differs from the name, so that sharing stays visible.
+	// The slug is shortened and sanitised, so the directory a named session
+	// gets rarely reads back as the name typed. Say which directory it actually
+	// is whenever the two differ. A name that shortens onto another session's
+	// sandbox is refused later, at EnsureRunning; this only names the directory.
 	if cfg.RawName != "" && cfg.RawName != cfg.Slug {
 		fmt.Fprintf(os.Stderr, "brig: session %q uses %s (sandbox %s)\n",
 			cfg.RawName, cfg.Workspace, cfg.VMName)
@@ -771,6 +772,7 @@ func reset(args []string) error {
 		// Config, because reset works from the instance list and a stopped
 		// sandbox need not correspond to a profile brig can still look up.
 		wrap.ForgetWorkspace(inst.Name)
+		wrap.ForgetSession(inst.Name)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "brig: could not remove %s: %v\n", inst.Name, err)
 			continue

--- a/internal/wrap/index.go
+++ b/internal/wrap/index.go
@@ -55,24 +55,25 @@ func stateDir() (string, error) {
 	return filepath.Join(home, ".brig"), nil
 }
 
-func workspaceIndexPath() (string, error) {
+// indexPath is stateDir/name, for one of brig's small bookkeeping files.
+func indexPath(name string) (string, error) {
 	dir, err := stateDir()
 	if err != nil {
 		return "", err
 	}
-	return filepath.Join(dir, workspaceIndexName), nil
+	return filepath.Join(dir, name), nil
 }
 
-// readWorkspaceIndex returns what has been recorded, and an empty map for
-// every way that can fail.
+// readIndex returns the string map recorded under name, and an empty one for
+// every way the read can fail.
 //
 // A file that is missing, unreadable or corrupt is not worth failing a command
-// over: an absent entry costs the sandbox one restart, and that is exactly the
-// behaviour of the release before this file existed. Failing instead would
+// over: at worst an absent entry costs one restart, which is exactly the
+// behaviour of the release before these files existed. Failing instead would
 // make a stray file in ~/.brig able to stop every brig command on the host.
-func readWorkspaceIndex() map[string]string {
+func readIndex(name string) map[string]string {
 	index := map[string]string{}
-	path, err := workspaceIndexPath()
+	path, err := indexPath(name)
 	if err != nil {
 		return index
 	}
@@ -86,9 +87,9 @@ func readWorkspaceIndex() map[string]string {
 	return index
 }
 
-// writeWorkspaceIndex replaces the file with the map it is given.
-func writeWorkspaceIndex(index map[string]string) error {
-	path, err := workspaceIndexPath()
+// writeIndex replaces the file named name with the map it is given.
+func writeIndex(name string, index map[string]string) error {
+	path, err := indexPath(name)
 	if err != nil {
 		return err
 	}
@@ -102,9 +103,9 @@ func writeWorkspaceIndex(index map[string]string) error {
 		return err
 	}
 	// Written through a temporary file and renamed, so a crash mid-write
-	// cannot leave a half-parsed map behind -- which would cost every sandbox
-	// on the host its entry rather than one of them.
-	tmp, err := os.CreateTemp(filepath.Dir(path), ".workspaces-*")
+	// cannot leave a half-parsed map behind -- which would cost every entry in
+	// the file rather than one of them.
+	tmp, err := os.CreateTemp(filepath.Dir(path), "."+name+"-*")
 	if err != nil {
 		return err
 	}
@@ -117,6 +118,13 @@ func writeWorkspaceIndex(index map[string]string) error {
 		return err
 	}
 	return os.Rename(tmp.Name(), path)
+}
+
+// readWorkspaceIndex and writeWorkspaceIndex are the workspace index's names
+// for the shared read and write above.
+func readWorkspaceIndex() map[string]string { return readIndex(workspaceIndexName) }
+func writeWorkspaceIndex(index map[string]string) error {
+	return writeIndex(workspaceIndexName, index)
 }
 
 // RememberedWorkspace is the workspace a sandbox was started with, or "" when

--- a/internal/wrap/run.go
+++ b/internal/wrap/run.go
@@ -172,6 +172,12 @@ func (c *Config) resolveSecrets() (creds.Resolution, error) {
 // EnsureRunning brings the sandbox up if it is not already, and makes sure
 // the one that is up is mounting this workspace.
 func (c *Config) EnsureRunning(set creds.Set) error {
+	// Before anything is prepared or booted: a name that shortens to a sandbox
+	// another name already owns is refused here rather than dropped into that
+	// sandbox's home directory. See slugclaim.go.
+	if err := c.claimSlug(); err != nil {
+		return err
+	}
 	// BRIG_HYPERVISOR (or BRIG_<PROFILE>_HYPERVISOR) beats what the profile
 	// asked for, which is the same order every other setting follows. Resolved
 	// once here so the preflight below and the spec built later cannot disagree
@@ -467,6 +473,7 @@ func (c *Config) Remove() error {
 	_ = c.Runtime.Stop(c.VMName)
 	err := c.Runtime.Remove(c.VMName)
 	ForgetWorkspace(c.VMName)
+	ForgetSession(c.VMName)
 	return err
 }
 

--- a/internal/wrap/slugclaim.go
+++ b/internal/wrap/slugclaim.go
@@ -1,0 +1,76 @@
+package wrap
+
+import "fmt"
+
+// The session-claim index: which session name owns each sandbox.
+//
+// A session name is turned into a short slug for its paths, and the sandbox is
+// brig-<profile>-<slug>. The slug budget is tight, so two different names that
+// share their leading characters can shorten to one slug and land on one
+// sandbox and one workspace -- with whatever credentials each was handed. brig
+// used to warn about that and carry on, which left two agents in one guest home
+// with different logins. Refuse the second name instead.
+//
+// The first name to take a sandbox writes down that it owns it; a later run
+// whose name shortens to the same sandbox but is not that name is refused and
+// told to pick another --name. The same name returning is the ordinary repeat
+// run and is let through.
+//
+// Keyed by sandbox name, not by the bare slug: the sandbox name carries the
+// profile, and two profiles that shorten to one slug share nothing, since the
+// sandbox and the workspace both include the profile. It is also the key rm and
+// reset already have in hand, so releasing a claim sits beside ForgetWorkspace
+// on both paths. Same file conventions as the workspace index (see index.go):
+// atomic write, an unusable file treated as empty, and a bookkeeping failure
+// never fatal to a command that would otherwise work.
+
+// sessionIndexName is the file, inside stateDir.
+const sessionIndexName = "sessions.json"
+
+// claimSlug records that this run's session name owns its sandbox, and refuses
+// the run when a different name owns it already.
+//
+// An unnamed run cannot collide: its sandbox is brig-<profile> with no slug,
+// and every unnamed run of a profile is meant to be the one session. So it
+// claims nothing and is always let through.
+//
+// A failure to write the claim is a warning, not an error, the way
+// rememberWorkspace treats its own: the sandbox this run wants is free, so
+// refusing it over a bookkeeping file that could not be rewritten would deny
+// the thing that was actually asked for. The only cost is that a later
+// colliding name goes uncaught.
+func (c *Config) claimSlug() error {
+	if c.RawName == "" {
+		return nil
+	}
+	index := readIndex(sessionIndexName)
+	owner, taken := index[c.VMName]
+	if taken && owner != c.RawName {
+		return fmt.Errorf("session %q shortens to %q, the sandbox session %q already "+
+			"uses (%s). Sharing it would put both agents in one home directory with "+
+			"whichever credentials arrived last, so run one under a different --name",
+			c.RawName, c.Slug, owner, c.VMName)
+	}
+	if owner == c.RawName {
+		return nil
+	}
+	index[c.VMName] = c.RawName
+	if err := writeIndex(sessionIndexName, index); err != nil {
+		c.warnf("could not record %s as the owner of %s (%v). A later run whose name "+
+			"shortens to the same sandbox will not be refused.", c.RawName, c.VMName, err)
+	}
+	return nil
+}
+
+// ForgetSession drops a removed sandbox's claim, so the next session name that
+// shortens to it can take it. Errors are dropped the way ForgetWorkspace drops
+// its own: a removal that worked must not report a failure because a
+// bookkeeping file could not be rewritten.
+func ForgetSession(vmName string) {
+	index := readIndex(sessionIndexName)
+	if _, ok := index[vmName]; !ok {
+		return
+	}
+	delete(index, vmName)
+	_ = writeIndex(sessionIndexName, index)
+}

--- a/internal/wrap/slugclaim_test.go
+++ b/internal/wrap/slugclaim_test.go
@@ -1,0 +1,111 @@
+package wrap
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// The transcript in issue #26: two different session names whose slugs shorten
+// to the same sandbox. The first claims it; the second must be refused rather
+// than dropped into the same guest home with different credentials.
+func TestACollidingSessionNameIsRefused(t *testing.T) {
+	isolateState(t)
+
+	prod := mustLoad(t, Options{Name: "acme-corp-prod"})
+	if err := prod.claimSlug(); err != nil {
+		t.Fatalf("the first name could not claim its own sandbox: %v", err)
+	}
+
+	staging := mustLoad(t, Options{Name: "acme-corp-staging"})
+	if staging.VMName != prod.VMName {
+		t.Fatalf("the two names did not collide: %q and %q -- pick names that do",
+			prod.VMName, staging.VMName)
+	}
+
+	err := staging.claimSlug()
+	if err == nil {
+		t.Fatal("a name colliding with another was allowed to share the sandbox")
+	}
+	// The refusal has to name both sessions, so the reader knows what they are
+	// up against and which other name to look for.
+	if !strings.Contains(err.Error(), "acme-corp-prod") ||
+		!strings.Contains(err.Error(), "acme-corp-staging") {
+		t.Errorf("the refusal does not name both sessions: %v", err)
+	}
+}
+
+// The ordinary repeat run: the same name returning to its own sandbox is not a
+// collision and must be let through.
+func TestTheSameNameKeepsItsOwnSandbox(t *testing.T) {
+	isolateState(t)
+
+	first := mustLoad(t, Options{Name: "acme-corp-prod"})
+	if err := first.claimSlug(); err != nil {
+		t.Fatalf("the first run could not claim: %v", err)
+	}
+	again := mustLoad(t, Options{Name: "acme-corp-prod"})
+	if err := again.claimSlug(); err != nil {
+		t.Errorf("a repeat run of the same name was refused its own sandbox: %v", err)
+	}
+}
+
+// `brig rm` releases the claim, so the sandbox a different name was refused is
+// free for it once the first is gone.
+func TestRemoveReleasesTheClaim(t *testing.T) {
+	isolateState(t)
+
+	prod := mustLoad(t, Options{Name: "acme-corp-prod"})
+	if err := prod.claimSlug(); err != nil {
+		t.Fatalf("the first name could not claim: %v", err)
+	}
+
+	rt := &removingRuntime{}
+	prod.Runtime = rt
+	if err := prod.Remove(); err != nil {
+		t.Fatalf("remove failed: %v", err)
+	}
+
+	staging := mustLoad(t, Options{Name: "acme-corp-staging"})
+	if err := staging.claimSlug(); err != nil {
+		t.Errorf("the sandbox was not released by rm: %v", err)
+	}
+}
+
+// `brig reset` works from the instance list, so it releases by name without a
+// Config -- the claim has to go on that path too, or a reset leaves every
+// sandbox it removed still claimed.
+func TestForgetSessionPrunesByName(t *testing.T) {
+	isolateState(t)
+
+	prod := mustLoad(t, Options{Name: "acme-corp-prod"})
+	if err := prod.claimSlug(); err != nil {
+		t.Fatalf("the first name could not claim: %v", err)
+	}
+
+	// A name never claimed is not an error: reset walks every brig sandbox.
+	ForgetSession("brig-claude-code-neverseen")
+	ForgetSession(prod.VMName)
+
+	staging := mustLoad(t, Options{Name: "acme-corp-staging"})
+	if err := staging.claimSlug(); err != nil {
+		t.Errorf("reset did not release the claim: %v", err)
+	}
+}
+
+// The claim index is bookkeeping, so an unusable one costs nothing: a corrupt
+// file is treated as empty and the run proceeds, exactly as it did before the
+// file existed.
+func TestACorruptClaimIndexDoesNotBreakARun(t *testing.T) {
+	dir := isolateState(t)
+	path := filepath.Join(dir, sessionIndexName)
+	if err := os.WriteFile(path, []byte("{not json at all"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	c := mustLoad(t, Options{Name: "acme-corp-prod"})
+	if err := c.claimSlug(); err != nil {
+		t.Errorf("a corrupt claim index failed the run: %v", err)
+	}
+}

--- a/script/smoke.sh
+++ b/script/smoke.sh
@@ -361,6 +361,31 @@ grep -q -- '--name brig-claude-code-my-big-ref' "$STUB_LOG" \
 grep -q -- "-- claude --name My Big Refactor -p hi" "$STUB_LOG" \
   && ok "the raw name reaches the agent" || bad "the raw name reaches the agent"
 
+echo "== session collision =="
+# Two names whose slugs shorten to one sandbox must not share it: the tight slug
+# budget used to drop the second into the first's home with its own credentials,
+# and brig only warned. Now the second is refused. See issue #26.
+"$WORK/brig" reset > /dev/null 2>&1
+"$WORK/brig" run claude --name acme-corp-prod -d > /dev/null 2>&1
+out="$("$WORK/brig" run claude --name acme-corp-staging -d 2>&1)"; rc=$?
+[ "$rc" != 0 ] && ok "a colliding session name is refused" \
+  || bad "a colliding session name started anyway -- got rc $rc"
+case "$out" in
+  *acme-corp-prod*) ok "the refusal names the session already holding the sandbox" ;;
+  *) bad "the refusal names the other session -- got: $out" ;;
+esac
+# The same name returning is the ordinary repeat run, not a collision.
+"$WORK/brig" run claude --name acme-corp-prod -d > /dev/null 2>&1 \
+  && ok "the owning name runs again without complaint" \
+  || bad "the owning name was refused its own sandbox"
+# rm releases the claim, so the name that was refused can take the sandbox once
+# the first is gone.
+"$WORK/brig" rm claude --name acme-corp-prod > /dev/null 2>&1
+"$WORK/brig" run claude --name acme-corp-staging -d > /dev/null 2>&1 \
+  && ok "rm frees the sandbox for the other name" \
+  || bad "the sandbox stayed claimed after rm"
+"$WORK/brig" reset > /dev/null 2>&1
+
 echo "== stop =="
 : > "$STUB_LOG"
 "$WORK/brig" stop claude > /dev/null 2>&1


### PR DESCRIPTION
Slugs truncate at 10 characters, so two different session names that share their first 10 resolve to the same sandbox **and the same guest home**, with whatever credentials each was given. brig warned on stderr and carried on.

    $ brig create claude --name acme-corp-prod     -> brig-claude-code-acme-corp
    $ brig create claude --name acme-corp-staging  -> brig-claude-code-acme-corp

Now the second refuses:

    brig: session "acme-corp-staging" shortens to "acme-corp", the sandbox session
    "acme-corp-prod" already uses (brig-claude-code-acme-corp). Sharing it would put
    both agents in one home directory with whichever credentials arrived last, so run
    one under a different --name

A slug->name index lives beside the existing workspace bookkeeping, with the same rules: atomic write, a corrupt or missing file reads as empty, and bookkeeping failure never breaks a command that would otherwise work. The same name reusing its own slug is the ordinary repeat run and still works. `rm` and `reset` release the claim.

`maxSlug` is unchanged: longer slugs make longer paths and do not remove the class.

Verified on real boots: the collision refuses, the repeat run works, and the claim is released on `rm`.

Closes #26