### PR TITLE
feat(envelope): report the isolation boundary of the sandbox

### DIFF
--- a/README.md
+++ b/README.md
@@ -350,6 +350,7 @@ your own.
 $ brig info claude
 PROFILE      claude-code
 SANDBOX      brig-claude-code (hull)
+ISOLATION    microVM (hull, vz backend)
 WORKSPACE    /Users/you/brig/claude-code (read-write)
 IMAGE        ghcr.io/brig-sh/claude-code-stock:latest (pull missing)
 CREDENTIALS  GH_TOKEN

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -40,6 +40,7 @@ The first run is the slow one. In order:
   ```
   PROFILE      claude-code
   SANDBOX      brig-claude-code (hull)
+  ISOLATION    microVM (hull, vz backend)
   WORKSPACE    /Users/you/brig/claude-code (read-write)
   IMAGE        ghcr.io/brig-sh/claude-code-stock:latest (pull missing)
   CREDENTIALS  GH_TOKEN

--- a/docs/runtimes.md
+++ b/docs/runtimes.md
@@ -203,8 +203,9 @@ it is the same pair hull takes on its command line.
 
 **containerd** has to be running with the urunc shim installed.
 `BRIG_CONTAINERD_RUNTIME=runc` asks for a plain container instead, which shares
-the host kernel. That is the weaker boundary, and `docs/security.md` says what
-it costs.
+the host kernel. That is the weaker boundary, the envelope's `ISOLATION` row
+says which one a run got, and `docs/security.md` says what the weaker one
+costs.
 
 ### Versions and pins
 
@@ -232,7 +233,10 @@ Cheap swaps, no code:
 - docker instead of nerdctl: it is already in the PATH search, with the
   `genericBoot` limitation above.
 - a different containerd shim: `BRIG_CONTAINERD_RUNTIME`. Anything that reads
-  the two boot annotations replaces urunc without brig noticing.
+  the two boot annotations replaces urunc without brig noticing. The envelope's
+  `ISOLATION` row names the shim you put there, and calls the boundary unknown
+  rather than a microVM for any shim other than urunc's own that it cannot
+  place.
 - a different hypervisor backend under hull: `BRIG_HYPERVISOR`, or
   `hypervisor:` in a profile.
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -24,6 +24,21 @@ too. `BRIG_CONTAINERD_RUNTIME=runc` asks for a plain container instead, which
 shares the host kernel: that is the weaker of the two, and it is something you
 have to choose rather than something you get.
 
+Which of them you got is the `ISOLATION` row of the execution envelope, printed
+before every boot and by `brig info`:
+
+```
+ISOLATION    microVM (hull, vz backend)
+ISOLATION    microVM (nerdctl over containerd, io.containerd.urunc.v2)
+ISOLATION    container (docker over containerd, runc: the guest shares the host kernel)
+```
+
+The row reports what this run resolved -- the binary in hand, the backend it
+settled on, the shim it will name -- rather than what the paragraph above
+promises. A shim brig does not recognise may well boot a VM, and brig cannot
+establish that from a name, so the row says it cannot tell instead of claiming
+the stronger boundary.
+
 Inside it, the guest has your workspace mounted as its home. It does not have
 your keychain, your SSH agent, your secret manager, or any other directory on
 the host. That inaccessibility is the isolation boundary, and it is also the

--- a/internal/runtime/hull.go
+++ b/internal/runtime/hull.go
@@ -45,6 +45,18 @@ func newHull(bin string) (Runtime, error) {
 func (h *hull) Kind() string { return "hull" }
 func (h *hull) Bin() string  { return h.bin }
 
+// Isolation is a microVM on every hull backend: vz, hvi and qemu are all
+// hypervisors, so the guest has a kernel of its own whichever one boots it.
+// The backend is named anyway, because it decides what that VM can do -- the
+// graphical console, the shares, the gateway -- and a reader asking what their
+// sandbox is wants the whole answer in one row.
+//
+// The default is applied here rather than reported as blank, so the row names
+// the backend that will actually boot rather than the absence of a setting.
+func (h *hull) Isolation(hv string) Isolation {
+	return Isolation{BoundaryVM, fmt.Sprintf("hull, %s backend", hypervisorOrDefault(hv))}
+}
+
 // PinsDigest asks the hull on this machine whether it can boot a digest
 // reference from its own store, which it can from 0.1.0-rc23. Before that a
 // repo@sha256:... boot missed the cache and re-pulled every run, and failed
@@ -142,7 +154,14 @@ func hullVersionPinsDigest(out string) bool {
 // another -- hvi for the Hypervisor Virtualization Interface, qemu for a qemu
 // host -- and BRIG_HYPERVISOR beats the profile. Both are resolved before they
 // reach here; see wrap.
-func hypervisor(spec RunSpec) string { return orDefault(spec.Hypervisor, "vz") }
+func hypervisor(spec RunSpec) string { return hypervisorOrDefault(spec.Hypervisor) }
+
+// hypervisorOrDefault is where the default lives, so the backend that boots and
+// the backend the envelope names are read off one line. Two copies of "vz"
+// would be two things to change, and the one that goes stale is a report about
+// a boundary rather than the boundary itself -- which is the worse half to get
+// wrong, because nothing fails to make it visible.
+func hypervisorOrDefault(hv string) string { return orDefault(hv, "vz") }
 
 // The kernel and initrd a genericBoot profile needs live in boot.go: both
 // backends take the same two annotations, so resolving them is not hull's

--- a/internal/runtime/isolation.go
+++ b/internal/runtime/isolation.go
@@ -1,0 +1,87 @@
+package runtime
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Boundary is what stands between the guest and the host kernel.
+//
+// Three values rather than two, because "brig cannot tell" is a real answer
+// and the only honest one for a shim brig does not recognise. A reader acts on
+// this row -- it is the difference between running an agent on an untrusted
+// repository and not -- so a guess in the direction of the stronger boundary is
+// the one mistake this type must not make.
+type Boundary string
+
+const (
+	// BoundaryVM is a guest with a kernel of its own, booted by a hypervisor.
+	BoundaryVM Boundary = "microVM"
+	// BoundaryContainer is a guest sharing the host kernel.
+	BoundaryContainer Boundary = "container"
+	// BoundaryUnknown is everything brig has not established either way.
+	BoundaryUnknown Boundary = "unknown"
+)
+
+// Isolation is the boundary a sandbox gets, and what establishes it.
+//
+// It reports what this invocation resolved -- the runtime binary in hand, the
+// hypervisor backend the run settled on, the containerd shim the run will name
+// -- and not what a profile or the documentation says a sandbox ought to be.
+// brig does not look inside a running guest to confirm it, and the row says
+// nothing that depends on doing so.
+type Isolation struct {
+	Boundary Boundary
+	// Detail is what establishes the boundary, in the reader's terms: which
+	// runtime, which backend or shim, and for anything short of a microVM what
+	// that costs them.
+	Detail string
+}
+
+// Line is the isolation as the envelope prints it: the boundary, then the
+// detail in parentheses, which is the shape every other row of the block uses.
+func (i Isolation) Line() string { return fmt.Sprintf("%s (%s)", i.Boundary, i.Detail) }
+
+// uruncShim is the containerd shim that boots the container as a microVM, and
+// the default containerdRuntime returns. See docs/runtimes.md for the contract
+// between brig and urunc.
+const uruncShim = "io.containerd.urunc.v2"
+
+// sharedKernelShims are the shims brig knows boot an ordinary container: the
+// two runc shim versions, and the bare binary names docker and containerd also
+// accept. A shim outside this list and not urunc is not assumed to be either
+// thing -- gVisor's runsc is neither a plain container nor a VM, and that is
+// the case the unknown boundary is for. See containerdIsolation.
+var sharedKernelShims = map[string]bool{
+	"io.containerd.runc.v1": true,
+	"io.containerd.runc.v2": true,
+	"runc":                  true,
+	"crun":                  true,
+}
+
+// containerdIsolation reports what driver over shim actually gives the guest.
+//
+// Pure, and separate from the adapter, because naming the boundary is the part
+// worth being sure about and it should be testable without a containerd.
+//
+// Three cases, and the third is why this is not a boolean. urunc boots the
+// container as a microVM, so that is a kernel of its own. runc and crun share
+// the host kernel, and BRIG_CONTAINERD_RUNTIME pointing at one is the case this
+// row exists for: it is a supported thing to ask for and it used to be
+// invisible. Anything else -- a kata shim, a gVisor shim, a fork of urunc under
+// another name -- may well be a VM, and brig has no way to establish that from
+// a shim name, so it says so instead of picking the answer the reader would
+// prefer.
+func containerdIsolation(driver, shim string) Isolation {
+	over := driver + " over containerd"
+	switch {
+	case shim == uruncShim || strings.HasPrefix(shim, "io.containerd.urunc."):
+		return Isolation{BoundaryVM, fmt.Sprintf("%s, %s", over, shim)}
+	case sharedKernelShims[shim]:
+		return Isolation{BoundaryContainer, fmt.Sprintf(
+			"%s, %s: the guest shares the host kernel", over, shim)}
+	default:
+		return Isolation{BoundaryUnknown, fmt.Sprintf(
+			"%s, %s: brig cannot tell whether that shim boots a kernel of its own", over, shim)}
+	}
+}

--- a/internal/runtime/isolation_test.go
+++ b/internal/runtime/isolation_test.go
@@ -1,0 +1,104 @@
+package runtime
+
+import (
+	"strings"
+	"testing"
+)
+
+// The default is the whole promise: containerd hands the container to the
+// urunc shim, so the guest on Linux has a kernel of its own the way the macOS
+// guest does.
+func TestNerdctlReportsAMicroVMOnTheUruncShim(t *testing.T) {
+	t.Setenv("BRIG_CONTAINERD_RUNTIME", "")
+
+	got := (&nerdctl{bin: "/usr/local/bin/nerdctl"}).Isolation("")
+	if got.Boundary != BoundaryVM {
+		t.Errorf("the default shim is urunc, so the boundary is a microVM: %s", got.Line())
+	}
+	if !strings.Contains(got.Detail, uruncShim) {
+		t.Errorf("the row does not name the shim that establishes it: %s", got.Line())
+	}
+}
+
+// The case the row exists for. BRIG_CONTAINERD_RUNTIME=runc is a supported
+// thing to ask for and it costs the kernel boundary, and until this row nothing
+// said so: the block reported the same sandbox either way.
+func TestNerdctlReportsASharedKernelWhenTheShimIsReplaced(t *testing.T) {
+	t.Setenv("BRIG_CONTAINERD_RUNTIME", "runc")
+
+	got := (&nerdctl{bin: "/usr/local/bin/nerdctl"}).Isolation("")
+	if got.Boundary != BoundaryContainer {
+		t.Errorf("runc shares the host kernel, so this is a container: %s", got.Line())
+	}
+	if !strings.Contains(got.Detail, "shares the host kernel") {
+		t.Errorf("the row does not say what the replacement costs: %s", got.Line())
+	}
+	if strings.Contains(got.Line(), string(BoundaryVM)) {
+		t.Errorf("the row claimed a microVM the shim does not boot: %s", got.Line())
+	}
+}
+
+// A shim brig does not know may well boot a VM -- kata does -- and brig cannot
+// establish that from a name. The row says so rather than picking the answer
+// the reader would rather have.
+func TestNerdctlWillNotGuessAtAnUnknownShim(t *testing.T) {
+	t.Setenv("BRIG_CONTAINERD_RUNTIME", "io.containerd.kata.v2")
+
+	got := (&nerdctl{bin: "/usr/local/bin/nerdctl"}).Isolation("")
+	if got.Boundary != BoundaryUnknown {
+		t.Errorf("an unrecognised shim is not established either way: %s", got.Line())
+	}
+	if !strings.Contains(got.Detail, "io.containerd.kata.v2") {
+		t.Errorf("the row does not name the shim it cannot place: %s", got.Line())
+	}
+	if !strings.Contains(got.Detail, "cannot tell") {
+		t.Errorf("the row does not say brig cannot tell: %s", got.Line())
+	}
+}
+
+// One adapter drives nerdctl and docker both, and it used to report "nerdctl"
+// for either. A row about a runtime the reader has not installed is a row they
+// cannot check.
+func TestDockerIsReportedAsDocker(t *testing.T) {
+	t.Setenv("BRIG_CONTAINERD_RUNTIME", "")
+
+	d := &nerdctl{bin: "/usr/bin/docker"}
+	if got := d.Kind(); got != "docker" {
+		t.Errorf("Kind() = %q, want docker", got)
+	}
+	if got := d.Isolation("").Detail; !strings.HasPrefix(got, "docker over containerd") {
+		t.Errorf("the isolation row does not name docker: %s", got)
+	}
+	if got := (&nerdctl{bin: "/usr/local/bin/nerdctl"}).Kind(); got != "nerdctl" {
+		t.Errorf("Kind() = %q, want nerdctl", got)
+	}
+}
+
+// Every hull backend is a hypervisor, so the boundary does not turn on which
+// one -- but which one is named, because it decides what that VM can do. An
+// unset backend reports the one that would boot rather than a blank.
+func TestHullReportsAMicroVMAndTheBackendUnderIt(t *testing.T) {
+	for _, tc := range []struct{ asked, want string }{
+		{"", "vz"},
+		{"vz", "vz"},
+		{"hvi", "hvi"},
+		{"qemu", "qemu"},
+	} {
+		got := (&hull{bin: "hull"}).Isolation(tc.asked)
+		if got.Boundary != BoundaryVM {
+			t.Errorf("hull on %q is a microVM: %s", tc.asked, got.Line())
+		}
+		if !strings.Contains(got.Detail, tc.want+" backend") {
+			t.Errorf("hull on %q does not name the %s backend: %s", tc.asked, tc.want, got.Line())
+		}
+	}
+}
+
+// The row reads as one sentence in the envelope's own shape: the boundary,
+// then the detail in parentheses, the way the network and sandbox rows do.
+func TestIsolationLineIsTheBoundaryThenTheDetail(t *testing.T) {
+	got := Isolation{BoundaryVM, "hull, vz backend"}.Line()
+	if got != "microVM (hull, vz backend)" {
+		t.Errorf("Line() = %q", got)
+	}
+}

--- a/internal/runtime/nerdctl.go
+++ b/internal/runtime/nerdctl.go
@@ -46,8 +46,32 @@ func newNerdctl(bin string) (Runtime, error) {
 		"or point BRIG_RUNTIME_BIN at one", ErrNoRuntime)
 }
 
-func (n *nerdctl) Kind() string { return "nerdctl" }
+// Kind names the binary being driven rather than the adapter driving it. This
+// one adapter accepts nerdctl and docker both, and it reported "nerdctl" for
+// either, so a docker user read a report about a runtime they had not
+// installed. The adapter already knows the difference -- isDocker turns on it
+// -- so there was never anything to find out, only something to say.
+func (n *nerdctl) Kind() string { return n.driver() }
 func (n *nerdctl) Bin() string  { return n.bin }
+
+// Isolation is decided by the containerd shim, not by the driver: urunc boots
+// the container as a microVM, and BRIG_CONTAINERD_RUNTIME can point at one that
+// does not. containerdRuntime is the same call runArgs makes, so the row names
+// the shim the run will actually name.
+//
+// The hypervisor is nothing to this runtime: the backend is hull's business,
+// and what boots a microVM here is the shim.
+func (n *nerdctl) Isolation(string) Isolation {
+	return containerdIsolation(n.driver(), containerdRuntime())
+}
+
+// driver is the binary in hand, by name. newNerdctl takes either.
+func (n *nerdctl) driver() string {
+	if n.isDocker() {
+		return "docker"
+	}
+	return "nerdctl"
+}
 
 // PinsDigest is true here: containerd's store is content-addressed, so a
 // reference of the form repo@sha256:... resolves to that exact object and, when

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -149,6 +149,20 @@ type Runtime interface {
 	Kind() string
 	// Bin is the executable actually being driven.
 	Bin() string
+	// Isolation reports what a sandbox this runtime boots actually stands on:
+	// a kernel of its own, the host's, or something brig cannot establish.
+	//
+	// hypervisor is the macOS backend the run resolved to, or "" for the
+	// runtime's own default; a container runtime ignores it, the way it already
+	// ignores RootfsType. It is a parameter rather than a field because the
+	// backend is a property of the run and not of the binary in hand, and
+	// because the envelope is printed before any RunSpec exists.
+	//
+	// On the interface rather than an optional one asserted for, unlike
+	// NetworkPruner: every runtime knows what it gives a guest, and a backend
+	// that silently reported nothing would be read as a sandbox with no
+	// boundary worth naming.
+	Isolation(hypervisor string) Isolation
 	// Running reports whether a sandbox of this name is up, and returns an
 	// error when it could not find out at all.
 	//

--- a/internal/wrap/envelope.go
+++ b/internal/wrap/envelope.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/brig-sh/brig/internal/creds"
 	"github.com/brig-sh/brig/internal/profile"
+	"github.com/brig-sh/brig/internal/runtime"
 )
 
 // envelopeRow is one line of the execution envelope: a label and the value
@@ -52,6 +53,13 @@ func (c *Config) envelope(set creds.Set) []envelopeRow {
 	rows = append(rows,
 		envelopeRow{"PROFILE", c.Profile.Name},
 		envelopeRow{"SANDBOX", fmt.Sprintf("%s (%s)", c.VMName, kind)},
+		// Directly under the sandbox, because it is the same subject: the row
+		// above says which runtime holds the sandbox, this one says what that
+		// actually gets you. The sentence brig's own documentation makes -- the
+		// sandbox is a microVM on both operating systems -- is true of a default
+		// install and not of every run, and this is the row that tells the two
+		// apart for the person in front of it.
+		envelopeRow{"ISOLATION", c.isolationLine()},
 		// The workspace is mounted as the guest's home, read-write. The
 		// annotation is here rather than implied so a later read-only mount has
 		// a place to say so in the row it already has, instead of needing a new
@@ -68,6 +76,26 @@ func (c *Config) envelope(set creds.Set) []envelopeRow {
 		envelopeRow{"NETWORK", c.Network.Line()},
 	)
 	return rows
+}
+
+// isolationLine is the ISOLATION row: what the sandbox this run would boot
+// actually stands on.
+//
+// The runtime answers it, because the runtime is what knows -- the hypervisor
+// under hull, the containerd shim under nerdctl or docker. brig only supplies
+// the backend this run resolved to, so the row names the one that would boot
+// rather than the one a profile happens to carry.
+//
+// No runtime is the one case brig answers itself, and it answers "cannot tell".
+// The alternative is to print what a working install would have given, which is
+// the documentation's claim rather than this host's, and this row is worth
+// having only if it never makes that claim on evidence it does not have.
+func (c *Config) isolationLine() string {
+	if c.Runtime == nil {
+		return string(runtime.BoundaryUnknown) +
+			" (no runtime, so brig cannot tell what a sandbox here would stand on)"
+	}
+	return c.Runtime.Isolation(c.hypervisor()).Line()
 }
 
 // credentialLine is the CREDENTIALS row: every credential this run hands the

--- a/internal/wrap/envelope_test.go
+++ b/internal/wrap/envelope_test.go
@@ -30,6 +30,10 @@ func envelopeConfig() *Config {
 		},
 		Out: &bytes.Buffer{},
 		Err: &bytes.Buffer{},
+		// A settings lookup that finds nothing, so the isolation row reports
+		// the backend a host with no BRIG_HYPERVISOR set would boot. Load
+		// always builds one; a zero Env has no lookup function at all.
+		env: NewEnv("claude-code", func(string) (string, bool) { return "", false }),
 	}
 }
 
@@ -50,6 +54,7 @@ func TestEnvelopeNamesTheBoundary(t *testing.T) {
 		"SESSION      review",
 		"PROFILE      claude-code",
 		"SANDBOX      brig-claude-code-review (hull)",
+		"ISOLATION    microVM (hull, vz backend)",
 		"WORKSPACE    /Users/me/src/brig (read-write)",
 		"IMAGE        ghcr.io/brig-sh/claude-code:latest (pull missing)",
 	} {
@@ -165,6 +170,44 @@ func TestEnvelopeUnderReportsAMalformedFileRefAndTheRunThenFails(t *testing.T) {
 	// The other half: the run does not quietly carry on past it.
 	if err := c.writeSecretFiles(); err == nil {
 		t.Error("a malformed file ref was written rather than failing the run")
+	}
+}
+
+// The row reports the boundary this run would get, so it has to be built from
+// the backend this run resolved to rather than from the runtime's default. The
+// preflight and the spec read the same resolution, which is what stops the
+// block describing a sandbox other than the one about to boot.
+func TestEnvelopeNamesTheResolvedHypervisor(t *testing.T) {
+	c := envelopeConfig()
+	c.env = NewEnv(c.Profile.Name, oneVar("BRIG_HYPERVISOR", "hvi"))
+
+	block := &bytes.Buffer{}
+	c.renderEnvelope(block, creds.Set{})
+
+	got := block.String()
+	if !strings.Contains(got, "ISOLATION    microVM (hull, hvi backend)") {
+		t.Errorf("the isolation row does not name the backend the run resolved to:\n%s", got)
+	}
+}
+
+// A row that guesses is worse than no row: it is the row a reader would rely
+// on. With no runtime there is nothing to ask, so the block says it cannot
+// tell rather than repeating the microVM the documentation promises.
+func TestEnvelopeDoesNotClaimIsolationItCannotEstablish(t *testing.T) {
+	c := testConfig(t, t.TempDir(), t.TempDir())
+	c.Runtime = nil
+	block := &bytes.Buffer{}
+	c.renderEnvelope(block, creds.Set{})
+
+	got := block.String()
+	if !strings.Contains(got, "ISOLATION") {
+		t.Fatalf("the envelope dropped the isolation row without a runtime:\n%s", got)
+	}
+	if !strings.Contains(got, "cannot tell") {
+		t.Errorf("the isolation row does not say it cannot tell:\n%s", got)
+	}
+	if strings.Contains(got, "microVM") {
+		t.Errorf("the isolation row claimed a microVM with no runtime to establish one:\n%s", got)
 	}
 }
 

--- a/internal/wrap/run.go
+++ b/internal/wrap/run.go
@@ -179,11 +179,9 @@ func (c *Config) EnsureRunning(set creds.Set) error {
 	if err := c.claimSlug(); err != nil {
 		return err
 	}
-	// BRIG_HYPERVISOR (or BRIG_<PROFILE>_HYPERVISOR) beats what the profile
-	// asked for, which is the same order every other setting follows. Resolved
-	// once here so the preflight below and the spec built later cannot disagree
-	// about which backend this run wants.
-	hypervisor := c.env.String("HYPERVISOR", c.Profile.Hypervisor)
+	// Read once, so the preflight below and the spec built later cannot
+	// disagree about which backend this run wants. See hypervisor.
+	hypervisor := c.hypervisor()
 	// Refuse a backend the host cannot boot before the workspace is prepared or
 	// an image is pulled, so the floor lands as one sentence that names the way
 	// past it rather than as the runtime dying at boot with no name. See
@@ -339,6 +337,19 @@ func (c *Config) EnsureRunning(set creds.Set) error {
 		focusWindow()
 	}
 	return c.deliverSecretFiles()
+}
+
+// hypervisor is the macOS backend this run wants: BRIG_HYPERVISOR (or
+// BRIG_<PROFILE>_HYPERVISOR) beats what the profile asked for, which is the
+// order every other setting follows. Empty means nothing was asked for, and the
+// runtime's own default applies.
+//
+// One function rather than a copy per caller, because three of them read it
+// now -- the preflight below, the spec handed to the runtime, and the envelope
+// row naming the isolation boundary. A row reporting a backend other than the
+// one that boots is worse than no row at all.
+func (c *Config) hypervisor() string {
+	return c.env.String("HYPERVISOR", c.Profile.Hypervisor)
 }
 
 // preflightHypervisor refuses a run whose hypervisor the host cannot boot,

--- a/internal/wrap/status_test.go
+++ b/internal/wrap/status_test.go
@@ -21,6 +21,17 @@ type fakeRuntime struct{ runtime.Runtime }
 func (fakeRuntime) Kind() string { return "hull" }
 func (fakeRuntime) Bin() string  { return "hull" }
 
+// The envelope asks a third: what a sandbox this runtime boots stands on. It
+// answers what the real hull answers for the backend it is handed, so a row
+// asserted here is the row a macOS run prints. Which shim or backend maps to
+// which boundary is settled in the runtime package, where the mapping lives.
+func (fakeRuntime) Isolation(hv string) runtime.Isolation {
+	if hv == "" {
+		hv = "vz"
+	}
+	return runtime.Isolation{Boundary: runtime.BoundaryVM, Detail: "hull, " + hv + " backend"}
+}
+
 const credentialProfile = "hostCredential:\n  keychainService: s\n" +
 	"  tokenField: accessToken\n  expiryField: expiresAt\n" +
 	"  targetVar: TOK\n  renewHint: run it once\n"

--- a/script/smoke.sh
+++ b/script/smoke.sh
@@ -201,6 +201,13 @@ grep -q '^SANDBOX .*brig-claude-code' "$WORK/run.err" \
   || bad "run prints the execution envelope: $(cat "$WORK/run.err")"
 grep -q '^WORKSPACE ' "$WORK/run.err" \
   && ok "the envelope names the workspace" || bad "the envelope names the workspace"
+# What the sandbox stands on, not only what drives it. The stub is a hull
+# stand-in and BRIG_HYPERVISOR is pinned to vz above, so the row names that
+# backend; which containerd shim maps to which boundary is settled in the
+# runtime package's own tests, there being no containerd here to ask.
+grep -q '^ISOLATION .*microVM (hull, vz backend)' "$WORK/run.err" \
+  && ok "the envelope names the isolation boundary" \
+  || bad "the envelope names the isolation boundary -- got: $(grep '^ISOLATION' "$WORK/run.err")"
 # A value must never reach the block, the same promise argv keeps. Scan the
 # whole envelope output rather than a fixed list of rows, so a row added later
 # is covered without touching this check.
@@ -331,7 +338,7 @@ grep -q 'is now `brig info`' "$WORK/info.err" \
 # preview a claim about a boundary nobody is going to use.
 "$WORK/brig" run claude -d > "$WORK/runenv.out" 2>&1
 "$WORK/brig" reset > /dev/null 2>&1
-envelope_rows() { grep -E '^(SESSION|PROFILE|SANDBOX|WORKSPACE|IMAGE|CREDENTIALS) ' "$1"; }
+envelope_rows() { grep -E '^(SESSION|PROFILE|SANDBOX|ISOLATION|WORKSPACE|IMAGE|CREDENTIALS) ' "$1"; }
 envelope_rows "$WORK/info.out" > "$WORK/rows.info"
 envelope_rows "$WORK/runenv.out" > "$WORK/rows.run"
 [ -s "$WORK/rows.info" ] \
@@ -575,6 +582,13 @@ esac
 case "$out" in
   *"runtime unavailable"*) ok "env marks the runtime line unavailable" ;;
   *) bad "env marks the runtime line unavailable -- got: $out" ;;
+esac
+# With nothing to ask, the isolation row says so. Printing the microVM a
+# working install would have given would be the documentation's claim rather
+# than this host's, on a report whose whole value is that it never does that.
+case "$out" in
+  *ISOLATION*"cannot tell"*) ok "the envelope will not name a boundary it cannot establish" ;;
+  *) bad "the envelope will not name a boundary it cannot establish -- got: $out" ;;
 esac
 case "$out" in
   *"image "*) ok "env still reports the lines it can" ;;


### PR DESCRIPTION
`Kind()` returned "nerdctl" while `isDocker()` in the same file already knew better, and `BRIG_CONTAINERD_RUNTIME` can point the container at an ordinary runtime -- a shared kernel rather than a microVM -- with nothing said. A reader could not tell from any output whether they got a VM or a container.

The envelope gains the row its own comment has been reserving:

    ISOLATION    microVM (hull, hvi backend)

It reports what is true rather than what was configured, covers hull, nerdctl, docker and a replaced containerd runtime, and says it cannot tell rather than guessing.

**Deliberately not in scope:** the `--isolation` contract that lets a profile *require* a microVM. That is the larger half of #30 and a separate PR. This is the reporting half only.

Refs #30