### PR TITLE
fix(runtime): tell a stopped sandbox from one that cannot be asked

### DIFF
--- a/cmd/brigd/daemon_test.go
+++ b/cmd/brigd/daemon_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"net"
 	"os"
@@ -492,6 +493,54 @@ func TestAProfilesRuntimeBinReachesTheSameBinaryThroughTheDaemon(t *testing.T) {
 	}
 	if rt.Bin() != cfg.Runtime.Bin() {
 		t.Errorf("the CLI drives %q and the daemon %q", rt.Bin(), cfg.Runtime.Bin())
+	}
+}
+
+// livenessRuntime answers the one question the inventory asks. Everything else
+// panics through the embedded nil interface, which is louder than a stub that
+// quietly answers something the status report never asked.
+type livenessRuntime struct {
+	runtime.Runtime
+	running bool
+	err     error
+}
+
+func (l livenessRuntime) Running(string) (bool, error) { return l.running, l.err }
+
+// The inventory re-reads liveness from the runtime on every report, so a
+// runtime that cannot be asked has to be reported as unanswered rather than as
+// a stopped sandbox. Folded into running:false it reads as a sandbox that
+// exited, and the operator goes looking for a VM that may well still be up.
+func TestStatusSaysWhenTheRuntimeCouldNotBeAsked(t *testing.T) {
+	d := newDaemon()
+	d.sessions["brig-broken"] = entry{
+		Session: Session{Agent: "claude-code", VM: "brig-broken"},
+		rt:      livenessRuntime{err: errors.New("cannot connect to the daemon")},
+	}
+	d.sessions["brig-up"] = entry{
+		Session: Session{Agent: "claude-code", VM: "brig-up"},
+		rt:      livenessRuntime{running: true},
+	}
+
+	byVM := map[string]Session{}
+	for _, s := range d.status() {
+		byVM[s.VM] = s
+	}
+
+	broken := byVM["brig-broken"]
+	if broken.RunningError == "" {
+		t.Error("a runtime that could not be asked was reported as a plain stopped sandbox")
+	}
+	if !strings.Contains(broken.RunningError, "cannot connect to the daemon") {
+		t.Errorf("the runtime's explanation was dropped: %q", broken.RunningError)
+	}
+	if broken.Running {
+		t.Error("a sandbox nothing could answer for was reported as running")
+	}
+
+	// The answers that were given are unchanged.
+	if up := byVM["brig-up"]; !up.Running || up.RunningError != "" {
+		t.Errorf("a running sandbox was misreported: %+v", up)
 	}
 }
 

--- a/cmd/brigd/main.go
+++ b/cmd/brigd/main.go
@@ -101,6 +101,13 @@ type Session struct {
 	VM        string `json:"vm"`
 	Workspace string `json:"workspace"`
 	Running   bool   `json:"running"`
+	// RunningError is why the runtime could not be asked. When it is set,
+	// Running says nothing -- a runtime that failed to answer is not a runtime
+	// reporting a stopped sandbox, and a client that shows the second for the
+	// first sends its reader looking for a VM that may well still be up. It
+	// carries the reason rather than a bare flag because that reason is the only
+	// account of what broke, and the daemon has no terminal to print it on.
+	RunningError string `json:"runningError,omitempty"`
 }
 
 func main() {
@@ -560,7 +567,14 @@ func (d *daemon) status() []Session {
 	defer d.mu.Unlock()
 	out := make([]Session, 0, len(d.sessions))
 	for vm, e := range d.sessions {
-		e.Running = e.rt.Running(vm)
+		running, err := e.rt.Running(vm)
+		// Reported as unanswered rather than as stopped. The inventory says brig
+		// booted this sandbox, so "not running" is a claim that it exited, and a
+		// runtime nobody could reach never made that claim.
+		e.Running = running
+		if err != nil {
+			e.RunningError = err.Error()
+		}
 		out = append(out, e.Session)
 	}
 	return out

--- a/docs/brigd.md
+++ b/docs/brigd.md
@@ -55,6 +55,21 @@ A response looks like:
 Errors come back as `{"ok":false,"error":"..."}` rather than as a closed
 connection.
 
+`running` is re-read from the runtime on every report rather than taken from
+the inventory, so a sandbox stopped by something else is still reported as
+stopped. When the runtime could not be asked at all -- its binary is gone, a
+permission error, containerd is down -- the session carries `runningError`
+instead, and `running` says nothing:
+
+```json
+{"agent":"claude-code","vm":"brig-claude-code","workspace":"/Users/me/brig/claude-code",
+  "running":false,"runningError":"nerdctl ps: exit status 1: cannot connect to containerd"}
+```
+
+Show that as "cannot tell", not as a stopped sandbox: the daemon booted this
+one, so `running:false` on its own would claim it exited, and a runtime nobody
+could reach never made that claim.
+
 Anything the run says about itself comes back with it, as `warnings`, one line
 each: a credential that was not forwarded and why, a secret about to expire, an
 image that could not be verified. The CLI prints these on the terminal of the

--- a/internal/runtime/hull.go
+++ b/internal/runtime/hull.go
@@ -199,21 +199,30 @@ func (h *hull) assetDir() (string, error) {
 
 // Running parses `ps` rather than asking for one instance, because a stopped
 // instance still holds its name and must not read as running.
-func (h *hull) Running(name string) bool {
+//
+// A `ps` that did not run is returned as an error rather than folded into
+// false. The two are different events -- no sandbox is up, versus this hull
+// could not be asked -- and the caller acts on the difference; see the note on
+// Runtime.Running. hull's own explanation is captured and carried along,
+// because "exit status 1" on its own tells nobody which of the two it was.
+func (h *hull) Running(name string) (bool, error) {
 	cmd := exec.Command(h.bin, "ps")
 	cmd.Env = mergeEnv(telemetryEnv(false))
-	var out bytes.Buffer
-	cmd.Stdout = &out
+	var out, errb bytes.Buffer
+	cmd.Stdout, cmd.Stderr = &out, &errb
 	if err := cmd.Run(); err != nil {
-		return false
+		if said := strings.TrimSpace(errb.String()); said != "" {
+			return false, fmt.Errorf("%s ps: %w: %s", h.bin, err, firstLines(said, 3))
+		}
+		return false, fmt.Errorf("%s ps: %w", h.bin, err)
 	}
 	for _, line := range strings.Split(out.String(), "\n") {
 		f := strings.Fields(line)
 		if len(f) >= 2 && f[0] == name && f[1] == "running" {
-			return true
+			return true, nil
 		}
 	}
-	return false
+	return false, nil
 }
 
 // List reads the same table Running does. A stopped instance still holds its

--- a/internal/runtime/nerdctl.go
+++ b/internal/runtime/nerdctl.go
@@ -99,20 +99,29 @@ func repoDigest(out string) string {
 	return ""
 }
 
-func (n *nerdctl) Running(name string) bool {
+// Running asks for the running containers under this exact name. The filter
+// already excludes a stopped one, so an empty listing is a genuine no.
+//
+// A `ps` that did not run is an error rather than a no, for the reason on
+// Runtime.Running: a containerd that is not up answers nothing, and reading
+// that as "no sandbox is running" is what booted a second one over the first.
+func (n *nerdctl) Running(name string) (bool, error) {
 	cmd := exec.Command(n.bin, "ps", "--filter", "name=^"+name+"$", "--format", "{{.Names}}")
 	cmd.Env = mergeEnv(telemetryEnv(false))
-	var out bytes.Buffer
-	cmd.Stdout = &out
+	var out, errb bytes.Buffer
+	cmd.Stdout, cmd.Stderr = &out, &errb
 	if err := cmd.Run(); err != nil {
-		return false
+		if said := strings.TrimSpace(errb.String()); said != "" {
+			return false, fmt.Errorf("%s ps: %w: %s", n.bin, err, firstLines(said, 3))
+		}
+		return false, fmt.Errorf("%s ps: %w", n.bin, err)
 	}
 	for _, line := range strings.Split(out.String(), "\n") {
 		if strings.TrimSpace(line) == name {
-			return true
+			return true, nil
 		}
 	}
-	return false
+	return false, nil
 }
 
 func (n *nerdctl) List() ([]Instance, error) {

--- a/internal/runtime/running_test.go
+++ b/internal/runtime/running_test.go
@@ -1,0 +1,131 @@
+package runtime
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// stubBin writes a stand-in runtime binary and returns its path.
+func stubBin(t *testing.T, script string) string {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("shell stand-in is not portable to windows")
+	}
+	path := filepath.Join(t.TempDir(), "rt")
+	if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+// brokenBin is a runtime that fails whatever it is asked, which is the shape of
+// a broken install, a permission error, or a daemon that is not up. The whole
+// point of #49 is that this is not the same event as "no sandbox is running".
+func brokenBin(t *testing.T) string {
+	t.Helper()
+	return stubBin(t, "#!/bin/sh\necho 'cannot connect to the daemon' >&2\nexit 1\n")
+}
+
+// A runtime that could not be asked must say so. Reported as "not running", it
+// makes EnsureRunning boot a second sandbox onto a workspace the first is still
+// holding.
+func TestHullRunningReportsARuntimeThatCannotAnswer(t *testing.T) {
+	h := &hull{bin: brokenBin(t)}
+
+	running, err := h.Running("brig-claude-code")
+	if err == nil {
+		t.Fatal("a runtime that failed to answer reported no error, which reads as 'not running'")
+	}
+	if running {
+		t.Error("a runtime that failed to answer must not report the sandbox as up")
+	}
+	// The runtime's own explanation is the only account of what went wrong, so
+	// it has to survive into the error.
+	if !strings.Contains(err.Error(), "cannot connect to the daemon") {
+		t.Errorf("the runtime's explanation was dropped: %v", err)
+	}
+}
+
+// A binary that is not there at all is the same class of event: nothing was
+// asked, so nothing was answered.
+func TestHullRunningReportsAMissingBinary(t *testing.T) {
+	h := &hull{bin: filepath.Join(t.TempDir(), "not-installed")}
+
+	if _, err := h.Running("brig-claude-code"); err == nil {
+		t.Fatal("a missing runtime binary reported no error")
+	}
+}
+
+// The other two answers keep working. A stopped instance still holds its name
+// and must not read as running, and an absent one is a plain no with no error
+// on it -- that is what lets a first boot happen at all.
+func TestHullRunningTellsUpFromStoppedAndAbsent(t *testing.T) {
+	bin := stubBin(t, "#!/bin/sh\ncat <<'EOF'\nNAME STATE\n"+
+		"brig-other running\nbrig-stopped stopped\nEOF\n")
+	h := &hull{bin: bin}
+
+	for _, tc := range []struct {
+		name string
+		want bool
+	}{
+		{"brig-other", true},
+		{"brig-stopped", false},
+		{"brig-absent", false},
+	} {
+		running, err := h.Running(tc.name)
+		if err != nil {
+			t.Fatalf("%s: %v", tc.name, err)
+		}
+		if running != tc.want {
+			t.Errorf("Running(%q) = %v, want %v", tc.name, running, tc.want)
+		}
+	}
+}
+
+func TestNerdctlRunningReportsARuntimeThatCannotAnswer(t *testing.T) {
+	n := &nerdctl{bin: brokenBin(t)}
+
+	running, err := n.Running("brig-claude-code")
+	if err == nil {
+		t.Fatal("a runtime that failed to answer reported no error, which reads as 'not running'")
+	}
+	if running {
+		t.Error("a runtime that failed to answer must not report the sandbox as up")
+	}
+	if !strings.Contains(err.Error(), "cannot connect to the daemon") {
+		t.Errorf("the runtime's explanation was dropped: %v", err)
+	}
+}
+
+func TestNerdctlRunningReportsAMissingBinary(t *testing.T) {
+	n := &nerdctl{bin: filepath.Join(t.TempDir(), "not-installed")}
+
+	if _, err := n.Running("brig-claude-code"); err == nil {
+		t.Fatal("a missing runtime binary reported no error")
+	}
+}
+
+// The filter already restricts the listing to running containers, so an empty
+// answer is the genuine no this adapter reports.
+func TestNerdctlRunningTellsUpFromAbsent(t *testing.T) {
+	up := &nerdctl{bin: stubBin(t, "#!/bin/sh\necho brig-claude-code\n")}
+	running, err := up.Running("brig-claude-code")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !running {
+		t.Error("a listed sandbox was not reported as running")
+	}
+
+	absent := &nerdctl{bin: stubBin(t, "#!/bin/sh\nexit 0\n")}
+	running, err = absent.Running("brig-claude-code")
+	if err != nil {
+		t.Fatalf("an empty listing is a plain no, not a failure: %v", err)
+	}
+	if running {
+		t.Error("an absent sandbox was reported as running")
+	}
+}

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -140,8 +140,17 @@ type Runtime interface {
 	Kind() string
 	// Bin is the executable actually being driven.
 	Bin() string
-	// Running reports whether a sandbox of this name is up.
-	Running(name string) bool
+	// Running reports whether a sandbox of this name is up, and returns an
+	// error when it could not find out at all.
+	//
+	// Three answers, not two, because a runtime that cannot be asked -- a binary
+	// that is not there, a permission error, a daemon that is down -- is not a
+	// runtime saying no. Both adapters used to fold the failure into false, so a
+	// broken runtime read as an empty machine and EnsureRunning booted a second
+	// sandbox onto a workspace the first was still holding (#49). A caller that
+	// cannot tell must not boot: false with a non-nil error means "unknown", and
+	// the boolean says nothing.
+	Running(name string) (bool, error)
 	// List returns every sandbox the runtime knows about, running or not.
 	List() ([]Instance, error)
 	// Run boots a sandbox, detached.

--- a/internal/wrap/run.go
+++ b/internal/wrap/run.go
@@ -1,6 +1,7 @@
 package wrap
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"strconv"
@@ -208,7 +209,17 @@ func (c *Config) EnsureRunning(set creds.Set) error {
 		return err
 	}
 
-	if c.Runtime.Running(c.VMName) {
+	// Three answers, and the third one refuses. A runtime that could not be
+	// asked has said nothing about this workspace, and booting on that is the
+	// dangerous direction: it starts a second sandbox on a workspace the first
+	// is still holding, two guests writing the same home. Stopping here costs a
+	// run that might have been fine; proceeding costs the state of one that was.
+	running, err := c.Runtime.Running(c.VMName)
+	if err != nil {
+		return fmt.Errorf("cannot tell whether the sandbox %s is already running, so "+
+			"refusing to start a second one over it: %w", c.VMName, err)
+	}
+	if running {
 		if c.guestMountsWorkspace() {
 			// The guest has confirmed this workspace, so record it. Nothing has
 			// changed for a session brig already knows about; for one created
@@ -452,10 +463,26 @@ func (c *Config) guestMountsWorkspace() bool {
 // the runtime complains was already in the state that was asked for -- so the
 // runtime is asked again before its error is believed, which is also what
 // keeps "it was not running to begin with" from becoming a failure.
+//
+// Only an answer clears a failed stop. A runtime that could not say whether the
+// sandbox is still up has not established the end state, and treating that as
+// "gone anyway" puts the swallow back: the user is told a VM holding a
+// forwarded credential is down when nothing checked.
 func (c *Config) Stop() error {
 	err := c.Runtime.Stop(c.VMName)
-	if err == nil || !c.Runtime.Running(c.VMName) {
+	if err == nil {
 		return nil
+	}
+	running, askErr := c.Runtime.Running(c.VMName)
+	if askErr == nil && !running {
+		return nil
+	}
+	if askErr != nil {
+		// Both, joined: what the stop said and why the end state could not be
+		// checked are two separate things to fix, and errors.Is finds either.
+		return fmt.Errorf("the sandbox %s would not stop, and whether it is still running "+
+			"could not be established (%s): %w", c.VMName, c.Runtime.LogsHint(c.VMName),
+			errors.Join(err, askErr))
 	}
 	return fmt.Errorf("the sandbox %s is still running and would not stop (%s): %w",
 		c.VMName, c.Runtime.LogsHint(c.VMName), err)

--- a/internal/wrap/running_test.go
+++ b/internal/wrap/running_test.go
@@ -1,0 +1,122 @@
+package wrap
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/brig-sh/brig/internal/creds"
+	"github.com/brig-sh/brig/internal/profile"
+	"github.com/brig-sh/brig/internal/runtime"
+	"github.com/brig-sh/brig/internal/verify"
+)
+
+// livenessRuntime answers the one question the boot decision turns on, and
+// counts the boots so a case can tell "refused" from "started a second
+// sandbox". Everything else panics through the embedded nil interface, which
+// is louder than a stub quietly answering something it was never asked.
+type livenessRuntime struct {
+	runtime.Runtime
+	running    bool
+	runningErr error
+	// workspace is the directory the guest is pretending to mount, so Output
+	// can read back the marker brig wrote there.
+	workspace string
+	boots     int
+	stops     int
+	removes   int
+}
+
+func (r *livenessRuntime) Kind() string                 { return "hull" }
+func (r *livenessRuntime) Running(string) (bool, error) { return r.running, r.runningErr }
+func (r *livenessRuntime) Stop(string) error            { r.stops++; return nil }
+func (r *livenessRuntime) Remove(string) error          { r.removes++; return nil }
+func (r *livenessRuntime) Run(runtime.RunSpec) error    { r.boots++; return nil }
+func (r *livenessRuntime) Probe(runtime.ExecSpec) bool  { return true }
+func (r *livenessRuntime) LogsHint(name string) string  { return "hull logs " + name }
+
+// Output stands in for the guest reading its own home: a guest that mounts the
+// workspace reads back the marker brig put there.
+func (r *livenessRuntime) Output(runtime.ExecSpec) (string, error) {
+	b, err := os.ReadFile(filepath.Join(r.workspace, markerFile))
+	return string(b), err
+}
+
+// livenessConfig is a run with nothing in its way: no secret files to deliver,
+// no volumes to mount, and no image check, so what a case observes is the boot
+// decision alone.
+func livenessConfig(t *testing.T, rt *livenessRuntime) *Config {
+	t.Helper()
+	isolateState(t)
+	ws := t.TempDir()
+	c := testConfig(t, ws, ws, profile.Profile{
+		Name:      "liveness",
+		Image:     "img",
+		GuestHome: "/home/liveness",
+		Mem:       1024,
+		CPUs:      1,
+	})
+	c.Verify = verify.Off
+	rt.workspace = ws
+	c.Runtime = rt
+	return c
+}
+
+// The bug in #49. Both adapters folded an exec failure into "not running", so a
+// runtime brig could not reach read as a workspace with nothing on it, and
+// EnsureRunning booted a second sandbox over the first. Failing to answer is
+// not answering no, and booting on it is the dangerous direction.
+func TestEnsureRunningRefusesWhenTheRuntimeCannotSayIfItIsUp(t *testing.T) {
+	rt := &livenessRuntime{runningErr: errors.New("cannot connect to the daemon")}
+	c := livenessConfig(t, rt)
+
+	err := c.EnsureRunning(creds.Set{})
+	if err == nil {
+		t.Fatal("a runtime that could not answer let the run boot a second sandbox")
+	}
+	if rt.boots != 0 {
+		t.Errorf("booted %d sandboxes on an answer the runtime never gave", rt.boots)
+	}
+	// The refusal has to name the sandbox it is about and carry the runtime's
+	// own explanation, which is the only account of what actually broke.
+	if !strings.Contains(err.Error(), c.VMName) {
+		t.Errorf("the refusal does not name the sandbox: %v", err)
+	}
+	if !strings.Contains(err.Error(), "cannot connect to the daemon") {
+		t.Errorf("the runtime's explanation was dropped: %v", err)
+	}
+}
+
+// The ordinary first boot. A genuinely absent sandbox is a plain no, and the
+// run must still start one -- refusing on every no would be the opposite bug.
+func TestEnsureRunningBootsWhenNothingIsRunning(t *testing.T) {
+	rt := &livenessRuntime{running: false}
+	c := livenessConfig(t, rt)
+
+	if err := c.EnsureRunning(creds.Set{}); err != nil {
+		t.Fatalf("a first boot was refused: %v", err)
+	}
+	if rt.boots != 1 {
+		t.Errorf("booted %d times, want 1", rt.boots)
+	}
+}
+
+// And a sandbox that is up is still reused rather than rebooted, which is what
+// keeps a second `brig run` from throwing away a live session.
+func TestEnsureRunningReusesASandboxThatIsUp(t *testing.T) {
+	rt := &livenessRuntime{running: true}
+	c := livenessConfig(t, rt)
+
+	if err := c.EnsureRunning(creds.Set{}); err != nil {
+		t.Fatalf("a running sandbox was not reused: %v", err)
+	}
+	if rt.boots != 0 {
+		t.Errorf("a running sandbox was rebooted %d times", rt.boots)
+	}
+	if rt.stops != 0 || rt.removes != 0 {
+		t.Errorf("a running sandbox mounting this workspace was torn down (%d stops, %d removes)",
+			rt.stops, rt.removes)
+	}
+}

--- a/internal/wrap/stop_test.go
+++ b/internal/wrap/stop_test.go
@@ -13,13 +13,15 @@ import (
 // nothing.
 type stubRuntime struct {
 	runtime.Runtime
-	stopErr error
-	running bool
-	stops   int
+	stopErr    error
+	running    bool
+	runningErr error
+	stops      int
 }
 
-func (s *stubRuntime) Stop(string) error   { s.stops++; return s.stopErr }
-func (s *stubRuntime) Running(string) bool { return s.running }
+func (s *stubRuntime) Stop(string) error { s.stops++; return s.stopErr }
+
+func (s *stubRuntime) Running(string) (bool, error) { return s.running, s.runningErr }
 func (s *stubRuntime) LogsHint(name string) string {
 	return "hull logs " + name
 }
@@ -49,6 +51,30 @@ func TestStopReportsASandboxThatWouldNotStop(t *testing.T) {
 // The end state is what decides. A stop that failed against an instance which
 // is no longer running asked for the state it got, and reporting that as a
 // failure would make `brig stop` on an already-stopped sandbox an error.
+// A runtime that cannot say whether the sandbox is still up cannot clear a
+// stop that failed. Reading its silence as "gone anyway" is the same swallow
+// as #49 in the other direction: the user is told a VM holding a forwarded
+// credential is down when nothing established that.
+func TestStopReportsWhenTheRuntimeCannotSayIfItIsStillUp(t *testing.T) {
+	rt := &stubRuntime{
+		stopErr:    errors.New("hull: instance is busy"),
+		runningErr: errors.New("cannot connect to the daemon"),
+	}
+	c := testConfig(t, t.TempDir(), t.TempDir())
+	c.Runtime = rt
+
+	err := c.Stop()
+	if err == nil {
+		t.Fatal("a stop that failed with no way to check the end state was reported as success")
+	}
+	if !errors.Is(err, rt.stopErr) {
+		t.Errorf("the stop failure was dropped: %v", err)
+	}
+	if !errors.Is(err, rt.runningErr) {
+		t.Errorf("the reason the end state is unknown was dropped: %v", err)
+	}
+}
+
 func TestStopIsSilentWhenTheSandboxIsGoneAnyway(t *testing.T) {
 	c := testConfig(t, t.TempDir(), t.TempDir())
 	c.Runtime = &stubRuntime{stopErr: errors.New("no such instance"), running: false}

--- a/internal/wrap/verify_test.go
+++ b/internal/wrap/verify_test.go
@@ -32,8 +32,8 @@ func (v verifyRuntime) LocalDigest(string) (string, error) { return v.local, nil
 // running and removing is a no-op, which is the state a first boot starts in.
 // Run is deliberately absent: a test that got that far would be booting, and
 // every case here is meant to refuse before then.
-func (v verifyRuntime) Running(string) bool { return false }
-func (v verifyRuntime) Remove(string) error { return nil }
+func (v verifyRuntime) Running(string) (bool, error) { return false, nil }
+func (v verifyRuntime) Remove(string) error          { return nil }
 
 // Stops the boot at the point a real runtime would start doing work, so a
 // test can drive EnsureRunning through the checks without booting anything.


### PR DESCRIPTION
Both adapters returned `false` from `Running()` on any exec error, so a missing binary, a permission error, or a broken runtime all read as "nothing is running" -- and `EnsureRunning` then booted a second sandbox over the first.

There are three answers, not two: running, not running, and could not tell. `Running` returns `(bool, error)` now, and a caller that cannot tell refuses rather than boots:

    cannot tell whether the sandbox brig-claude-code is already running, so
    refusing to start a second one over it: ...

Failing to answer is not the same as answering no, and booting on it is the dangerous direction: it is how two sandboxes end up on one workspace.

Every implementation, caller and test double updated, including brigd.

Closes #49