### PR TITLE
refactor(brigd): rename the protocol's vm field to sandbox

### DIFF
--- a/cmd/brigd/daemon_test.go
+++ b/cmd/brigd/daemon_test.go
@@ -512,24 +512,25 @@ func (l livenessRuntime) Running(string) (bool, error) { return l.running, l.err
 // The inventory re-reads liveness from the runtime on every report, so a
 // runtime that cannot be asked has to be reported as unanswered rather than as
 // a stopped sandbox. Folded into running:false it reads as a sandbox that
-// exited, and the operator goes looking for a VM that may well still be up.
+// exited, and the operator goes looking for a sandbox that may well still be
+// up.
 func TestStatusSaysWhenTheRuntimeCouldNotBeAsked(t *testing.T) {
 	d := newDaemon()
 	d.sessions["brig-broken"] = entry{
-		Session: Session{Agent: "claude-code", VM: "brig-broken"},
+		Session: Session{Agent: "claude-code", Sandbox: "brig-broken"},
 		rt:      livenessRuntime{err: errors.New("cannot connect to the daemon")},
 	}
 	d.sessions["brig-up"] = entry{
-		Session: Session{Agent: "claude-code", VM: "brig-up"},
+		Session: Session{Agent: "claude-code", Sandbox: "brig-up"},
 		rt:      livenessRuntime{running: true},
 	}
 
-	byVM := map[string]Session{}
+	bySandbox := map[string]Session{}
 	for _, s := range d.status() {
-		byVM[s.VM] = s
+		bySandbox[s.Sandbox] = s
 	}
 
-	broken := byVM["brig-broken"]
+	broken := bySandbox["brig-broken"]
 	if broken.RunningError == "" {
 		t.Error("a runtime that could not be asked was reported as a plain stopped sandbox")
 	}
@@ -541,7 +542,7 @@ func TestStatusSaysWhenTheRuntimeCouldNotBeAsked(t *testing.T) {
 	}
 
 	// The answers that were given are unchanged.
-	if up := byVM["brig-up"]; !up.Running || up.RunningError != "" {
+	if up := bySandbox["brig-up"]; !up.Running || up.RunningError != "" {
 		t.Errorf("a running sandbox was misreported: %+v", up)
 	}
 }

--- a/cmd/brigd/main.go
+++ b/cmd/brigd/main.go
@@ -98,13 +98,13 @@ type Response struct {
 type Session struct {
 	Agent     string `json:"agent"`
 	Name      string `json:"name,omitempty"`
-	VM        string `json:"vm"`
+	Sandbox   string `json:"sandbox"`
 	Workspace string `json:"workspace"`
 	Running   bool   `json:"running"`
 	// RunningError is why the runtime could not be asked. When it is set,
 	// Running says nothing -- a runtime that failed to answer is not a runtime
 	// reporting a stopped sandbox, and a client that shows the second for the
-	// first sends its reader looking for a VM that may well still be up. It
+	// first sends its reader looking for a sandbox that may well still be up. It
 	// carries the reason rather than a bare flag because that reason is the only
 	// account of what broke, and the daemon has no terminal to print it on.
 	RunningError string `json:"runningError,omitempty"`
@@ -596,7 +596,7 @@ func (d *daemon) remember(cfg *wrap.Config) {
 		Session: Session{
 			Agent:     cfg.Profile.Name,
 			Name:      cfg.RawName,
-			VM:        cfg.VMName,
+			Sandbox:   cfg.VMName,
 			Workspace: cfg.Workspace,
 		},
 		// The runtime this sandbox was booted with, so asking whether it is

--- a/docs/brigd.md
+++ b/docs/brigd.md
@@ -53,7 +53,7 @@ A response looks like:
 
 ```json
 {"ok":true,"sessions":[{"agent":"claude-code","name":"refactor",
-  "vm":"brig-claude-code-refactor","workspace":"/Users/me/brig/claude-code-refactor",
+  "sandbox":"brig-claude-code-refactor","workspace":"/Users/me/brig/claude-code-refactor",
   "running":true}]}
 ```
 
@@ -67,7 +67,7 @@ permission error, containerd is down -- the session carries `runningError`
 instead, and `running` says nothing:
 
 ```json
-{"agent":"claude-code","vm":"brig-claude-code","workspace":"/Users/me/brig/claude-code",
+{"agent":"claude-code","sandbox":"brig-claude-code","workspace":"/Users/me/brig/claude-code",
   "running":false,"runningError":"nerdctl ps: exit status 1: cannot connect to containerd"}
 ```
 


### PR DESCRIPTION
## Summary

The brigd daemon protocol was the last place in brig still calling a sandbox a "vm". brig says
"sandbox" everywhere a user can see, because it is the only word true on both platforms -- a microVM
on macOS, a container on Linux -- so `"vm"` on the wire disagreed with the CLI, the docs and the
error messages about the very thing it was reporting.

The protocol has no client yet, which is the whole reason to do this now. Today it costs a
three-file diff; after 0.2 it is a compatibility break, and the field would keep the wrong name for
as long as anyone spoke the old protocol.

## Related issues

Closes #112. Part of #47, where this is the one sub-issue with no dependencies and so the first to
land.

## Changes

- `Session.VM` becomes `Session.Sandbox`, and its JSON tag `"vm"` becomes `"sandbox"`.
- The fill site in `daemon.remember` follows, as does `cmd/brigd/daemon_test.go` including its
  `byVM` map.
- Both example payloads in `docs/brigd.md` now match what the daemon actually emits.
- Two doc comments that named the *thing* rather than the technology now say "sandbox". Comments
  that genuinely mean the VM technology ("microVM") are left alone.
- `workspace` deliberately keeps its name. #6 will touch this struct to add a `project` field beside
  it, and renaming `workspace` is that change's business rather than a second break here -- the "no
  client yet" window does not close until 0.2 ships, so nothing is lost by waiting.
- `wrap.Config.VMName` is untouched: an internal Go identifier no client ever sees. That leaves
  `Sandbox: cfg.VMName` as a naming seam at the fill site, which is intentional and scoped out.

Two notes on the checklist above. **No new test was added** because the compiler enforces a field
rename; the existing daemon tests were updated instead, which is what the box is ticked for.
**`script/smoke.sh` does not pass, and does not pass at `8340bb4` either** -- the two failure sets
are identical (11 each, verified by diffing them), so nothing here regresses it. At least two of
those failures are the host environment rather than the tree: an imported credential that expired
11 days ago, and a `GH_TOKEN` holding an unresolved `op://` reference.

## Checklist

- [x] `make all` passes (vet, test, build)
- [x] `script/smoke.sh` passes
- [x] I have added or updated tests covering the change
- [x] I have run `go test ./... -race`, if the change touches concurrency, subprocesses or the daemon
- [ ] ~~I have exercised the change against a real runtime (`brig run <agent>`), if it touches the run, exec or credential path~~
- [x] I have updated the affected docs (README, `docs/security.md`, `docs/profiles.md`, `docs/brigd.md`)

## LLM usage

Authored with assistance from Claude Code (Opus 5), which produced the rename, the commit message
and this description. Verification was re-run independently of the agent that made the change:
`make all` green, and the `script/smoke.sh` failure set diffed against the parent commit to confirm
it is unchanged. Accountability for every line remains the author's.
