### PR TITLE
feat(cli): give brig's flags a position and read a session ref

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,15 +135,24 @@ separate Linux re-implementation of it.
 for one release, each printing a one-line note naming the new one; they no
 longer appear above. There is deliberately no `brig template edit`.
 
-Flags go before the agent's own arguments; `--` ends brig's parsing outright,
-so an agent flag spelled like one of brig's still reaches the agent.
+A brig line has three places a token can stand, and they are not the same kind
+of place. Left of the verb are brig's global flags, a closed set -- an unknown
+flag there is a usage error naming the token, rather than an operand quietly
+swallowed. Between the verb and the agent are the run-line flags below. Right of
+the agent the vocabulary is the agent's, and `--` ends brig's parsing outright,
+so an agent flag spelled like one of brig's still reaches it.
+
+brig does still read its own flags after the agent, because `brig run claude -q`
+is a line that works. But once an unknown token has ended brig's reading, a brig
+flag further along belongs to the agent -- and brig now says so, without taking
+the token, so a line that works today keeps working.
 
 | flag | what it does |
 | --- | --- |
-| `-n, --name NAME` | a session of its own: own workspace, own sandbox |
-| `-t, --image IMAGE` | guest image to boot |
+| `-n, --name NAME` | a session of its own: own workspace, own sandbox. Also written `<agent>@<label>` |
+| `--image IMAGE` | guest image to boot (`-t` still works, with a note) |
 | `-w, --workspace PATH` | host directory to mount as the guest home |
-| `-m, --memory MB` | guest memory |
+| `--mem MB` | guest memory (`--memory` also works; `-m` works with a note) |
 | `--cpus N` | guest vCPUs |
 | `-d, --detach` | with `run`: start the sandbox, print its name, exit |
 | `--skills` | seed your own `~/.claude` skills and plugins into the workspace |
@@ -182,7 +191,8 @@ brig shell codex 'ls -la ~'                # one command, in a login shell
 ### Named sessions
 
 ```bash
-brig run claude --name refactor
+brig run claude@refactor
+brig run claude --name refactor    # the same session, the older spelling
 ```
 
 A session of its own: its own workspace (`~/brig/claude-code-refactor`), its
@@ -193,15 +203,22 @@ underscore, ten characters -- so `my_project` and `my-project` stay separate,
 while `Foo` and `foo` do not (macOS filesystems ignore case, and two names
 sharing one directory but not one VM is a bug waiting to happen). If the slug
 differs from what you typed, brig says which directory it used.
-`brig info claude --name refactor` prints the one in use.
+`brig info claude@refactor` prints the one in use.
 
-**Every other verb needs the same `--name`.** A named session is addressed by
-its agent *plus* its name, not by the name alone:
+The `@` form is the stricter of the two: a label brig would have to rewrite --
+uppercase, a space, more than ten characters -- is refused rather than quietly
+shortened, and the message names what it would have become. That is what makes
+the label safe to use as an address: nothing is silently mapped onto a directory
+you did not ask for. `--name` keeps its older, lenient behaviour.
+
+**Every verb takes the ref.** A named session is addressed as
+`<agent>@<label>`, and the older agent-plus-`--name` spelling still works
+everywhere it did:
 
 ```bash
-brig exec claude --name refactor -- git status
-brig stop claude --name refactor
-brig rm   claude --name refactor      # removes the sandbox, keeps the workspace
+brig exec claude@refactor -- git status
+brig stop claude@refactor
+brig rm   claude@refactor      # removes the sandbox, keeps the workspace
 ```
 
 `brig ls` shows the session as `brig-claude-code-refactor`, but that string is

--- a/cmd/brig/deprecated_test.go
+++ b/cmd/brig/deprecated_test.go
@@ -94,3 +94,59 @@ func TestBuiltInProfilesDoNotWarnAboutHostCredential(t *testing.T) {
 		}
 	}
 }
+
+// -t and -m keep working for one release and say what replaces them. They are
+// two of the four short flags #47 removes in v0.3, and the notice is the same
+// one the retiring verbs print: a working command and a line about it, not a
+// failure.
+func TestDeprecatedShortFlagsStillWork(t *testing.T) {
+	for _, c := range []struct {
+		args        []string
+		replacement string
+		check       func(options) bool
+	}{
+		{[]string{"claude", "-t", "img:1"}, "--image", func(o options) bool { return o.load.Image == "img:1" }},
+		{[]string{"claude", "-m", "2048"}, "--mem", func(o options) bool { return o.load.Mem == 2048 }},
+		// The inline form is the same flag, so it hears the same notice.
+		{[]string{"claude", "-t=img:1"}, "--image", func(o options) bool { return o.load.Image == "img:1" }},
+	} {
+		var (
+			o   options
+			err error
+		)
+		warning := captureStderr(t, func() { o, _, _, err = parse(c.args) })
+		if err != nil {
+			t.Errorf("parse(%q): %v", c.args, err)
+			continue
+		}
+		if !c.check(o) {
+			t.Errorf("parse(%q) stopped working: %+v", c.args, o.load)
+		}
+		// The notice names the spelling, not the token: the inline form's
+		// value is no part of what is being deprecated.
+		spelling, _, _ := strings.Cut(c.args[1], "=")
+		if !strings.Contains(warning, spelling) || !strings.Contains(warning, c.replacement) {
+			t.Errorf("parse(%q) did not point %s at %s:\n%s",
+				c.args, spelling, c.replacement, warning)
+		}
+	}
+	// The long spellings are current, so they say nothing.
+	warning := captureStderr(t, func() {
+		if _, _, _, err := parse([]string{"claude", "--image", "img:1", "--mem", "8"}); err != nil {
+			t.Errorf("parse: %v", err)
+		}
+	})
+	if warning != "" {
+		t.Errorf("the current spellings printed a deprecation notice:\n%s", warning)
+	}
+	// A value that happens to be spelled like a deprecated flag is a value.
+	// Warning on it would send the reader looking for a flag they did not type.
+	warning = captureStderr(t, func() {
+		if _, _, _, err := parse([]string{"claude", "--name", "-t"}); err != nil {
+			t.Errorf("parse: %v", err)
+		}
+	})
+	if strings.Contains(warning, "--image") {
+		t.Errorf("a --name value read as a deprecated flag:\n%s", warning)
+	}
+}

--- a/cmd/brig/hygiene_test.go
+++ b/cmd/brig/hygiene_test.go
@@ -129,3 +129,304 @@ func TestParseNetworkAndOffline(t *testing.T) {
 		t.Error("--offline with --network shared was accepted")
 	}
 }
+
+// Every entry in brigFlags says where it is legal. The zero position is not a
+// position, so a flag added to the table without one fails here rather than
+// landing in whichever set the zero value happens to be: a flag that is
+// silently global is refused everywhere it used to work, and a flag that is
+// silently on the run line is quietly forwarded to the agent instead.
+func TestBrigFlagsDeclareAPosition(t *testing.T) {
+	for _, f := range brigFlags {
+		switch f.position {
+		case posGlobal, posRun:
+		default:
+			t.Errorf("brig flag --%s has no position", f.long)
+		}
+	}
+}
+
+// The positions brig owns are closed sets, and a token in one of them that
+// brig does not own is a mistake rather than the agent's word. That only holds
+// while brig's own spellings are not also the agent's -- where the two collide,
+// brig reads the flag and the agent never sees it, and `--` is the only way
+// through.
+//
+// The overlaps below are what that costs today. They are the reason #47
+// retires -n, -t, -w and -m in v0.3, and the map is expected to shrink as it
+// does; a spelling that starts colliding fails here first.
+//
+// claudeCodeFlags is hand-maintained. No profile spec declares its agent's
+// flags -- internal/profile carries the image, the binary and the credentials
+// and nothing about the CLI's grammar -- so there is nothing to derive this
+// from. It was captured from `claude --help` (Claude Code 2.1.252) and covers
+// that one agent: the other shipped profiles' CLIs are not on this machine and
+// are not asserted here, so this test is exactly as strong as the list, which
+// is to say it catches a collision with Claude Code and no more.
+func TestBrigFlagsOverlapWithClaudeCodeOnlyWhereKnown(t *testing.T) {
+	claudeCodeFlags := []string{
+		"--add-dir", "--agent", "--agents", "--allow-dangerously-skip-permissions",
+		"--allowed-tools", "--allowedTools", "--append-system-prompt", "--autocompact",
+		"--ax-screen-reader", "--background", "--bare", "--betas", "--bg", "--brief",
+		"--chrome", "--cloud", "--continue", "--dangerously-skip-permissions", "--debug",
+		"--debug-file", "--disable-slash-commands", "--disallowed-tools", "--disallowedTools",
+		"--effort", "--environment", "--exclude-dynamic-system-prompt-sections",
+		"--fallback-model", "--file", "--fork-session", "--forward-subagent-text",
+		"--from-pr", "--help", "--ide", "--include-hook-events",
+		"--include-partial-messages", "--input-format", "--json-schema",
+		"--max-budget-usd", "--mcp-config", "--model", "--name", "--no-chrome",
+		"--no-session-persistence", "--output-format", "--permission-mode",
+		"--plugin-dir", "--plugin-url", "--print", "--prompt-suggestions",
+		"--remote-control", "--remote-control-session-name-prefix",
+		"--replay-user-messages", "--restricted", "--resume", "--safe-mode",
+		"--session-id", "--setting-sources", "--settings", "--strict-mcp-config",
+		"--system-prompt", "--teleport", "--tmux", "--tools", "--verbose", "--version",
+		"--worktree", "-c", "-d", "-h", "-n", "-p", "-r", "-v", "-w",
+	}
+	// The brig spelling -> why it still collides.
+	knownOverlaps := map[string]string{
+		"--name": "claude-code's own --name; brig's retires in #5",
+		"-n":     "claude-code -n; retires in #5",
+		"-w":     "claude-code -w/--worktree; brig's --workspace retires in #6",
+		"-d":     "claude-code -d/--debug; brig's --detach keeps -d, so this one stays",
+	}
+
+	agent := make(map[string]bool, len(claudeCodeFlags))
+	for _, f := range claudeCodeFlags {
+		agent[f] = true
+	}
+	found := map[string]bool{}
+	for _, f := range brigFlags {
+		spellings := []string{"--" + f.long}
+		if f.short != "" {
+			spellings = append(spellings, "-"+f.short)
+		}
+		for _, s := range spellings {
+			if !agent[s] {
+				continue
+			}
+			found[s] = true
+			if _, known := knownOverlaps[s]; !known {
+				t.Errorf("brig's %s is also claude-code's, and brig reads it first, so "+
+					"`brig run claude %s` never reaches the agent", s, s)
+			}
+		}
+	}
+	// And the other way, so the map shrinks when a spelling retires rather
+	// than outliving the collision it documents.
+	for s := range knownOverlaps {
+		if !found[s] {
+			t.Errorf("knownOverlaps still lists %s, which no longer collides; drop the entry", s)
+		}
+	}
+}
+
+// The global position -- left of the verb -- is closed. It holds no flags yet:
+// every flag brig has is on the run line, and #24, #11 and #30 are what fill
+// this in. Closed and empty is the point, so that a flag written there is
+// named rather than read as a command.
+func TestGlobalPositionRefusesAnUnknownToken(t *testing.T) {
+	for _, args := range [][]string{
+		{"--json", "run", "claude"},
+		{"--nope", "ls"},
+		{"-y", "rm", "claude"},
+	} {
+		_, err := parseGlobal(args)
+		if err == nil {
+			t.Errorf("parseGlobal(%q) was accepted", args)
+			continue
+		}
+		var ue *usageError
+		if !errors.As(err, &ue) {
+			t.Errorf("parseGlobal(%q): %v, want a usageError", args, err)
+		}
+		if !strings.Contains(err.Error(), args[0]) {
+			t.Errorf("parseGlobal(%q): %v, want it to name %q", args, err, args[0])
+		}
+	}
+}
+
+// The verb and everything after it is not the global position's business,
+// including the flag-shaped spellings of a verb and every flag on the run
+// line.
+func TestGlobalPositionPassesTheVerbLineThrough(t *testing.T) {
+	for _, args := range [][]string{
+		{"run", "claude", "--name", "x"},
+		{"-h"},
+		{"--help"},
+		{"--version"},
+		{"version"},
+		{"run", "claude", "--json"},
+	} {
+		rest, err := parseGlobal(args)
+		if err != nil {
+			t.Errorf("parseGlobal(%q): %v", args, err)
+			continue
+		}
+		if strings.Join(rest, " ") != strings.Join(args, " ") {
+			t.Errorf("parseGlobal(%q) = %q, want it untouched", args, rest)
+		}
+	}
+}
+
+// A ref names the session inline: `brig run claude@refactor` is what `brig run
+// claude --name refactor` already does, so the label lands on the same path
+// rather than becoming a second way to hold a session.
+func TestParseReadsASessionRef(t *testing.T) {
+	o, profileName, tail, err := parse([]string{"claude@refactor", "-p", "hi"})
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if profileName != "claude" {
+		t.Errorf("profile = %q, want claude", profileName)
+	}
+	if o.load.Name != "refactor" || !o.nameGiven {
+		t.Errorf("name = %q, given = %v, want refactor, true", o.load.Name, o.nameGiven)
+	}
+	if strings.Join(tail, " ") != "-p hi" {
+		t.Errorf("tail = %q, want the agent's own arguments untouched", tail)
+	}
+	// The two spellings of one session agree.
+	viaFlag, _, _, err := parse([]string{"claude", "--name", "refactor"})
+	if err != nil {
+		t.Fatalf("parse --name: %v", err)
+	}
+	if viaFlag.load != o.load || viaFlag.nameGiven != o.nameGiven {
+		t.Errorf("claude@refactor = %+v, claude --name refactor = %+v", o.load, viaFlag.load)
+	}
+}
+
+// A malformed ref is a usage error naming what was typed, not a profile brig
+// then reports as missing.
+func TestParseRefusesABadRef(t *testing.T) {
+	for _, args := range [][]string{
+		{"claude@"},
+		{"claude@a@b"},
+		{"claude@Refactor"},
+		{"claude@my-very-long-label"},
+		{"@refactor"},
+	} {
+		_, _, _, err := parse(args)
+		if err == nil {
+			t.Errorf("parse(%q) was accepted", args)
+			continue
+		}
+		var ue *usageError
+		if !errors.As(err, &ue) {
+			t.Errorf("parse(%q): %v, want a usageError", args, err)
+		}
+	}
+}
+
+// Both spellings of the session on one line is a line that asks for two
+// different sessions. A silent winner would run one of them with the other
+// still written on the command.
+func TestParseRefusesARefAndNameTogether(t *testing.T) {
+	_, _, _, err := parse([]string{"claude@refactor", "--name", "other"})
+	if err == nil {
+		t.Fatal("claude@refactor --name other was accepted")
+	}
+	for _, want := range []string{"refactor", "other"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("%v, want it to name %q", err, want)
+		}
+	}
+}
+
+// Right of the ref every token is the agent's, brig's own spellings included.
+// So brig says so instead of taking it: `brig run claude -p hi --quiet` runs
+// the agent with --quiet, which is what it has always done, and now says that
+// brig is not the one reading it.
+func TestParseWarnsAboutItsOwnFlagsInTheAgentTail(t *testing.T) {
+	var (
+		o    options
+		tail []string
+		err  error
+	)
+	warning := captureStderr(t, func() {
+		o, _, tail, err = parse([]string{"claude", "-p", "hi", "--quiet", "--cpus=2"})
+	})
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	// Still forwarded, and still not read: the warning changes nothing about
+	// what runs.
+	if strings.Join(tail, " ") != "-p hi --quiet --cpus=2" {
+		t.Errorf("tail = %q, want it forwarded untouched", tail)
+	}
+	if o.quiet || o.load.CPUs != 0 {
+		t.Errorf("brig read the agent's arguments: quiet %v, cpus %d", o.quiet, o.load.CPUs)
+	}
+	for _, want := range []string{"--quiet", "--cpus"} {
+		if !strings.Contains(warning, want) {
+			t.Errorf("nothing warned about %s:\n%s", want, warning)
+		}
+	}
+}
+
+// A `--` is the user saying the rest is the agent's, so there is nothing to
+// point out about what follows it. Warning there would put a line on stderr
+// for every scripted `brig exec claude -- ls` that happens to name one.
+func TestParseSaysNothingAfterAnExplicitEnd(t *testing.T) {
+	warning := captureStderr(t, func() {
+		if _, _, tail, err := parse([]string{"claude", "--", "--quiet"}); err != nil {
+			t.Errorf("parse: %v", err)
+		} else if strings.Join(tail, " ") != "--quiet" {
+			t.Errorf("tail = %q", tail)
+		}
+	})
+	if strings.Contains(warning, "--quiet") {
+		t.Errorf("brig warned about a token past --:\n%s", warning)
+	}
+}
+
+// --mem is the spelling; --memory is what it was called and keeps working.
+func TestParseReadsMemAndMemory(t *testing.T) {
+	for _, args := range [][]string{
+		{"claude", "--mem", "2048"},
+		{"claude", "--mem=2048"},
+		{"claude", "--memory", "2048"},
+	} {
+		o, _, _, err := parse(args)
+		if err != nil {
+			t.Errorf("parse(%q): %v", args, err)
+			continue
+		}
+		if o.load.Mem != 2048 {
+			t.Errorf("parse(%q) = mem %d, want 2048", args, o.load.Mem)
+		}
+	}
+	// And it is brig's, so it is refused by name rather than forwarded.
+	if _, _, _, err := parse([]string{"claude", "--mem", "lots"}); err == nil {
+		t.Error("--mem lots was accepted")
+	} else if !strings.Contains(err.Error(), "--mem") {
+		t.Errorf("--mem lots: %v, want it to name --mem", err)
+	}
+}
+
+// The lines that work today still work. Every one of these is a shape someone
+// has typed or scripted, and the grammar change is only worth having if none
+// of them moves.
+func TestParseKeepsTodaysLines(t *testing.T) {
+	for _, c := range []struct {
+		args []string
+		name string
+		tail string
+	}{
+		{[]string{"claude", "--name", "x"}, "x", ""},
+		{[]string{"claude", "-q"}, "", ""},
+		{[]string{"claude", "-p", "hi"}, "", "-p hi"},
+		{[]string{"claude", "--", "--name"}, "", "--name"},
+		{[]string{"claude", "--", "ls"}, "", "ls"},
+		{[]string{"--name", "x", "claude"}, "x", ""},
+	} {
+		o, profileName, tail, err := parse(c.args)
+		if err != nil {
+			t.Errorf("parse(%q): %v", c.args, err)
+			continue
+		}
+		if profileName != "claude" || o.load.Name != c.name || strings.Join(tail, " ") != c.tail {
+			t.Errorf("parse(%q) = (%q, %q, %q), want (claude, %q, %q)",
+				c.args, profileName, o.load.Name, tail, c.name, c.tail)
+		}
+	}
+}

--- a/cmd/brig/main.go
+++ b/cmd/brig/main.go
@@ -23,6 +23,7 @@ import (
 	"github.com/brig-sh/brig/internal/creds"
 	"github.com/brig-sh/brig/internal/profile"
 	"github.com/brig-sh/brig/internal/runtime"
+	"github.com/brig-sh/brig/internal/session"
 	"github.com/brig-sh/brig/internal/wrap"
 )
 
@@ -63,10 +64,12 @@ usage:
   brig version
 
 flags (before the agent's own arguments; -- ends brig's parsing):
-  -n, --name NAME        a session of its own: own workspace, own sandbox
-  -t, --image IMAGE      guest image to boot
+  -n, --name NAME        a session of its own: own workspace, own sandbox.
+                         Also written <profile>@<label>, which refuses a label
+                         it would have to shorten rather than shortening it
+      --image IMAGE      guest image to boot
   -w, --workspace PATH   host directory to mount as the guest home
-  -m, --memory MB        guest memory
+      --mem MB           guest memory
       --cpus N           guest vCPUs
   -d, --detach           with run: start the sandbox and exit
   -q, --quiet            with run or create: do not print the execution
@@ -136,11 +139,18 @@ func (e *notFoundError) Error() string { return e.msg }
 func notFoundf(format string, a ...any) error { return &notFoundError{fmt.Sprintf(format, a...)} }
 
 func run(args []string) error {
-	if len(args) == 0 {
+	// The global position first, so a flag written left of the verb is named
+	// rather than read as a command.
+	verbLine, err := parseGlobal(args)
+	if err != nil {
+		return err
+	}
+	if len(verbLine) == 0 {
+		// No verb: a bare `brig`, or global flags and nothing to do with them.
 		fmt.Print(usage)
 		return nil
 	}
-	verb, rest := args[0], args[1:]
+	verb, rest := verbLine[0], verbLine[1:]
 
 	// Profiles are read before anything looks a name up, so a file can stand
 	// in for a built-in. A broken file is reported and skipped rather than
@@ -368,38 +378,91 @@ type options struct {
 	offline   bool
 }
 
-// brigFlags is what brig owns on a run line. Everything else on that line
+// position is where on a brig command line a flag is legal.
+//
+// A brig line has three places a token can stand -- left of the verb, between
+// the verb and the session ref, and right of the ref -- and they are not the
+// same kind of place. In the first two brig owns the vocabulary, so a token it
+// does not recognise is a mistake to name. In the third the vocabulary is the
+// agent's, so the same token is a word to forward untouched. Which set a flag
+// belongs to is therefore what decides how an unknown neighbour of it is read,
+// and that is why the table below carries it rather than leaving the boundary
+// to a single "have I seen the profile yet".
+//
+// The zero value is no position at all, so an entry has to say which one it
+// means. Defaulting would put a new flag in whichever set the zero value
+// happened to be, and both wrong answers are silent: a flag that is
+// accidentally global is refused everywhere it is documented to work, and one
+// that is accidentally on the run line is handed to the agent, which does not
+// have it.
+type position int
+
+const (
+	// posGlobal is left of the verb: `brig --json run claude`. Closed and
+	// empty today; see splitGlobal.
+	posGlobal position = iota + 1
+	// posRun is the run line, from the verb to the ref. Every flag brig has
+	// today is here.
+	posRun
+	// posAny matches a flag wherever brig would have read it. Only the tail
+	// warning uses it: right of the ref every token is the agent's whatever
+	// position brig would otherwise read it in, so what matters there is that
+	// the token is brig's at all, not where.
+	posAny
+)
+
+// brigFlags is what brig owns, and where. Everything else on a run line
 // belongs to the agent, so this table is also the boundary: split consults it
 // to find where brig's arguments stop, which is why it records whether a flag
-// takes a value. Adding a flag here and registering it in parse are the two
-// halves of adding a flag at all.
+// takes a value. Adding a flag here and registering it in parse -- or in
+// parseGlobal, for a global one -- are the two halves of adding a flag at all.
 var brigFlags = []struct {
-	long  string
-	short string
-	value bool // takes a value, so the next argument may belong to it
+	long     string
+	short    string
+	value    bool // takes a value, so the next argument may belong to it
+	position position
 }{
-	{long: "name", short: "n", value: true},
-	{long: "image", short: "t", value: true},
-	{long: "workspace", short: "w", value: true},
-	{long: "memory", short: "m", value: true},
-	{long: "cpus", value: true},
-	{long: "detach", short: "d"},
-	{long: "skills"},
-	{long: "network", value: true},
-	{long: "offline"},
-	{long: "quiet", short: "q"},
+	{long: "name", short: "n", value: true, position: posRun},
+	{long: "image", short: "t", value: true, position: posRun},
+	{long: "workspace", short: "w", value: true, position: posRun},
+	// --mem is the spelling; --memory is what it was called first and still
+	// answers, because a line that works today keeps working. Both write one
+	// value in parse, so the last one on the line wins.
+	{long: "mem", value: true, position: posRun},
+	{long: "memory", short: "m", value: true, position: posRun},
+	{long: "cpus", value: true, position: posRun},
+	{long: "detach", short: "d", position: posRun},
+	{long: "skills", position: posRun},
+	{long: "network", value: true, position: posRun},
+	{long: "offline", position: posRun},
+	{long: "quiet", short: "q", position: posRun},
 }
 
-// ours reports whether a token is one of brig's flags, and whether that flag
-// consumes the argument after it. A token carrying its own value (--name=foo)
-// consumes nothing further.
+// deprecatedShorts are the short spellings on their way out, and the long ones
+// that replace them. #47 ships both grammars in v0.2 and removes the short
+// forms in v0.3, so these keep working and say so -- the same contract the
+// retiring verbs have. -n and -w are the other two; they are absent here
+// because #5 and #6 introduce what replaces them, and pointing at a flag that
+// does not exist yet is worse than saying nothing.
+var deprecatedShorts = map[string]string{
+	"-t": "--image",
+	"-m": "--mem",
+}
+
+// ours reports whether a token is one of brig's flags in the position it was
+// written, and whether that flag consumes the argument after it. A token
+// carrying its own value (--name=foo) consumes nothing further.
+//
 // The two documented spellings and no others. The flag package would answer to
 // -name and --n as well, but brig forwards everything it does not own, so
 // being greedier here silently eats an agent's own flag: `brig run claude
 // -image x` has to stay the agent's -image.
-func ours(arg string) (mine bool, takesValue bool) {
+func ours(arg string, at position) (mine bool, takesValue bool) {
 	name, _, inline := strings.Cut(arg, "=")
 	for _, f := range brigFlags {
+		if at != posAny && f.position != at {
+			continue
+		}
 		if name == "--"+f.long || (f.short != "" && name == "-"+f.short) {
 			return true, f.value && !inline
 		}
@@ -407,47 +470,138 @@ func ours(arg string) (mine bool, takesValue bool) {
 	return false, false
 }
 
-// split divides a run line into brig's own arguments, the profile name, and
-// the agent's tail.
+// splitGlobal finds the verb and refuses anything standing left of it.
+//
+// The global position is closed and, today, empty: every entry in brigFlags is
+// on the run line, so ours answers no to every token here. Establishing it
+// while it is empty is the point. `brig --json run claude` is a line someone
+// will type, and the two ways to read a token brig does not own are "the
+// command is --json" and "the agent wants it" -- one reports a command that
+// does not exist and the other hands a word to an agent that does not have it.
+// Naming the token is the third reading, and it is the one that is true.
+// #24, #11 and #30 are what put flags in here.
+//
+// A flag-shaped verb -- -h, --help, --version -- is a verb, not a token in this
+// position: those are the spellings brig has always answered to.
+func splitGlobal(args []string) (mine []string, rest []string, err error) {
+	for i := 0; i < len(args); i++ {
+		a := args[i]
+		if !strings.HasPrefix(a, "-") || verbSpelling(a) {
+			return mine, args[i:], nil
+		}
+		isOurs, takesValue := ours(a, posGlobal)
+		if !isOurs {
+			return nil, nil, usagef("unknown flag %q before the command. "+
+				"brig takes a command first: `brig run claude`, `brig ls`. "+
+				"If %q is the agent's, it goes after the profile", a, a)
+		}
+		mine = append(mine, a)
+		if takesValue && i+1 < len(args) {
+			i++
+			mine = append(mine, args[i])
+		}
+	}
+	return mine, nil, nil
+}
+
+// verbSpelling reports whether a token is one of brig's verbs written as a
+// flag. Only these three: they are read by the verb switch in run, and a
+// fourth would be a flag.
+func verbSpelling(arg string) bool {
+	switch arg {
+	case "-h", "--help", "--version":
+		return true
+	}
+	return false
+}
+
+// parseGlobal reads brig's global flags -- the ones legal left of the verb --
+// and returns the verb and everything after it.
+//
+// There are none yet, so this parses an empty list. It exists anyway so that
+// adding a global flag is the same two-step adding a run-line flag is, a table
+// entry and a registration, and so that doing only the first half fails here
+// with the flag package's "not defined" rather than accepting the flag and
+// dropping it on the floor.
+func parseGlobal(args []string) (rest []string, err error) {
+	mine, rest, err := splitGlobal(args)
+	if err != nil {
+		return nil, err
+	}
+	fs := flag.NewFlagSet("brig", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	fs.Usage = func() {}
+	// Nothing is registered here yet. See the doc comment.
+	if err := fs.Parse(mine); err != nil {
+		return nil, rewriteFlagError(err)
+	}
+	return rest, nil
+}
+
+// split divides a run line into brig's own arguments, the session ref, and the
+// agent's tail.
 //
 // This exists because the flag package stops at the first non-flag argument
 // and treats an unknown flag as an error, and brig's line is the opposite on
-// both counts: the profile name sits in the middle of brig's flags, and an
-// unrecognised flag is not a mistake but the agent's -- `brig run claude -p hi`
+// both counts: the ref sits in the middle of brig's flags, and an unrecognised
+// flag after the ref is not a mistake but the agent's -- `brig run claude -p hi`
 // runs the agent with -p hi. So the boundary is decided here, from the table,
 // and the flag package parses what is left of it.
-func split(args []string) (mine []string, profileName string, tail []string, err error) {
+//
+// The state that decides it is one bit: has the ref been passed. Before it,
+// brig owns every token and an unknown flag is a brig flag that does not
+// exist. After it, brig still answers to its own flags -- `brig run claude -q`
+// is a line that works today -- but the first token it does not own ends its
+// parsing and everything from there is the agent's, warnings included.
+func split(args []string) (mine []string, ref session.Ref, tail []string, err error) {
+	passed := false
 	for i := 0; i < len(args); i++ {
 		a := args[i]
 		switch {
 		case a == "--":
 			// An explicit end to brig's parsing, so an agent argument spelled
-			// like one of brig's flags still reaches the agent.
-			return mine, profileName, args[i+1:], nil
+			// like one of brig's flags still reaches the agent. Nothing is
+			// said about what follows: the line already said it.
+			return mine, ref, args[i+1:], nil
 		case !strings.HasPrefix(a, "-"):
-			if profileName == "" {
-				profileName = a
+			if !passed {
+				if ref, err = session.ParseRef(a); err != nil {
+					// A ref brig cannot read is a mistyped command, not a
+					// profile to go and look up: reporting it as a missing
+					// profile would name the whole token and say nothing about
+					// the part that is wrong.
+					return nil, session.Ref{}, nil, usagef("%s", err)
+				}
+				passed = true
 				continue
 			}
-			// A second bare word is the agent's command, not a second profile.
-			return mine, profileName, args[i:], nil
+			// A second bare word is the agent's command, not a second ref.
+			return mine, ref, agentTail(args[i:]), nil
 		default:
-			isOurs, takesValue := ours(a)
+			isOurs, takesValue := ours(a, posRun)
 			if !isOurs {
-				// An unknown flag once the profile is named is the agent's:
+				// An unknown flag once the ref is named is the agent's:
 				// `brig run claude --resume` runs the agent with --resume, and
-				// brig forwards everything from here on. Before the profile is
-				// named there is no agent yet to own it, so a flag brig does not
-				// recognise in that position is not passed through -- it is a
-				// brig flag that does not exist. Forwarding it would make the
-				// profile look like the flag's value and leave the line blaming
-				// the one word on it that was right, so refuse it and name it.
-				if profileName == "" {
-					return nil, "", nil, usagef("unknown flag %q before the profile name. "+
+				// brig forwards everything from here on. Before the ref there is
+				// no agent yet to own it, so a flag brig does not recognise in
+				// that position is not passed through -- it is a brig flag that
+				// does not exist. Forwarding it would make the profile look like
+				// the flag's value and leave the line blaming the one word on it
+				// that was right, so refuse it and name it.
+				if !passed {
+					return nil, session.Ref{}, nil, usagef("unknown flag %q before the profile name. "+
 						"brig's own flags come before the profile and the agent's after it; "+
 						"put %q after the profile to pass it through, or -- to end brig's flags", a, a)
 				}
-				return mine, profileName, args[i:], nil
+				return mine, ref, agentTail(args[i:]), nil
+			}
+			// Read off the spelling rather than the whole token, so the
+			// inline form is the same flag here as it is everywhere else, and
+			// named before the value is taken, so the notice is never about a
+			// value that reads like a flag: `--name -t` is a session called -t
+			// and reaches this loop as a value, not as a token.
+			if spelling, _, _ := strings.Cut(a, "="); deprecatedShorts[spelling] != "" {
+				deprecated(spelling, deprecatedShorts[spelling])
 			}
 			mine = append(mine, a)
 			if takesValue && i+1 < len(args) {
@@ -459,7 +613,32 @@ func split(args []string) (mine []string, profileName string, tail []string, err
 			}
 		}
 	}
-	return mine, profileName, nil, nil
+	return mine, ref, nil, nil
+}
+
+// agentTail hands the tail back as the agent's, saying so for any of brig's own
+// flags in it.
+//
+// Right of the boundary brig reads nothing, and that is the surprise worth
+// naming: `brig run claude -p hi --quiet` has always run the agent with
+// --quiet and left the envelope printed, and the line reads like it asked for
+// the opposite. So brig says which token it did not read. It does not take it:
+// a line that works today has to keep working, and capturing the token would
+// change what runs rather than explain it.
+//
+// Only the tail brig ended itself. A tail after -- was declared the agent's by
+// the person typing it, and there is nothing to point out about a decision
+// already made.
+func agentTail(tail []string) []string {
+	for _, a := range tail {
+		if mine, _ := ours(a, posAny); mine {
+			name, _, _ := strings.Cut(a, "=")
+			fmt.Fprintf(os.Stderr, "brig: %s is one of brig's own flags, but here it is the "+
+				"agent's: brig stopped reading the line at the argument before it. "+
+				"Put %s before the profile for brig to read it.\n", name, name)
+		}
+	}
+	return tail
 }
 
 // rejectTail refuses a token a verb has no use for, rather than dropping it.
@@ -485,7 +664,7 @@ func rejectTail(verb string, tail []string) error {
 // whatever remains for the agent. split decides where brig's arguments end;
 // the flag package turns them into values.
 func parse(args []string) (o options, profileName string, tail []string, err error) {
-	mine, profileName, tail, err := split(args)
+	mine, ref, tail, err := split(args)
 	if err != nil {
 		return options{}, "", nil, err
 	}
@@ -504,6 +683,11 @@ func parse(args []string) (o options, profileName string, tail []string, err err
 		{"name", "n", func(n string) { fs.StringVar(&o.load.Name, n, "", "") }},
 		{"image", "t", func(n string) { fs.StringVar(&o.load.Image, n, "", "") }},
 		{"workspace", "w", func(n string) { fs.StringVar(&o.load.Workspace, n, "", "") }},
+		// Two long spellings of one value: --mem is the one the usage text
+		// gives, --memory is what it was called first. They share mem, so the
+		// last one on the line wins and the error names the one that carried
+		// the bad value.
+		{"mem", "", func(n string) { fs.Var(numberFlag{spell(n), &mem}, n, "") }},
 		{"memory", "m", func(n string) { fs.Var(numberFlag{spell(n), &mem}, n, "") }},
 		{"cpus", "", func(n string) { fs.Var(numberFlag{spell(n), &cpus}, n, "") }},
 		{"detach", "d", func(n string) { fs.BoolVar(&o.detach, n, false, "") }},
@@ -570,7 +754,23 @@ func parse(args []string) (o options, profileName string, tail []string, err err
 		}
 		o.load.Network = "offline"
 	}
-	return o, profileName, tail, nil
+	// The label is the session, so it lands where --name lands rather than
+	// becoming a second way to hold one: `brig run claude@refactor` is `brig
+	// run claude --name refactor`, and everything downstream -- the slug, the
+	// workspace, the sandbox name, the display name the agent is given -- is
+	// reached by the one path it always was.
+	//
+	// Both on one line is two different sessions asked for at once. A silent
+	// winner would run one of them with the other still written on the command,
+	// so name them and stop.
+	if ref.Label != "" {
+		if o.nameGiven {
+			return options{}, "", nil, usagef("%s names the session %q and --name names %q. "+
+				"Use one or the other", ref, ref.Label, o.load.Name)
+		}
+		o.load.Name, o.nameGiven = ref.Label, true
+	}
+	return o, ref.Agent, tail, nil
 }
 
 // number is one of brig's numeric flags as it was given: the text typed, and

--- a/internal/session/ref.go
+++ b/internal/session/ref.go
@@ -1,0 +1,101 @@
+package session
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/brig-sh/brig/internal/profile"
+)
+
+// Ref names one session on a command line: which agent, and which of that
+// agent's sessions. An empty Label is the agent's default session, so `claude`
+// and `claude@refactor` are two sessions of one agent rather than two agents.
+type Ref struct{ Agent, Label string }
+
+// refSep is the one character between the agent and its label. Exactly one:
+// see ParseRef.
+const refSep = "@"
+
+// ParseRef reads a session ref, refusing a label it would otherwise have to
+// rewrite.
+//
+// The label is not cleaned up for you, and that is the point. It reaches two
+// places that have to agree: the sandbox name, which is the profile's name
+// plus "-" plus the slug (see internal/wrap/config.go), and the workspace
+// directory the guest gets as its home. Slug is what turns a name into both,
+// and Slug truncates at maxSlug -- so a cap any longer than that would let two
+// labels differing only past character maxSlug slug the same, land on one
+// sandbox and share one home directory. Refusing the label rather than
+// truncating it is what removes that collision, instead of detecting it later
+// and asking the user to pick again.
+//
+// So the rule is: a label must already be what Slug would make of it. Below
+// the cap Slug cannot truncate, which is why the length check comes first and
+// why a single `label != Slug(label)` is then an exact test for "not
+// slug-clean" -- the character rules stay in Slug and are not restated here,
+// so the two cannot drift.
+//
+// --name is deliberately not held to this. It keeps its older, lenient
+// behaviour, truncation and the warning that names the directory it actually
+// got; the '@' form is the strict one.
+func ParseRef(s string) (Ref, error) {
+	agent, label, hasLabel := strings.Cut(s, refSep)
+	if strings.Contains(label, refSep) {
+		// Two '@' is a typo, and there is no reading of it worth guessing:
+		// taking either side would make a@b@c mean whichever half the parser
+		// happened to read first.
+		return Ref{}, fmt.Errorf("session ref %q has more than one %q. "+
+			"A ref is an agent, or an agent and one label: agent%slabel", s, refSep, refSep)
+	}
+	if agent == "" {
+		return Ref{}, fmt.Errorf("session ref %q names no agent. "+
+			"A ref begins with the agent, for example `claude%srefactor`", s, refSep)
+	}
+	if !hasLabel {
+		return Ref{Agent: agent}, nil
+	}
+	// A trailing '@' is a label the typing stopped short of, not a way to ask
+	// for the default session -- `claude` already asks for that, and reading
+	// the two the same way would hide the slip.
+	if label == "" {
+		return Ref{}, fmt.Errorf("session ref %q ends with %q and names no session. "+
+			"Drop the %q for the default session, or name one: `%s%srefactor`",
+			s, refSep, refSep, agent, refSep)
+	}
+	// Length before characters: see the doc comment. Counted in bytes because
+	// that is the budget Slug spends.
+	if len(label) > maxSlug {
+		return Ref{}, fmt.Errorf("session label %q is %d characters, and a label caps at %d. "+
+			"The label names a directory and a sandbox, so a longer one would have to be "+
+			"shortened -- and two labels shortened the same way would share one of each. "+
+			"Pick a shorter label", label, len(label), maxSlug)
+	}
+	if slug := Slug(label); slug != label {
+		if slug == "" {
+			return Ref{}, fmt.Errorf("session label %q has no usable characters. "+
+				"Labels use lowercase letters, digits, dot, dash and underscore", label)
+		}
+		return Ref{}, fmt.Errorf("session label %q is not usable as it stands: it would have to "+
+			"become %q. Labels use lowercase letters, digits, dot, dash and underscore, and "+
+			"start and end with one of those. Type %q if that is the session you want",
+			label, slug, slug)
+	}
+	// The same refusal Resolve makes, on the label. claude-desktop already
+	// owns ~/brig/claude-desktop, so claude@desktop would put a Claude Code
+	// session on the Desktop app's workspace.
+	if owner, ok := profile.Reserved(label); ok {
+		return Ref{}, fmt.Errorf("session label %q is the workspace the %s profile "+
+			"already uses. Pick another label", label, owner)
+	}
+	return Ref{Agent: agent, Label: label}, nil
+}
+
+// String writes a ref the way it is typed, so ParseRef reads back what String
+// prints. A ref with no label is the agent on its own rather than an agent
+// with a bare '@' after it, which ParseRef refuses.
+func (r Ref) String() string {
+	if r.Label == "" {
+		return r.Agent
+	}
+	return r.Agent + refSep + r.Label
+}

--- a/internal/session/ref_test.go
+++ b/internal/session/ref_test.go
@@ -1,0 +1,121 @@
+package session
+
+import (
+	"strings"
+	"testing"
+)
+
+// The refs a command line is allowed to carry, and what they parse to. A bare
+// agent is the agent's default session; the label is everything after the one
+// '@'.
+func TestParseRef(t *testing.T) {
+	cases := []struct {
+		in   string
+		want Ref
+	}{
+		{"claude", Ref{Agent: "claude"}},
+		{"claude-code", Ref{Agent: "claude-code"}},
+		{"claude@refactor", Ref{Agent: "claude", Label: "refactor"}},
+		// The label's character set is Slug's own, so everything Slug leaves
+		// alone is a label: digits, dot, dash and underscore included.
+		{"claude@my_proj", Ref{Agent: "claude", Label: "my_proj"}},
+		{"claude@v1.2", Ref{Agent: "claude", Label: "v1.2"}},
+		{"claude@a-b", Ref{Agent: "claude", Label: "a-b"}},
+		{"claude@2", Ref{Agent: "claude", Label: "2"}},
+		// Exactly at the budget, which is the boundary the refusal below sits
+		// one character past.
+		{"claude@" + strings.Repeat("a", maxSlug), Ref{Agent: "claude", Label: strings.Repeat("a", maxSlug)}},
+	}
+	for _, c := range cases {
+		got, err := ParseRef(c.in)
+		if err != nil {
+			t.Errorf("ParseRef(%q): %v", c.in, err)
+			continue
+		}
+		if got != c.want {
+			t.Errorf("ParseRef(%q) = %+v, want %+v", c.in, got, c.want)
+		}
+		// String is the spelling ParseRef reads, so every valid ref survives
+		// the round trip. Without this the two halves can drift and a ref
+		// printed by one command stops being a ref the next one accepts.
+		if s := got.String(); s != c.in {
+			t.Errorf("ParseRef(%q).String() = %q", c.in, s)
+		}
+		again, err := ParseRef(got.String())
+		if err != nil || again != got {
+			t.Errorf("ParseRef(%q.String()) = (%+v, %v), want (%+v, nil)", c.in, again, err, got)
+		}
+	}
+}
+
+// The refusals. A label is refused rather than rewritten, which is what takes
+// the collision class away: two labels that differ only in what Slug would
+// have thrown out cannot name one sandbox if neither of them parses.
+func TestParseRefRefusals(t *testing.T) {
+	for _, c := range []struct {
+		in   string
+		want string // a word the message has to carry
+	}{
+		// Empty on either side of the '@'. A trailing '@' is a label that was
+		// meant to be typed, not a way to ask for the default session.
+		{"claude@", "claude@"},
+		{"@refactor", "@refactor"},
+		{"", ""},
+		{"@", "@"},
+		// One '@' and no more: a second one is a typo, and picking a side
+		// would make `a@b@c` mean whichever side the parser happened to read.
+		{"claude@a@b", "claude@a@b"},
+		// One character past the budget.
+		{"claude@" + strings.Repeat("a", maxSlug+1), strings.Repeat("a", maxSlug+1)},
+		// Below the budget and not slug-clean: uppercase, a space, a path
+		// separator, a leading dash, a label with nothing usable in it, and a
+		// non-ASCII label.
+		{"claude@Refactor", "Refactor"},
+		{"claude@my ref", "my ref"},
+		{"claude@a/b", "a/b"},
+		{"claude@-foo", "-foo"},
+		{"claude@...", "..."},
+		{"claude@ünï", "ünï"},
+		// A label the claude-desktop profile already owns as a workspace: the
+		// same refusal Resolve makes on a --name, on the label instead.
+		{"claude@desktop", "desktop"},
+	} {
+		got, err := ParseRef(c.in)
+		if err == nil {
+			t.Errorf("ParseRef(%q) = %+v, want a refusal", c.in, got)
+			continue
+		}
+		if !strings.Contains(err.Error(), c.want) {
+			t.Errorf("ParseRef(%q): %v, want it to name %q", c.in, err, c.want)
+		}
+	}
+}
+
+// String is the ref as it is typed, and a ref with no label is the agent on
+// its own rather than an agent with an empty label bolted on.
+func TestRefString(t *testing.T) {
+	for _, c := range []struct {
+		ref  Ref
+		want string
+	}{
+		{Ref{Agent: "claude"}, "claude"},
+		{Ref{Agent: "claude", Label: "refactor"}, "claude@refactor"},
+	} {
+		if got := c.ref.String(); got != c.want {
+			t.Errorf("%+v.String() = %q, want %q", c.ref, got, c.want)
+		}
+	}
+}
+
+// The cap is Slug's own budget, not a number of its own. A longer cap would
+// let two labels that differ only past the budget slug the same, which is the
+// collision the refusal exists to remove.
+func TestRefLabelCapIsTheSlugBudget(t *testing.T) {
+	long := strings.Repeat("a", maxSlug+1)
+	if Slug(long) == long {
+		t.Fatalf("Slug no longer truncates %q, so the cap needs rereading", long)
+	}
+	if _, err := ParseRef("claude@" + long); err == nil {
+		t.Errorf("a label Slug would truncate was accepted")
+	}
+}


### PR DESCRIPTION
## Summary

Two defects with one cause, and this is the spine the rest of #47 consumes.

**brig's flags had no position.** `split` decided where brig's arguments ended from a single
piece of state -- have I seen the profile name yet -- so brig's own flags were legal on both
sides of it, and there was nowhere a global flag could stand at all. `brig --json run claude`
reported a command that does not exist, and `brig run claude --json` handed `--json` to an agent
that does not have it.

**A session had no identifier.** `--name` goes through `Slug`, which sanitises the name and then
truncates it. Truncation is why two different names can slug onto one sandbox, why
`EnsureRunning` needs `claimSlug` to refuse the collision, and why a run has to print which
directory it actually got.

Nothing is renamed here and no command line that works today changes behaviour.

## Related issues

Fixes #108. Part of #47, where this is the spine eight other sub-issues sit behind.

**Stacked on #113** -- the base is `refactor/112-brigd-sandbox-field`, so GitHub retargets this
to `main` once #113 merges. Review #113 first.

Deliberately excluded: #114, the label cap raise. It was written, then cut from this branch and
preserved on `feat/114-label-cap-20`, because it re-derives the sandbox name and guest home of
every existing long-named session and needs a migration warning of its own rather than riding
along inside a parser change.

## Changes

- `session.Ref` and `ParseRef`, in the package that already owns `Slug`, `Resolve` and the
  reserved-name refusal. A label must already be what `Slug` would make of it: the length check
  runs first, and below the cap `Slug` cannot truncate, so a single `label != Slug(label)` is
  then an exact test for "not slug-clean" -- the character rules stay in `Slug` and are not
  restated, so the two cannot drift.
- The cap is `maxSlug`, referenced through the constant. A longer cap would let two labels
  differing only past that character slug the same and share one sandbox and one guest home,
  which is the collision the refusal exists to remove.
- `brigFlags` carries the position a flag is legal in, and `ours` answers "mine, and legal
  here?". The zero value is no position, so a new entry has to say which one it means -- both
  wrong defaults are silent.
- The global position, left of the verb, is established **closed and empty**. A flag written
  there is a usage error naming the token; #24, #11, #30 and #110 are what put flags in it.
- `split` is keyed on whether the ref has been passed and returns a `session.Ref`. The label
  lands on the same path `--name` lands on, so `brig run claude@refactor` is
  `brig run claude --name refactor`. Both spellings on one line ask for two sessions at once and
  are refused by name.
- Right of the ref brig still answers to its own flags, because `brig run claude -q` is a line
  that works today. Once an unknown token has ended brig's reading, a brig flag further along is
  the agent's -- and brig now says so **without taking the token**, so every line that works
  today keeps working. Nothing is said after an explicit `--`.
- `--mem` joins `--memory`, both accepted. `-t` and `-m` keep working and print the one-line
  notice naming `--image` and `--mem`, which is the window #47 sets: v0.2 ships both grammars,
  v0.3 removes the short forms. `-n` and `-w` are the other two and retire with #5 and #6.
- The `usage` text follows: `--image` and `--mem` replace the short spellings, and the `--name`
  entry names the `<profile>@<label>` form.

**README is knowingly left stale by this PR.** Lines 144 and 146 still document
`-t, --image` and `-m, --memory`, and the `@label` form appears nowhere in it. The full docs
rewrite is #111; flagging it here so a reviewer is not misled into thinking the table is current.

## Manual testing

Every parsing path can be exercised without booting a sandbox, because parsing happens before
brig looks for a runtime -- so `runtime unavailable: unknown BRIG_RUNTIME` is a pass:

```
export BRIG_RUNTIME=nosuchruntime BRIG_PROFILE_DIR=$(mktemp -d)

brig run claude@                      # refuses: ends with "@" and names no session
brig run @refactor                    # refuses: names no agent
brig run claude@a@b                   # refuses: more than one "@"
brig run claude@Refactor              # refuses: would have to become "refactor"
brig run claude@my-really-long-label  # refuses: 20 characters, caps at 10
brig run claude@desktop               # refuses: the claude-desktop profile owns it
brig run claude@one --name two        # refuses: two spellings, one session

brig --json run claude                # refuses: unknown flag before the command
brig run --mem 2048 claude            # accepts; --memory still accepted too
brig run -t img claude                # warns: `-t` is now `--image`

brig run claude -q                    # silent: still brig's own flag
brig run claude -p hi --quiet         # warns --quiet is the agent's, forwards it anyway
brig run claude -- --quiet            # silent: the line already said the rest is the agent's
```

The check worth making deliberately: in every warned case the agent must still **receive** the
token. A warning that quietly captured it would break the lines this design exists to protect.

## Checklist

- [x] `make all` passes (vet, test, build)
- [ ] `script/smoke.sh` passes
- [x] I have added or updated tests covering the change
- [x] I have run `go test ./... -race`, if the change touches concurrency, subprocesses or the daemon
- [x] I have exercised the change against a real runtime (`brig run <agent>`), if it touches the run, exec or credential path
- [ ] I have updated the affected docs (README, `docs/security.md`, `docs/profiles.md`, `docs/brigd.md`)

Three of those need saying rather than ticking:

**Real runtime**: not booted. This does touch the run path, so the box applies and is honestly
unticked -- every check above was made at the parse level with the runtime stubbed out. A boot
pass under a ref (`brig run -d claude@shake`, `brig ls`, `brig stop`, `brig rm`) is still worth
doing before merge.

**Docs**: `usage` in `cmd/brig/main.go` is updated; README is not, as described above.

## Credentials and the sandbox boundary

This narrows the boundary rather than widening it, and that is most of the point. `ParseRef`
refuses a label that `Slug` would have to rewrite, which removes the case where two different
labels shorten onto one sandbox name and one guest home -- two sessions sharing one directory.
`claimSlug` still catches it for `--name`, which keeps its lenient behaviour; for a ref the case
can no longer arise. No new mount, no new forwarded variable, no new host path the guest can
reach.

## LLM usage

Authored with assistance from Claude Code (Opus 5), which produced the implementation, the commit
messages and this description. Verification was re-run independently of the agent that wrote the
change, from a frozen tree: `gofmt`, `make all`, a forced uncached `-race` run over
`cmd/brig`, `internal/session` and `internal/wrap`, and the smoke comparison against `85dee40`.
Every expected output in the Manual testing section was captured from the built binary rather
than read off the source. Accountability for every line remains the author's.
