### PR TITLE
fix(brigd): arm the signal handler before binding the socket

### DIFF
--- a/cmd/brigd/main.go
+++ b/cmd/brigd/main.go
@@ -246,6 +246,17 @@ func serve(socket string) error {
 	if err := os.MkdirAll(filepath.Dir(socket), 0o700); err != nil {
 		return err
 	}
+	// Armed before the socket exists, not after. Notify changes the process's
+	// disposition for these signals, and until it runs the default one applies:
+	// SIGTERM kills outright, no deferred close, no unlink, so the socket is
+	// left behind for the next daemon to trip over. The listen below is what
+	// makes brigd reachable, so anything watching for the socket can signal it
+	// from that moment, and the handler has to already be there. The channel is
+	// buffered, so a signal that arrives before the goroutine starts is held
+	// rather than dropped.
+	stop := make(chan os.Signal, 1)
+	signal.Notify(stop, syscall.SIGINT, syscall.SIGTERM)
+
 	// One daemon per socket path, and the lock is what decides it. Binding a
 	// unix socket takes no lock of any kind, so nothing in the listen below
 	// keeps a second daemon out: both stay up, both report listening, and the
@@ -276,8 +287,6 @@ func serve(socket string) error {
 
 	d := newDaemon()
 
-	stop := make(chan os.Signal, 1)
-	signal.Notify(stop, syscall.SIGINT, syscall.SIGTERM)
 	go func() {
 		<-stop
 		// Closing the listener is the whole of the shutdown, and the socket is


### PR DESCRIPTION
Not a flaky test. A real startup race in brigd that the test was correctly catching.

## Root cause

\`serve()\` ran in this order:

    net.Listen(...)      <- socket becomes dialable
    os.Chmod, newDaemon
    signal.Notify(...)   <- handler installed

Anything watching for the socket can signal the daemon from the moment it is dialable. Until \`Notify\` runs the default disposition applies, so a SIGTERM landing in between kills the process outright: no deferred close, no unlink, and the socket is left behind for the next daemon to trip over. That is precisely what \`TestASignalledDaemonLeavesThePathFreeForItsSuccessor\` exists to check.

## Proof

The window is microseconds wide, which is why it never reproduced locally: 40 runs on macOS, 60 on Linux, 60 on the branch, 6 full-suite rounds, and 40 more under \`GOMAXPROCS=1\` all passed. CI hits it because a two-core runner widens every window.

Widening it deliberately makes it deterministic. A 300ms sleep between the listen and the Notify:

| tree | result |
| --- | --- |
| before the fix | fails **every** run |
| after the fix | passes **every** run |

Same probe, opposite outcome. That is the root cause, not a timing coincidence.

## The fix

\`Notify\` moves ahead of the lock, so it covers the whole of startup rather than the part after the listen. The channel is buffered, so a signal arriving before the goroutine that reads it starts is held rather than dropped, and the shutdown runs as soon as the goroutine does.

## No new test

The window is only reachable by widening it, which would mean a seam in production code for a race the existing test already guards behaviourally. The ordering constraint is written down at the \`Notify\` instead.

Closes #106