### PR TITLE
fix: refuse a bad hosts.yml and an over-long socket path

### DIFF
--- a/cmd/brigd/daemon_test.go
+++ b/cmd/brigd/daemon_test.go
@@ -90,7 +90,9 @@ func ask(t *testing.T, socket, request string) Response {
 // limit. t.TempDir puts the test's own name in the path, and on macOS that
 // lands the socket past 104 bytes, where bind fails with "invalid argument"
 // and the daemon looks broken for a reason that has nothing to do with it.
-// See #80 for the daemon-side check that should name this limit.
+//
+// chooseSocket now refuses such a path by name, but refusing it is not binding
+// it: a test that wants a listener still needs one that fits.
 func shortDir(t *testing.T) string {
 	t.Helper()
 	dir, err := os.MkdirTemp("", "brigd")

--- a/cmd/brigd/main.go
+++ b/cmd/brigd/main.go
@@ -111,8 +111,15 @@ type Session struct {
 }
 
 func main() {
-	socket := flag.String("socket", defaultSocket(), "unix socket to listen on")
+	flagSocket := flag.String("socket", "",
+		"unix socket to listen on (default $XDG_RUNTIME_DIR/brigd.sock, or ~/.brig/brigd.sock)")
 	flag.Parse()
+
+	socket, err := chooseSocket(*flagSocket)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "brigd: "+err.Error())
+		os.Exit(1)
+	}
 
 	// The daemon builds the registry from the same sources the CLI does. It
 	// looks profiles up by name, so without this it would know only the names
@@ -122,21 +129,60 @@ func main() {
 		fmt.Fprintln(os.Stderr, "brigd: "+err.Error())
 	}
 
-	if err := serve(*socket); err != nil {
+	if err := serve(socket); err != nil {
 		fmt.Fprintln(os.Stderr, "brigd: "+err.Error())
 		os.Exit(1)
 	}
 }
 
-func defaultSocket() string {
+// maxSocketPath is the longest path the kernel will bind a unix socket to.
+//
+// bind copies the path into sun_path, a fixed array in the address struct --
+// 104 bytes on macOS, 108 on Linux -- and the last byte has to be the
+// terminator, so what fits is one less than the array. Derived from the
+// platform's own struct rather than written out, because the two numbers
+// differ and a hard-coded 104 would turn away paths Linux binds happily.
+const maxSocketPath = len(syscall.RawSockaddrUnix{}.Path) - 1
+
+// chooseSocket settles which socket the daemon listens on -- the --socket
+// value if one was given, the default otherwise -- and refuses a path the
+// kernel cannot bind.
+//
+// Both sources go through the same check, because the default is not
+// automatically short: XDG_RUNTIME_DIR is whatever the session manager set,
+// and a home directory can be nested anywhere.
+//
+// The check is here, where the path is chosen, rather than around the bind.
+// bind answers an over-long path with EINVAL, and net renders that as "bind:
+// invalid argument" -- which names neither the path, nor the limit, nor the
+// fact that length is what is wrong with it, so the daemon looks broken for a
+// reason that has nothing to do with it. The one thing the reader needs is the
+// three numbers, and the only place all three are known is here.
+func chooseSocket(flagValue string) (string, error) {
+	socket, source := flagValue, "--socket"
+	if socket == "" {
+		socket, source = defaultSocket()
+	}
+	if len(socket) > maxSocketPath {
+		return "", fmt.Errorf("refusing to listen on %s: a unix socket path on this system "+
+			"can be at most %d bytes and this one is %d, so the kernel would turn the bind "+
+			"away without saying why. It came from %s; give brigd a shorter path with "+
+			"--socket", socket, maxSocketPath, len(socket), source)
+	}
+	return socket, nil
+}
+
+// defaultSocket is the socket brigd picks when it is not told one, and where
+// that choice came from.
+func defaultSocket() (string, string) {
 	if dir := os.Getenv("XDG_RUNTIME_DIR"); dir != "" {
-		return filepath.Join(dir, "brigd.sock")
+		return filepath.Join(dir, "brigd.sock"), "XDG_RUNTIME_DIR"
 	}
 	home, err := os.UserHomeDir()
 	if err != nil {
 		home = "."
 	}
-	return filepath.Join(home, ".brig", "brigd.sock")
+	return filepath.Join(home, ".brig", "brigd.sock"), "your home directory"
 }
 
 // lockSocket takes the exclusive lock that makes this process the daemon for

--- a/cmd/brigd/socket_test.go
+++ b/cmd/brigd/socket_test.go
@@ -1,0 +1,125 @@
+package main
+
+import (
+	"net"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// longSocket builds a socket path one byte over the limit, under a directory
+// short enough that the padding is what makes it too long.
+func longSocket(t *testing.T, dir string) string {
+	t.Helper()
+	name := strings.Repeat("s", maxSocketPath-len(dir))
+	path := filepath.Join(dir, name)
+	if len(path) != maxSocketPath+1 {
+		t.Fatalf("the test built a %d byte path, wanted %d", len(path), maxSocketPath+1)
+	}
+	return path
+}
+
+// maxSocketPath has to be the kernel's limit rather than a number somebody
+// wrote down: a refusal that names the wrong one either turns away a path that
+// would have worked or lets through the "bind: invalid argument" it exists to
+// replace. So this asserts against bind itself, on the platform running the
+// test.
+func TestMaxSocketPathIsWhatTheKernelAccepts(t *testing.T) {
+	dir := shortDir(t)
+
+	atLimit := filepath.Join(dir, strings.Repeat("s", maxSocketPath-len(dir)-1))
+	ln, err := net.Listen("unix", atLimit)
+	if err != nil {
+		t.Fatalf("a %d byte path was refused by bind, so the limit is lower than "+
+			"maxSocketPath = %d: %v", len(atLimit), maxSocketPath, err)
+	}
+	_ = ln.Close()
+
+	overLimit := longSocket(t, dir)
+	ln, err = net.Listen("unix", overLimit)
+	if err == nil {
+		_ = ln.Close()
+		t.Fatalf("a %d byte path was bound, so the limit is higher than "+
+			"maxSocketPath = %d", len(overLimit), maxSocketPath)
+	}
+	// The error this whole change exists to replace.
+	if !strings.Contains(err.Error(), "invalid argument") {
+		t.Logf("bind refused the over-long path with %v, not \"invalid argument\"", err)
+	}
+}
+
+// An over-long --socket used to reach bind and come back as "bind: invalid
+// argument", which names neither the path, nor the limit, nor the fact that
+// length is what is wrong with it.
+func TestAnOverlongSocketFlagIsRefusedByName(t *testing.T) {
+	path := longSocket(t, shortDir(t))
+
+	socket, err := chooseSocket(path)
+	if err == nil {
+		t.Fatalf("a %d byte socket path was accepted: %s", len(path), socket)
+	}
+	msg := err.Error()
+	for _, want := range []string{
+		path,                        // which path
+		strconv.Itoa(len(path)),     // how long it is
+		strconv.Itoa(maxSocketPath), // what the limit is
+		"--socket",                  // what supplied it
+	} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("the refusal does not name %q: %s", want, msg)
+		}
+	}
+	if strings.Contains(msg, "invalid argument") {
+		t.Errorf("the refusal still hands back the kernel's error: %s", msg)
+	}
+}
+
+// The default path is chosen from XDG_RUNTIME_DIR, which can be as long as
+// whoever set it made it, so the check has to cover the path brigd picks for
+// itself as well as the one it is given.
+func TestAnOverlongDefaultSocketIsRefusedByName(t *testing.T) {
+	dir := shortDir(t)
+	// One byte over, once brigd.sock is joined onto it.
+	runtimeDir := filepath.Join(dir, strings.Repeat("d", maxSocketPath-len(dir)-len("brigd.sock")))
+	if err := os.MkdirAll(runtimeDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("XDG_RUNTIME_DIR", runtimeDir)
+
+	socket, err := chooseSocket("")
+	if err == nil {
+		t.Fatalf("an over-long default socket path was accepted: %s", socket)
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "XDG_RUNTIME_DIR") {
+		t.Errorf("the refusal does not name the setting that supplied the path: %s", msg)
+	}
+	if !strings.Contains(msg, strconv.Itoa(maxSocketPath)) {
+		t.Errorf("the refusal does not name the limit: %s", msg)
+	}
+}
+
+// A path within the limit is returned untouched, from either source.
+func TestASocketPathWithinTheLimitIsAccepted(t *testing.T) {
+	dir := shortDir(t)
+
+	given := filepath.Join(dir, "brigd.sock")
+	got, err := chooseSocket(given)
+	if err != nil {
+		t.Fatalf("chooseSocket refused %s: %v", given, err)
+	}
+	if got != given {
+		t.Errorf("chooseSocket(%q) = %q", given, got)
+	}
+
+	t.Setenv("XDG_RUNTIME_DIR", dir)
+	got, err = chooseSocket("")
+	if err != nil {
+		t.Fatalf("chooseSocket refused the default: %v", err)
+	}
+	if want := filepath.Join(dir, "brigd.sock"); got != want {
+		t.Errorf("the default socket is %q, want %q", got, want)
+	}
+}

--- a/docs/brigd.md
+++ b/docs/brigd.md
@@ -24,6 +24,11 @@ brigd --socket /tmp/brigd.sock
 The socket is created 0600. It carries lifecycle control over sandboxes
 holding live credentials, so it belongs to the invoking user alone.
 
+A unix socket path has a length limit the kernel enforces -- 103 bytes on
+macOS, 107 on Linux -- and a path over it is refused before the bind, with the
+limit, the length given, and where the path came from. The kernel's own answer
+to an over-long path is `bind: invalid argument`, which names none of those.
+
 One daemon serves one socket path. Starting a second on a path that is already
 being served exits non-zero and names the process in the way, rather than
 taking the path over: two daemons on one socket would each keep an inventory

--- a/internal/wrap/config.go
+++ b/internal/wrap/config.go
@@ -332,7 +332,9 @@ func Load(t profile.Profile, o Options, rt runtime.Runtime) (*Config, error) {
 		return nil, strictErr
 	}
 	c.GuestCwd = GuestCwd(cwd, c.Workspace, t.GuestHome)
-	c.resolveGitIdentity()
+	if err := c.resolveGitIdentity(); err != nil {
+		return nil, err
+	}
 	return c, nil
 }
 

--- a/internal/wrap/git.go
+++ b/internal/wrap/git.go
@@ -10,6 +10,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"syscall"
 
 	"github.com/brig-sh/brig/internal/creds"
 )
@@ -38,14 +39,18 @@ const (
 // guest can neither execute nor reach, so forwarding commit.gpgsign would
 // make every guest commit fail rather than degrade. Guest commits are
 // unsigned.
-func (c *Config) resolveGitIdentity() {
+func (c *Config) resolveGitIdentity() error {
 	c.GitName = c.env.String("GIT_NAME", c.gitConfigValue("user.name"))
 	c.GitEmail = c.env.String("GIT_EMAIL", c.gitConfigValue("user.email"))
 
-	if user, ok := c.hostGitUser(); ok {
+	user, ok, err := c.hostGitUser()
+	if err != nil {
+		return err
+	}
+	if ok {
 		c.GitUserFromHost = true
 		c.GitUser = c.env.String("GIT_USER", user)
-		return
+		return nil
 	}
 	// GitHub requires exactly x-access-token for a GitHub App installation
 	// token and generally ignores the username for a PAT, so that is the
@@ -53,6 +58,7 @@ func (c *Config) resolveGitIdentity() {
 	// rather than letting a later "Invalid username or token" look like a
 	// broken sandbox.
 	c.GitUser = c.env.String("GIT_USER", "x-access-token")
+	return nil
 }
 
 func (c *Config) gitConfigValue(key string) string {
@@ -68,17 +74,20 @@ func (c *Config) gitConfigValue(key string) string {
 
 // hostGitUser finds the GitHub login to pair with the token: github.user
 // first, then the gh CLI's own record.
-func (c *Config) hostGitUser() (string, bool) {
+func (c *Config) hostGitUser() (string, bool, error) {
 	u := c.gitConfigValue("github.user")
 	if u == "" {
-		u = ghHostsUser(c.primaryGitHost())
+		var err error
+		if u, err = ghHostsUser(c.primaryGitHost()); err != nil {
+			return "", false, err
+		}
 	}
 	// A GitHub login never contains whitespace; ignore anything that does.
 	// user.name is a display name, and is the usual thing to get wrong here.
 	if u == "" || strings.ContainsAny(u, " \t") {
-		return "", false
+		return "", false, nil
 	}
-	return u, true
+	return u, true, nil
 }
 
 func (c *Config) primaryGitHost() string {
@@ -94,18 +103,24 @@ func (c *Config) primaryGitHost() string {
 // whichever host comes first -- an Enterprise login paired with a github.com
 // token, which is exactly the "Invalid username or token" this exists to
 // prevent. Only the stanza for the host being configured is read.
-func ghHostsUser(host string) string {
+func ghHostsUser(host string) (string, error) {
 	dir := os.Getenv("GH_CONFIG_DIR")
 	if dir == "" {
 		home, err := os.UserHomeDir()
 		if err != nil {
-			return ""
+			return "", nil
 		}
 		dir = filepath.Join(home, ".config", "gh")
 	}
-	f, err := os.Open(filepath.Join(dir, "hosts.yml"))
+	f, err := openHostFile(filepath.Join(dir, "hosts.yml"))
 	if err != nil {
-		return ""
+		if errors.Is(err, errNotRegularFile) {
+			return "", err
+		}
+		// Anything else -- no file, no permission -- is the ordinary case of
+		// gh not being set up, and the caller falls back to a default
+		// username rather than failing the run.
+		return "", nil
 	}
 	defer f.Close()
 
@@ -125,10 +140,52 @@ func ghHostsUser(host string) string {
 			continue
 		}
 		if k, v, ok := strings.Cut(strings.TrimSpace(line), ":"); ok && k == "user" {
-			return strings.TrimSpace(v)
+			return strings.TrimSpace(v), nil
 		}
 	}
-	return ""
+	return "", nil
+}
+
+// errNotRegularFile marks the refusal below, so a caller that treats every
+// other open failure as "gh is not set up" can tell this one apart.
+var errNotRegularFile = errors.New("not a regular file")
+
+// openHostFile opens one of the host's own configuration files and refuses
+// anything that is not a regular file, deciding from the OPEN DESCRIPTOR
+// rather than from a prior stat.
+//
+// This is the workspace rule from openRegular, applied to a path outside the
+// workspace. os.Root does not reach here -- hosts.yml is the host's file, not
+// the guest's home -- so nothing checked what was at the path, and a plain
+// os.Open of a FIFO waits for a writer that never comes. The read happens at
+// the end of Load, so one `mkfifo ~/.config/gh/hosts.yml` hung every verb that
+// loads a profile, with no output and nothing to diagnose. A directory or a
+// device did not hang but failed further along, in a kernel error that named
+// neither the file nor what was wrong with it.
+//
+// O_NONBLOCK is what makes the FIFO case return rather than park: Go opens
+// non-blocking and registers the descriptor with the poller anyway, so the
+// flag is belt and braces here, and it costs nothing on a regular file.
+// The fstat afterwards is what decides, and it cannot be raced: it asks about
+// the descriptor already held rather than about the path.
+func openHostFile(path string) (*os.File, error) {
+	f, err := os.OpenFile(path, os.O_RDONLY|syscall.O_NONBLOCK, 0)
+	if err != nil {
+		return nil, err
+	}
+	fi, err := f.Stat()
+	if err != nil {
+		_ = f.Close()
+		return nil, err
+	}
+	if !fi.Mode().IsRegular() {
+		_ = f.Close()
+		return nil, fmt.Errorf("refusing to read %s: it is a %s, not a regular file, and "+
+			"brig would block on it or fail later with a kernel error. Point GH_CONFIG_DIR "+
+			"at a directory holding a real hosts.yml, or remove what is there: %w",
+			path, describeType(fi.Mode()), errNotRegularFile)
+	}
+	return f, nil
 }
 
 // SetupGit writes the managed git files into the workspace and adds the

--- a/internal/wrap/git_test.go
+++ b/internal/wrap/git_test.go
@@ -145,14 +145,18 @@ github.com:
 	}
 	t.Setenv("GH_CONFIG_DIR", dir)
 
-	if got := ghHostsUser("github.com"); got != "octocat" {
-		t.Errorf("ghHostsUser(github.com) = %q, want octocat", got)
-	}
-	if got := ghHostsUser("github.enterprise.example"); got != "enterprise-login" {
-		t.Errorf("ghHostsUser(enterprise) = %q", got)
-	}
-	if got := ghHostsUser("github.absent.example"); got != "" {
-		t.Errorf("an absent host returned %q", got)
+	for _, tc := range []struct{ host, want string }{
+		{"github.com", "octocat"},
+		{"github.enterprise.example", "enterprise-login"},
+		{"github.absent.example", ""},
+	} {
+		got, err := ghHostsUser(tc.host)
+		if err != nil {
+			t.Fatalf("ghHostsUser(%s): %v", tc.host, err)
+		}
+		if got != tc.want {
+			t.Errorf("ghHostsUser(%s) = %q, want %q", tc.host, got, tc.want)
+		}
 	}
 }
 

--- a/internal/wrap/hostfile_test.go
+++ b/internal/wrap/hostfile_test.go
@@ -1,0 +1,115 @@
+package wrap
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/brig-sh/brig/internal/profile"
+)
+
+// gh's hosts.yml is a host file, so os.Root does not cover it and nothing
+// checked what it was before opening it. A FIFO there hung brig on every verb
+// that loads a profile: resolveGitIdentity runs at the end of Load, the open
+// blocks waiting for a writer, and the user sees no output at all.
+//
+// The assertion is that the call RETURNS, not merely that it errors. Before
+// the fix this test does not fail, it hangs, and `within` is what turns that
+// into a failure the test binary can report.
+func TestGhHostsUserRefusesAFifoInsteadOfBlocking(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "hosts.yml")
+	mkfifo(t, path)
+	t.Setenv("GH_CONFIG_DIR", dir)
+
+	var (
+		user string
+		err  error
+	)
+	if !within(t, 5*time.Second, func() { user, err = ghHostsUser("github.com") }) {
+		t.Fatalf("brig blocked reading a FIFO at %s", path)
+	}
+	if err == nil {
+		t.Fatalf("a FIFO was read as if it were hosts.yml, returning %q", user)
+	}
+	if !strings.Contains(err.Error(), path) {
+		t.Errorf("the refusal does not name the path: %v", err)
+	}
+	// In words. fs.FileMode.Type() prints "p---------", which is not something
+	// to put in front of a person.
+	if !strings.Contains(err.Error(), "named pipe") {
+		t.Errorf("the refusal does not say what it found there: %v", err)
+	}
+	if strings.Contains(err.Error(), "p---------") {
+		t.Errorf("the refusal renders the file type as a mode string: %v", err)
+	}
+}
+
+// A directory does not hang, it fails somewhere else: os.Open succeeds on one,
+// the read fails with EISDIR, and the scanner's error was dropped -- so brig
+// silently fell back to x-access-token and the "Invalid username or token"
+// that followed pointed at nothing. Say what is there instead.
+func TestGhHostsUserRefusesADirectory(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "hosts.yml")
+	if err := os.Mkdir(path, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("GH_CONFIG_DIR", dir)
+
+	_, err := ghHostsUser("github.com")
+	if err == nil {
+		t.Fatal("a directory was accepted as hosts.yml")
+	}
+	if !strings.Contains(err.Error(), path) || !strings.Contains(err.Error(), "directory") {
+		t.Errorf("the refusal does not name the path and what it is: %v", err)
+	}
+}
+
+// An absent hosts.yml is the ordinary case -- gh is simply not set up -- and
+// must stay a fallback rather than becoming a refusal.
+func TestGhHostsUserIsQuietWhenThereIsNoHostsFile(t *testing.T) {
+	t.Setenv("GH_CONFIG_DIR", t.TempDir())
+
+	user, err := ghHostsUser("github.com")
+	if err != nil {
+		t.Fatalf("a missing hosts.yml was refused: %v", err)
+	}
+	if user != "" {
+		t.Errorf("a missing hosts.yml produced a user: %q", user)
+	}
+}
+
+// The refusal has to reach the person who typed the command, which means Load
+// fails rather than warning and carrying on with a username it did not read.
+func TestLoadRefusesAFifoWhereHostsYmlBelongs(t *testing.T) {
+	dir := t.TempDir()
+	mkfifo(t, filepath.Join(dir, "hosts.yml"))
+	t.Setenv("GH_CONFIG_DIR", dir)
+	// github.user in the host's git config short-circuits the hosts.yml read,
+	// so the lookup only happens with none set.
+	t.Setenv("GIT_CONFIG_GLOBAL", filepath.Join(t.TempDir(), "gitconfig"))
+	t.Setenv("GIT_CONFIG_SYSTEM", filepath.Join(t.TempDir(), "gitconfig"))
+
+	p, ok := profile.Lookup("claude-code")
+	if !ok {
+		t.Fatal("no claude-code profile")
+	}
+	if u := (&Config{}).gitConfigValue("github.user"); u != "" {
+		t.Skipf("this machine's git config sets github.user to %q, so hosts.yml is "+
+			"never read", u)
+	}
+
+	var err error
+	if !within(t, 10*time.Second, func() { _, err = Load(p, Options{}, nil) }) {
+		t.Fatal("Load blocked on a FIFO at hosts.yml")
+	}
+	if err == nil {
+		t.Fatal("Load accepted a FIFO at hosts.yml")
+	}
+	if !strings.Contains(err.Error(), "named pipe") {
+		t.Errorf("Load's error does not say what it found: %v", err)
+	}
+}


### PR DESCRIPTION
Two of the same shape: refuse a bad path with a sentence instead of hanging or failing with a kernel error.

**#74** -- the gh `hosts.yml` was opened with a plain `os.Open`, on every verb that loads a profile. A fifo there blocks brig forever. Now:

    brig: refusing to read .../hosts.yml: it is a named pipe (FIFO), not a regular
    file, and brig would block on it or fail later with a kernel error. Point
    GH_CONFIG_DIR at a directory holding a real hosts.yml, or remove what is there

**#80** -- a unix socket path over the platform limit failed with `bind: invalid argument`, which names nothing. It is refused before binding now, naming the limit and the length given. This one bites us today: `cmd/brigd/daemon_test.go` carries a `shortDir` helper purely to work around it, and I hit it by hand running brigd with a long `--socket`.

Verified both: the fifo case returns promptly rather than hanging, and the long socket path is refused before bind.

Closes #74
Closes #80