### PR TITLE
fix(cli): size the ls name column and list profile aliases

### DIFF
--- a/cmd/brig/main.go
+++ b/cmd/brig/main.go
@@ -671,7 +671,7 @@ func listSandboxes(args []string) error {
 		// shape of `brig ls` does not change with the runtime, and surface the
 		// platform-specific way to get one -- the hint run gives -- so a fresh
 		// box is told how rather than only that there is nothing.
-		fmt.Printf("%-28s %-10s %s\n", "SANDBOX", "STATE", "WORKSPACE")
+		printSandboxes(os.Stdout, nil)
 		fmt.Println("(none -- no runtime found on PATH, so there are no sandboxes)")
 		fmt.Printf("  %s\n", strings.TrimPrefix(err.Error(), "no runtime found on PATH: "))
 		return nil
@@ -681,19 +681,52 @@ func listSandboxes(args []string) error {
 		return err
 	}
 	sort.Slice(list, func(i, j int) bool { return list[i].Name < list[j].Name })
-	fmt.Printf("%-28s %-10s %s\n", "SANDBOX", "STATE", "WORKSPACE")
-	shown := 0
+	rows := make([]sandboxRow, 0, len(list))
 	for _, inst := range list {
 		if !strings.HasPrefix(inst.Name, sandboxPrefix) {
 			continue
 		}
-		shown++
-		fmt.Printf("%-28s %-10s %s\n", inst.Name, inst.State, workspaceOf(inst.Name, rt))
+		rows = append(rows, sandboxRow{
+			name:      inst.Name,
+			state:     inst.State,
+			workspace: workspaceOf(inst.Name, rt),
+		})
 	}
-	if shown == 0 {
+	printSandboxes(os.Stdout, rows)
+	if len(rows) == 0 {
 		fmt.Println("(none -- `brig run claude` starts one)")
 	}
 	return nil
+}
+
+// sandboxRow is one line of the listing, gathered before anything is printed
+// so the name column can be sized to the names it will actually hold.
+type sandboxRow struct {
+	name      string
+	state     string
+	workspace string
+}
+
+// printSandboxes writes the listing, header included, with the name column as
+// wide as the names in it.
+//
+// The width was a constant, and no constant is right: a sandbox is named after
+// its profile plus a session slug, so brig-claude-desktop with a ten-character
+// slug is already 30 characters against the 28 that were reserved -- and a
+// profile read from a file can be called anything, so a wider constant only
+// moves where it breaks. Measuring the names costs a pass over a list brig has
+// in hand and cannot be outgrown.
+func printSandboxes(w io.Writer, rows []sandboxRow) {
+	name := len("SANDBOX")
+	for _, r := range rows {
+		if len(r.name) > name {
+			name = len(r.name)
+		}
+	}
+	fmt.Fprintf(w, "%-*s %-10s %s\n", name, "SANDBOX", "STATE", "WORKSPACE")
+	for _, r := range rows {
+		fmt.Fprintf(w, "%-*s %-10s %s\n", name, r.name, r.state, r.workspace)
+	}
 }
 
 // workspaceOf recovers the workspace for a sandbox: what it was started with
@@ -807,7 +840,43 @@ func reset(args []string) error {
 // not what I expected" and "there is a file I forgot about" are the same
 // question.
 func listProfiles() error {
-	for _, p := range profile.All() {
+	all := profile.All()
+	// The short spellings, in a column of their own: `brig run claude` runs
+	// claude-code, and this listing is where someone finds that out. The
+	// column is as wide as the spellings in it and absent when there are none,
+	// because a column that is empty on every line says nothing and costs
+	// every description the width.
+	//
+	// The name column is measured the same way, floored at the width it has
+	// always had. A profile from a file can be called anything, and a name
+	// past the floor used to push its own description out; now it would push
+	// the alias out with it.
+	alias := make(map[string]string, len(all))
+	nameWidth, aliasWidth := 15, 0
+	for _, p := range all {
+		alias[p.Name] = strings.Join(profile.Aliases(p.Name), " ")
+		if len(p.Name) > nameWidth {
+			nameWidth = len(p.Name)
+		}
+		if len(alias[p.Name]) > aliasWidth {
+			aliasWidth = len(alias[p.Name])
+		}
+	}
+	// A gutter inside the column: the widest spelling is desktop, and without
+	// this it ends up against the description it is meant to be read apart
+	// from.
+	if aliasWidth > 0 {
+		aliasWidth++
+	}
+	// What a profile's own lines are indented by, so they sit under the
+	// description rather than in the alias column, where they would read as
+	// more spellings of the name.
+	indent := nameWidth + 1
+	if aliasWidth > 0 {
+		indent += aliasWidth + 1
+	}
+	pad := strings.Repeat(" ", indent)
+	for _, p := range all {
 		suffix := ""
 		switch {
 		case profile.OverridesBuiltIn(p.Name):
@@ -818,19 +887,23 @@ func listProfiles() error {
 		if p.Unpublished {
 			suffix += "  (no published image)"
 		}
-		fmt.Printf("%-15s %s%s\n", p.Name, p.Desc, suffix)
-		fmt.Printf("%-15s image %s, home %s\n", "", p.Image, p.GuestHome)
+		head := fmt.Sprintf("%-*s", nameWidth, p.Name)
+		if aliasWidth > 0 {
+			head += fmt.Sprintf(" %-*s", aliasWidth, alias[p.Name])
+		}
+		fmt.Printf("%s %s%s\n", head, p.Desc, suffix)
+		fmt.Printf("%simage %s, home %s\n", pad, p.Image, p.GuestHome)
 		if len(p.Env) > 0 {
 			names := make([]string, 0, len(p.Env))
 			for _, b := range p.Env {
 				names = append(names, b.Name)
 			}
-			fmt.Printf("%-15s environment: %s\n", "", strings.Join(names, " "))
+			fmt.Printf("%senvironment: %s\n", pad, strings.Join(names, " "))
 		}
 		// Listed separately from the bindings above because these are the ones
 		// you have to create before the sandbox will start at all.
 		if len(p.Secrets) > 0 {
-			fmt.Printf("%-15s secrets: %s\n", "", strings.Join(profile.SecretNames(p.Secrets), " "))
+			fmt.Printf("%ssecrets: %s\n", pad, strings.Join(profile.SecretNames(p.Secrets), " "))
 			// Which ones brig can fill from your host and which ones only you
 			// can: the old single line said "create them" for both, which for
 			// an importable secret is the long way round.
@@ -840,16 +913,16 @@ func listProfiles() error {
 			// -- one command fills every importable name on this line -- while
 			// create takes a name at a time.
 			if importable := importableNames(p); len(importable) > 0 {
-				fmt.Printf("%-15s   from your host: brig secret import %s (%s)\n", "",
+				fmt.Printf("%s  from your host: brig secret import %s (%s)\n", pad,
 					p.Name, strings.Join(importable, " "))
 			}
 			if hand := handCreatedNames(p); len(hand) > 0 {
-				fmt.Printf("%-15s   by hand: brig secret create <name> (%s)\n", "",
+				fmt.Printf("%s  by hand: brig secret create <name> (%s)\n", pad,
 					strings.Join(hand, " "))
 			}
 		}
 		if len(p.Deny) > 0 {
-			fmt.Printf("%-15s never forwarded: %s\n", "", strings.Join(p.Deny, " "))
+			fmt.Printf("%snever forwarded: %s\n", pad, strings.Join(p.Deny, " "))
 		}
 	}
 	fmt.Printf("\nan unmarked profile is built in; your own live in %s\n", profile.Dir())

--- a/cmd/brig/main_test.go
+++ b/cmd/brig/main_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"os"
 	"path/filepath"
 	"strings"
@@ -353,5 +354,51 @@ func TestWorkspaceOfPrefersTheRecordedWorkspace(t *testing.T) {
 	}
 	if got := workspaceOf("brig-claude-code", nil); got != "/somewhere/else" {
 		t.Errorf("ls reported %q for an unrecorded sandbox, want the derived path", got)
+	}
+}
+
+// The name column holds names, so it is as wide as the names it is printing.
+// A constant was wrong at both ends: brig-claude-desktop plus a ten-character
+// session slug is 30 characters, which ran into the state and pushed the rest
+// of the row out, and a listing of short names paid for the width anyway. A
+// profile from a file can be called anything, so there is no constant that
+// fits every name brig can generate.
+func TestSandboxListingSizesTheNameColumnToItsNames(t *testing.T) {
+	long := sandboxPrefix + "claude-desktop-" + strings.Repeat("s", 10)
+	for _, c := range []struct {
+		what  string
+		rows  []sandboxRow
+		width int
+	}{
+		{"the longest name brig can generate", []sandboxRow{
+			{name: long, state: "stopped", workspace: "/ws/long"},
+		}, len(long)},
+		{"names shorter than the heading", []sandboxRow{
+			{name: sandboxPrefix + "codex", state: "running", workspace: "/ws/codex"},
+		}, len(sandboxPrefix + "codex")},
+		// The no-runtime case prints the header and no rows, and a header with
+		// nothing under it is as wide as the heading.
+		{"a header on its own", nil, len("SANDBOX")},
+	} {
+		var buf bytes.Buffer
+		printSandboxes(&buf, c.rows)
+		lines := strings.Split(strings.TrimRight(buf.String(), "\n"), "\n")
+		if len(lines) != len(c.rows)+1 {
+			t.Fatalf("%s: listing has %d lines, want a header and %d row(s):\n%s",
+				c.what, len(lines), len(c.rows), buf.String())
+		}
+		for i, line := range lines {
+			name, state := "SANDBOX", "STATE"
+			if i > 0 {
+				name, state = c.rows[i-1].name, c.rows[i-1].state
+			}
+			if !strings.HasPrefix(line, name) {
+				t.Errorf("%s: line %d is %q, want it to start with %q", c.what, i, line, name)
+			}
+			if got := strings.Index(line, state); got != c.width+1 {
+				t.Errorf("%s: line %d puts %q at column %d, want %d:\n%s",
+					c.what, i, state, got, c.width+1, buf.String())
+			}
+		}
 	}
 }

--- a/cmd/brig/profile_test.go
+++ b/cmd/brig/profile_test.go
@@ -147,6 +147,66 @@ func TestListProfilesMarksOrigin(t *testing.T) {
 	}
 }
 
+// `brig run claude` runs claude-code, and the listing was the one place that
+// could say so and did not: it printed the canonical names alone, so the word
+// people actually type appeared nowhere in brig's own output.
+func TestListProfilesShowsTheAliases(t *testing.T) {
+	t.Setenv("BRIG_PROFILE_DIR", t.TempDir())
+	if err := profile.Load(profile.Dir()); err != nil {
+		t.Fatal(err)
+	}
+
+	out, err := captureStdout(t, listProfiles)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// A column, not a suffix: the descriptions still start together, and a
+	// profile with no alias leaves the space rather than closing it up.
+	descAt := -1
+	for _, c := range []struct{ name, alias, desc string }{
+		{"claude-code", "claude", "Claude Code ("},
+		{"claude-desktop", "desktop", "Claude Desktop ("},
+		{"codex", "", "Codex ("},
+	} {
+		line := profileLine(t, out, c.name)
+		at := strings.Index(line, c.desc)
+		if at < 0 {
+			t.Fatalf("the %s line has no description:\n%s", c.name, line)
+		}
+		// Between the name and the description is the alias column and
+		// nothing else, so a profile with no alias reads as an empty one.
+		if got := strings.TrimSpace(line[len(c.name):at]); got != c.alias {
+			t.Errorf("the %s line shows %q where its alias goes, want %q:\n%s",
+				c.name, got, c.alias, line)
+		}
+		if descAt >= 0 && at != descAt {
+			t.Errorf("the %s line starts its description at column %d, the others at %d:\n%s",
+				c.name, at, descAt, out)
+		}
+		descAt = at
+	}
+	// The lines under a profile are its details, so they line up with the
+	// description rather than sitting in the alias column, where they would
+	// read as more spellings of the name.
+	image := profileLine(t, out, " ")
+	if at := strings.Index(image, "image "); at != descAt {
+		t.Errorf("the detail lines indent to column %d, the descriptions to %d:\n%s", at, descAt, out)
+	}
+}
+
+// profileLine returns the first line of a listing that starts with prefix.
+func profileLine(t *testing.T, out, prefix string) string {
+	t.Helper()
+	for _, line := range strings.Split(out, "\n") {
+		if strings.HasPrefix(line, prefix) {
+			return line
+		}
+	}
+	t.Fatalf("no line starting with %q in:\n%s", prefix, out)
+	return ""
+}
+
 // The listing reports what a run actually needs: bindings by name and
 // secrets by name, with the command that creates a missing one. forward: is
 // what this replaces -- C1 folds every forward: entry into env: at parse

--- a/internal/profile/registry.go
+++ b/internal/profile/registry.go
@@ -245,6 +245,29 @@ func Alias(name string) (string, bool) {
 	return canonical, ok
 }
 
+// Aliases is the other direction: the short spellings that reach a profile, in
+// order. The listing asks, because someone who only ever types `brig run
+// claude` has nowhere else to learn which profile that word runs.
+//
+// A spelling a profile has taken is left out rather than reported. Lookup
+// prefers a registry hit, so a file-backed profile called claude wins the word
+// outright, and listing it against claude-code would name the one profile that
+// word no longer reaches.
+func Aliases(canonical string) []string {
+	var out []string
+	for short, name := range aliases {
+		if name != canonical {
+			continue
+		}
+		if _, taken := registry[short]; taken {
+			continue
+		}
+		out = append(out, short)
+	}
+	sort.Strings(out)
+	return out
+}
+
 // All returns every profile, in name order. Copies, as Lookup returns.
 func All() []Profile {
 	out := make([]Profile, 0, len(registry))

--- a/internal/profile/registry_test.go
+++ b/internal/profile/registry_test.go
@@ -166,3 +166,35 @@ func TestImportRefusesAReservedName(t *testing.T) {
 		t.Errorf("refused a name that only resembles the reserved one: %v", err)
 	}
 }
+
+// Aliases is the reverse of the table Lookup reads: the listing has a profile
+// in hand and needs the short spellings that reach it.
+func TestAliasesReportsTheSpellingsThatReachAProfile(t *testing.T) {
+	reset(t)
+	got := Aliases("claude-code")
+	if len(got) != 1 || got[0] != "claude" {
+		t.Errorf("Aliases(claude-code) = %v, want [claude]", got)
+	}
+	if got := Aliases("codex"); len(got) != 0 {
+		t.Errorf("Aliases(codex) = %v, want none", got)
+	}
+}
+
+// Lookup prefers a registry hit over an alias, so a profile of your own called
+// claude takes the word and claude-code no longer answers to it. Listing the
+// alias against claude-code anyway would name the one profile that word does
+// not reach.
+func TestAliasesDropsASpellingAProfileHasTaken(t *testing.T) {
+	reset(t)
+	dir := t.TempDir()
+	blob := []byte("name: claude\nimage: i\nguestHome: /home/c\nbinary: c\nmem: 1\ncpus: 1\n")
+	if err := os.WriteFile(filepath.Join(dir, "claude.yaml"), blob, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := Load(dir); err != nil {
+		t.Fatal(err)
+	}
+	if got := Aliases("claude-code"); len(got) != 0 {
+		t.Errorf("Aliases(claude-code) = %v, but %q now looks up the file-backed profile", got, "claude")
+	}
+}


### PR DESCRIPTION
Two `good first issue` items in the same two printers.

**#51** -- sandbox listings used a fixed `%-28s`, and generated names now reach 30 characters, so long names pushed the rest of the row out. The column is sized to the content.

**#52** -- `brig profiles` printed no alias column, so nothing told you `claude` means `claude-code`. It does now:

    claude-code     claude   Claude Code (Anthropic)

Closes #51
Closes #52