### PR TITLE
feat(brig): document and use stable exit codes

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,26 @@ so an agent flag spelled like one of brig's still reaches the agent.
 Each flag overrides the corresponding `BRIG_*` setting, which overrides the
 profile.
 
+### Exit codes
+
+brig returns a small, stable set of exit codes so a script can tell what went
+wrong without reading the message. Anything a command prints on success stays on
+`stdout`; every failure below is reported on `stderr`.
+
+| code | meaning |
+| --- | --- |
+| `0` | success |
+| `1` | general failure -- something ran and did not finish |
+| `2` | usage error -- an unknown flag, a stray argument, a value in the wrong place |
+| `3` | no such profile or sandbox -- the name resolves to nothing |
+| `4` | runtime unavailable -- none is installed, or the one named is broken |
+| `5` | image verification refused the boot -- see [guest image verification](#guest-image-verification) |
+| `6` | a credential the run needed could not be resolved |
+
+`1` and `2` are unchanged from earlier releases. The rest name failures brig
+already produced under `1`, so a caller that only checked "zero or not" keeps
+working; one that wants to branch on the reason now can.
+
 ```bash
 brig run claude -p "summarise this repo"   # headless, arguments passed through
 brig run claude -- --name not-a-session    # --name reaches claude, not brig

--- a/cmd/brig/exit.go
+++ b/cmd/brig/exit.go
@@ -1,0 +1,63 @@
+package main
+
+import (
+	"errors"
+
+	"github.com/brig-sh/brig/internal/creds"
+	"github.com/brig-sh/brig/internal/runtime"
+	"github.com/brig-sh/brig/internal/wrap"
+)
+
+// Exit codes brig promises to a script. They are documented in the README
+// beside the command reference, and the mapping below is the only thing that
+// produces them, so the table and the behaviour cannot drift.
+//
+// 1 stays the general failure and 2 stays the usage error, so a caller written
+// against either keeps working. The rest name the failure shapes brig's own
+// paths already produce -- a profile that does not exist, a runtime that is
+// missing or broken, a boot refused over verification, a credential that could
+// not be resolved -- and nothing else, because a code no path returns is worse
+// than no code at all.
+const (
+	exitOK          = 0
+	exitFailure     = 1
+	exitUsage       = 2
+	exitNotFound    = 3
+	exitRuntime     = 4
+	exitVerify      = 5
+	exitCredentials = 6
+)
+
+// exitCode reads the exit status for a finished run out of its error. It reads
+// the cause rather than the message, so a wrapped error keeps its class the
+// whole way up the stack, and the order is most specific first.
+func exitCode(err error) int {
+	if err == nil {
+		return exitOK
+	}
+	var ue *usageError
+	if errors.As(err, &ue) {
+		return exitUsage
+	}
+	var nf *notFoundError
+	if errors.As(err, &nf) {
+		return exitNotFound
+	}
+	// Missing and broken are one class to a script: both mean "fix the runtime
+	// before this can run", and neither is something the command itself did
+	// wrong.
+	if errors.Is(err, runtime.ErrNoRuntime) || errors.Is(err, runtime.ErrBadRuntime) {
+		return exitRuntime
+	}
+	var vr *wrap.VerifyRefusedError
+	if errors.As(err, &vr) {
+		return exitVerify
+	}
+	// Both credential-failure shapes -- a required secret the store did not have
+	// and a store that could not be opened -- are one class here.
+	var ce creds.CredentialError
+	if errors.As(err, &ce) {
+		return exitCredentials
+	}
+	return exitFailure
+}

--- a/cmd/brig/exit_test.go
+++ b/cmd/brig/exit_test.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/brig-sh/brig/internal/creds"
+	"github.com/brig-sh/brig/internal/runtime"
+	"github.com/brig-sh/brig/internal/wrap"
+)
+
+// TestExitCode pins the mapping from an error to the process exit status. Every
+// code in the README table has a case here, so a documented code that nothing
+// returns is a test failure rather than a surprise for a script.
+func TestExitCode(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want int
+	}{
+		{"nil is success", nil, 0},
+		{"a bare error is the general failure", errors.New("boom"), 1},
+		{"a usage error", usagef("bad flag"), 2},
+		{"a missing profile", notFoundf("unknown profile %q", "nope"), 3},
+		{"no runtime on PATH", runtime.ErrNoRuntime, 4},
+		{"a broken runtime", runtime.ErrBadRuntime, 4},
+		{"a verification refusal", &wrap.VerifyRefusedError{Err: errors.New("refused")}, 5},
+		{"an unresolved credential", &creds.MissingSecretsError{
+			Sandbox: "brig-claude-code",
+			Profile: "claude-code",
+			Missing: []creds.Missing{{Name: "TOKEN"}},
+		}, 6},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := exitCode(c.err); got != c.want {
+				t.Fatalf("exitCode = %d, want %d", got, c.want)
+			}
+		})
+	}
+}
+
+// TestExitCodeThroughWrapping checks that the mapping reads the cause, not the
+// outermost message: an error handed up the stack is wrapped more than once, and
+// a code that only matched a bare sentinel would fall back to 1 the moment a
+// caller added context.
+func TestExitCodeThroughWrapping(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want int
+	}{
+		{"wrapped usage", fmt.Errorf("context: %w", usagef("bad flag")), 2},
+		{"wrapped not-found", fmt.Errorf("context: %w", notFoundf("unknown profile %q", "x")), 3},
+		{"wrapped no-runtime", fmt.Errorf("context: %w", runtime.ErrNoRuntime), 4},
+		{"wrapped bad-runtime", fmt.Errorf("context: %w", runtime.ErrBadRuntime), 4},
+		{"wrapped verify", fmt.Errorf("context: %w", &wrap.VerifyRefusedError{Err: errors.New("no")}), 5},
+		{"wrapped credentials", fmt.Errorf("context: %w", &creds.MissingSecretsError{Missing: []creds.Missing{{Name: "T"}}}), 6},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := exitCode(c.err); got != c.want {
+				t.Fatalf("exitCode = %d, want %d", got, c.want)
+			}
+		})
+	}
+}

--- a/cmd/brig/main.go
+++ b/cmd/brig/main.go
@@ -102,15 +102,13 @@ settings (BRIG_<AGENT>_<KEY> wins over BRIG_<KEY>; see the README for all):
 func main() {
 	if err := run(os.Args[1:]); err != nil {
 		fmt.Fprintln(os.Stderr, "brig: "+err.Error())
-		// A mistake in how the command was typed exits 2, the conventional
-		// usage-error code, kept apart from 1 so a script can tell "you asked
-		// for the wrong thing" from "it ran and failed". A run that stops and
-		// removes nothing because it was refused must not read as success.
-		var ue *usageError
-		if errors.As(err, &ue) {
-			os.Exit(2)
-		}
-		os.Exit(1)
+		// The exit status is a stable, documented set: a script can tell "you
+		// asked for the wrong thing" from "it ran and failed" from "the sandbox
+		// could not be verified" without parsing the message. exitCode owns the
+		// mapping; the README documents it. A run refused for any reason still
+		// exits non-zero, so a stop or a boot that removed or started nothing
+		// never reads as success.
+		os.Exit(exitCode(err))
 	}
 }
 
@@ -124,6 +122,16 @@ func (e *usageError) Error() string { return e.msg }
 
 // usagef builds a usageError the way fmt.Errorf builds an ordinary one.
 func usagef(format string, a ...any) error { return &usageError{fmt.Sprintf(format, a...)} }
+
+// notFoundError is a name that resolves to nothing: a profile brig does not
+// have, or a sandbox that is not there. It carries its own exit code so a
+// script can tell "no such thing" apart from a run that started and failed.
+type notFoundError struct{ msg string }
+
+func (e *notFoundError) Error() string { return e.msg }
+
+// notFoundf builds a notFoundError the way fmt.Errorf builds an ordinary one.
+func notFoundf(format string, a ...any) error { return &notFoundError{fmt.Sprintf(format, a...)} }
 
 func run(args []string) error {
 	if len(args) == 0 {
@@ -200,7 +208,7 @@ func run(args []string) error {
 			return fmt.Errorf("%s needs a profile, for example `brig %s claude`. "+
 				"`brig profiles` lists them", verb, verb)
 		}
-		return fmt.Errorf("unknown profile %q. `brig profiles` lists them", profileName)
+		return notFoundf("unknown profile %q. `brig profiles` lists them", profileName)
 	}
 	// Say why up front. Without this the pull fails against the registry
 	// with a 404 that reads like an outage rather than a decision.
@@ -1036,7 +1044,7 @@ func editProfile(args []string) error {
 	name := args[0]
 	p, ok := profile.Lookup(name)
 	if !ok {
-		return fmt.Errorf("unknown profile %q. `brig profiles` lists them", name)
+		return notFoundf("unknown profile %q. `brig profiles` lists them", name)
 	}
 	path, ok := profile.Path(p.Name)
 	if !ok {
@@ -1194,7 +1202,7 @@ func exportProfile(args []string) error {
 	}
 	p, ok := profile.Lookup(name)
 	if !ok {
-		return fmt.Errorf("unknown profile %q. `brig profiles` lists them", name)
+		return notFoundf("unknown profile %q. `brig profiles` lists them", name)
 	}
 	path, err := profile.ExportPath(dest, asJSON)
 	if err != nil {
@@ -1304,7 +1312,7 @@ func removeProfile(args []string) error {
 	// basename says nothing about which profile it serves.
 	p, ok := profile.Lookup(name)
 	if !ok {
-		return fmt.Errorf("no profile of your own named %q", name)
+		return notFoundf("no profile of your own named %q", name)
 	}
 	if _, ok := profile.Path(p.Name); !ok {
 		return fmt.Errorf("%s is a built-in profile, so there is nothing to remove. "+

--- a/internal/creds/resolve.go
+++ b/internal/creds/resolve.go
@@ -30,6 +30,18 @@ type Missing struct {
 	Hint string
 }
 
+// CredentialError is the class of run-stopping credential failures: a required
+// secret the store did not have (MissingSecretsError) and a store that could
+// not be opened at all (storeError). The two read differently to a person but
+// are one thing to a script -- a credential this run needed could not be
+// resolved -- so a caller mapping a failure to an exit code matches on this
+// rather than on either concrete type. The marker is unexported, so nothing
+// outside this package can join the class.
+type CredentialError interface {
+	error
+	credentialFailure()
+}
+
 // MissingSecretsError is every REQUIRED secret a run could not resolve,
 // collected into one error.
 //
@@ -47,6 +59,8 @@ type MissingSecretsError struct {
 	Profile string
 	Missing []Missing
 }
+
+func (e *MissingSecretsError) credentialFailure() {}
 
 func (e *MissingSecretsError) Error() string {
 	// Singular gets one line, because one missing secret is the common case
@@ -266,6 +280,8 @@ func (e *storeError) Error() string {
 	}
 	return msg
 }
+
+func (e *storeError) credentialFailure() {}
 
 func (e *storeError) Unwrap() error { return e.cause }
 

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -28,6 +28,15 @@ import (
 // stops the day the message or type changes from silently widening the swallow.
 var ErrNoRuntime = errors.New("no runtime found on PATH")
 
+// ErrBadRuntime is the other DetectFor failure: a runtime was asked for and is
+// wrong, rather than absent. An unknown BRIG_RUNTIME, or a runtimeBin that is
+// not on disk or is not executable, wrap this. It is kept apart from
+// ErrNoRuntime because the two want different handling -- env and ls degrade
+// over ErrNoRuntime and still fail over this -- and because a caller mapping a
+// failure to an exit code treats "you have no runtime" and "the runtime you
+// named is broken" as the same class to fix, so both reach it with errors.Is.
+var ErrBadRuntime = errors.New("runtime unavailable")
+
 // Share is a host directory made visible in the guest.
 type Share struct {
 	Host  string
@@ -219,7 +228,7 @@ func DetectFor(pref Preference) (Runtime, error) {
 	case "nerdctl":
 		return newNerdctl(bin)
 	default:
-		return nil, fmt.Errorf("unknown BRIG_RUNTIME %q (want hull or nerdctl)", kind)
+		return nil, fmt.Errorf("%w: unknown BRIG_RUNTIME %q (want hull or nerdctl)", ErrBadRuntime, kind)
 	}
 }
 
@@ -240,10 +249,10 @@ func runtimeBinFromProfile(bin string) (string, error) {
 	}
 	info, err := os.Stat(bin)
 	if err != nil {
-		return "", fmt.Errorf("this profile's runtimeBin is %s, which is not there: %w", bin, err)
+		return "", fmt.Errorf("%w: this profile's runtimeBin is %s, which is not there: %w", ErrBadRuntime, bin, err)
 	}
 	if info.IsDir() || info.Mode()&0o111 == 0 {
-		return "", fmt.Errorf("this profile's runtimeBin is %s, which is not an executable", bin)
+		return "", fmt.Errorf("%w: this profile's runtimeBin is %s, which is not an executable", ErrBadRuntime, bin)
 	}
 	return bin, nil
 }

--- a/internal/wrap/run.go
+++ b/internal/wrap/run.go
@@ -240,14 +240,17 @@ func (c *Config) EnsureRunning(set creds.Set) error {
 	// Verify before boot, not after: the point is to decide whether to run
 	// this image at all.
 	if err := c.verifyImage(); err != nil {
-		return err
+		// Tagged so a caller can map a verification refusal to its own exit code:
+		// every non-nil return from verifyImage is a refusal to boot, never an
+		// incidental error, so the whole thing is the class.
+		return &VerifyRefusedError{Err: err}
 	}
 	// And the kernel the sandbox boots, for a profile that boots a downloaded
 	// bundle rather than its own image. Checked here, beside the image, so the
 	// two refusals happen at the same point in the boot and under the same
 	// setting.
 	if err := c.verifyBootAssets(); err != nil {
-		return err
+		return &VerifyRefusedError{Err: err}
 	}
 
 	// The share below is a path, and the runtime resolves it again on its own

--- a/internal/wrap/verify.go
+++ b/internal/wrap/verify.go
@@ -11,6 +11,20 @@ import (
 	"github.com/brig-sh/brig/internal/verify"
 )
 
+// VerifyRefusedError marks a boot brig stopped because the guest image or the
+// kernel it boots did not verify: a bad signature, a mismatch, or a "could not
+// check" under BRIG_VERIFY=require, plus the interactive refusals of the same.
+//
+// It carries the underlying message unchanged and only adds a class a caller can
+// match, so a run refused for this reason gets an exit code of its own rather
+// than folding into the general failure. EnsureRunning wraps the verify step's
+// error in it, which is the one place both the image and the boot-asset checks
+// pass through.
+type VerifyRefusedError struct{ Err error }
+
+func (e *VerifyRefusedError) Error() string { return e.Err.Error() }
+func (e *VerifyRefusedError) Unwrap() error { return e.Err }
+
 // verifyImage checks the guest image before booting it, and decides what to
 // do about the answer.
 //

--- a/script/smoke.sh
+++ b/script/smoke.sh
@@ -591,6 +591,44 @@ case "$out" in
   *) bad "ls with no runtime points at getting one -- got: $out" ;;
 esac
 
+echo "== exit codes =="
+# The documented set, checked end to end so the numbers a script keys on cannot
+# drift from the README. Each verb here fails in a different way and the status
+# is the whole point, so it is captured and compared rather than the message.
+# A usage mistake is 2, kept apart from the general failure it used to share.
+"$WORK/brig" run --nope claude > /dev/null 2>&1; rc=$?
+[ "$rc" = 2 ] && ok "a usage error exits 2" || bad "a usage error exits 2 -- got $rc"
+# A profile that does not exist is 3: "no such thing", not "it ran and failed".
+"$WORK/brig" run nosuchprofile > /dev/null 2>&1; rc=$?
+[ "$rc" = 3 ] && ok "an unknown profile exits 3" || bad "an unknown profile exits 3 -- got $rc"
+# A runtime that is neither installed nor pinned is 4. run needs one to do its
+# work, so unlike env and ls it fails rather than degrading.
+PATH="" BRIG_RUNTIME_BIN= "$WORK/brig" run claude -d > /dev/null 2>&1; rc=$?
+[ "$rc" = 4 ] && ok "a missing runtime exits 4" || bad "a missing runtime exits 4 -- got $rc"
+# A runtime that is named and broken is the same class to a script: also 4.
+BRIG_RUNTIME=podman "$WORK/brig" run claude -d > /dev/null 2>&1; rc=$?
+[ "$rc" = 4 ] && ok "an unknown BRIG_RUNTIME exits 4" || bad "an unknown BRIG_RUNTIME exits 4 -- got $rc"
+# A credential a run required but could not resolve is 6. A profile of our own
+# that declares a required secret nothing supplies fails at credential
+# resolution, before the sandbox boots -- whether the store is absent (Linux) or
+# present but empty (macOS), the class a script sees is the same.
+mkdir -p "$BRIG_PROFILE_DIR"
+cat > "$BRIG_PROFILE_DIR/needsecret.yaml" <<'YAML'
+name: needsecret
+image: docker.io/library/ubuntu:24.04
+guestHome: /home/x
+binary: bash
+mem: 1024
+cpus: 1
+secrets:
+  - name: NEEDSECRET_TOKEN
+    required: true
+YAML
+"$WORK/brig" run needsecret -d > /dev/null 2>&1; rc=$?
+[ "$rc" = 6 ] && ok "an unresolved required secret exits 6" \
+  || bad "an unresolved required secret exits 6 -- got $rc"
+rm -f "$BRIG_PROFILE_DIR/needsecret.yaml"
+
 echo "== flags =="
 : > "$STUB_LOG"
 "$WORK/brig" run claude -t ghcr.io/me/img:latest -w "$WORK/other" -m 8192 --cpus 2 -d \
@@ -871,8 +909,10 @@ case "$out" in
   *"DID NOT VERIFY"*) ok "a bad signature on our own image is reported" ;;
   *) bad "a bad signature is reported -- got: $out" ;;
 esac
-[ "$rc" != 0 ] && ok "a bad signature stops the boot with no terminal to ask" \
-  || bad "a bad signature booted anyway"
+# A boot refused over verification has its own documented code, so a script can
+# tell it apart from a run that started and failed.
+[ "$rc" = 5 ] && ok "a bad signature stops the boot (exit 5) with no terminal to ask" \
+  || bad "a bad signature stops the boot with exit 5 -- got $rc"
 
 fresh
 out="$(BRIG_VERIFY=warn BRIG_IMAGE=docker.io/library/ubuntu:24.04 \
@@ -886,7 +926,8 @@ esac
 fresh
 out="$(BRIG_VERIFY=require BRIG_IMAGE=docker.io/library/ubuntu:24.04 \
   "$WORK/brig" run claude -p hi 2>&1)"; rc=$?
-[ "$rc" != 0 ] && ok "require refuses what it cannot check" || bad "require booted an unchecked image"
+[ "$rc" = 5 ] && ok "require refuses what it cannot check (exit 5)" \
+  || bad "require refuses what it cannot check with exit 5 -- got $rc"
 
 unset BRIG_COSIGN_BIN
 export BRIG_VERIFY=off


### PR DESCRIPTION
brig only ever exited 1 or 2, so a script could not tell "you asked for the wrong thing" from "it ran and failed" from "the image could not be verified".

A small documented set, used consistently and written down in the README. 1 stays the general failure so nothing silently changes meaning for an existing caller, and 2 stays the usage error it already was.

    $ brig run --nope claude      -> 2   usage
    $ brig run nosuchprofile      -> 3   no such profile
    $ PATH= brig run claude       -> 4   runtime missing

Every documented code is reachable and the tests prove it: a code in the table that nothing returns is worse than no table.

This unblocks #9, #19, #21 and the error paths in #26.

Closes #8