### PR TITLE
feat(wrap): key the session index by ref

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,10 +232,16 @@ included, leaving all workspaces alone.
 
 **`-w` is remembered.** A session created with `--workspace` keeps that
 directory for every later verb, so `brig exec claude --name refactor -- ls`
-finds it without repeating the flag. brig records the path a sandbox was
-started with under `~/.brig`, and reads it back when neither `--workspace` nor
-`BRIG_WORKSPACE` names one; `brig rm` and `brig reset` drop the entry with the
-sandbox. Pass either of them a directory that is not the one the sandbox is
+finds it without repeating the flag. brig records it in
+`~/.brig/sessions.json`, filed under the session's ref, and reads it back when
+neither `--workspace` nor `BRIG_WORKSPACE` names one; `brig rm` and `brig reset`
+drop the entry with the sandbox, and `brig ls` drops any whose sandbox has gone.
+
+That file is an index and not a record of the truth: the runtime stays the
+authority on what is actually mounted, and an unreadable index costs one restart
+rather than failing the command. Because it is filed under the ref, a session is
+found under either spelling of its agent -- `claude` and `claude-code` are one
+agent through an alias, and both reach the one entry. Pass either of them a directory that is not the one the sandbox is
 mounting and it restarts, as it always has -- a share cannot be moved on a
 running guest, and you asked for a different directory.
 

--- a/cmd/brig/main.go
+++ b/cmd/brig/main.go
@@ -895,6 +895,10 @@ func listSandboxes(args []string) error {
 	if err != nil {
 		return err
 	}
+	// The one verb that knows what the runtime actually has, so the one place
+	// an entry for a sandbox that went away without going through `brig rm`
+	// can be dropped. See wrap.PruneSessions.
+	pruneSessionIndex(list)
 	sort.Slice(list, func(i, j int) bool { return list[i].Name < list[j].Name })
 	rows := make([]sandboxRow, 0, len(list))
 	for _, inst := range list {
@@ -912,6 +916,20 @@ func listSandboxes(args []string) error {
 		fmt.Println("(none -- `brig run claude` starts one)")
 	}
 	return nil
+}
+
+// pruneSessionIndex hands the session index every instance the runtime has, so
+// that an entry naming a sandbox that is not among them goes.
+//
+// Every instance and not only brig's own: a sandbox brig would not recognise
+// still exists, and the question the index is asking is whether the sandbox is
+// there at all.
+func pruneSessionIndex(list []runtime.Instance) {
+	live := make([]string, 0, len(list))
+	for _, inst := range list {
+		live = append(live, inst.Name)
+	}
+	wrap.PruneSessions(live)
 }
 
 // sandboxRow is one line of the listing, gathered before anything is printed
@@ -955,7 +973,7 @@ func printSandboxes(w io.Writer, rows []sandboxRow) {
 // name, and reporting the derived one was reporting the wrong directory with
 // no sign that it was wrong.
 func workspaceOf(vmName string, rt runtime.Runtime) string {
-	if ws := wrap.RememberedWorkspace(vmName); ws != "" {
+	if ws := wrap.WorkspaceOfSandbox(vmName); ws != "" {
 		return ws
 	}
 	rest := strings.TrimPrefix(vmName, sandboxPrefix)
@@ -1018,8 +1036,8 @@ func reset(args []string) error {
 		// terms: this goes through the runtime directly rather than through a
 		// Config, because reset works from the instance list and a stopped
 		// sandbox need not correspond to a profile brig can still look up.
-		wrap.ForgetWorkspace(inst.Name)
-		wrap.ForgetSession(inst.Name)
+		wrap.ForgetSandbox(inst.Name)
+		wrap.ForgetSlugClaim(inst.Name)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "brig: could not remove %s: %v\n", inst.Name, err)
 			continue

--- a/cmd/brig/main_test.go
+++ b/cmd/brig/main_test.go
@@ -8,6 +8,8 @@ import (
 	"testing"
 
 	"github.com/brig-sh/brig/internal/profile"
+	"github.com/brig-sh/brig/internal/runtime"
+	"github.com/brig-sh/brig/internal/wrap"
 )
 
 // The registry is built at run time now rather than being a package-level
@@ -336,8 +338,11 @@ func TestWorkspaceOfPrefersTheRecordedWorkspace(t *testing.T) {
 	t.Setenv("BRIG_STATE_DIR", dir)
 	t.Setenv("BRIG_WORKSPACE", "/somewhere/else")
 
-	index := filepath.Join(dir, "workspaces.json")
-	body := `{"brig-claude-code-rc23test": "/private/tmp/ws-rc23"}`
+	// Keyed by the ref, and the sandbox is in the value: the listing has a
+	// sandbox name in hand and no ref, so this is the direction it reads.
+	index := filepath.Join(dir, "sessions.json")
+	body := `{"claude-code@rc23test":` +
+		`{"home": "/private/tmp/ws-rc23", "sandbox": "brig-claude-code-rc23test"}}`
 	if err := os.WriteFile(index, []byte(body), 0o600); err != nil {
 		t.Fatal(err)
 	}
@@ -354,6 +359,39 @@ func TestWorkspaceOfPrefersTheRecordedWorkspace(t *testing.T) {
 	}
 	if got := workspaceOf("brig-claude-code", nil); got != "/somewhere/else" {
 		t.Errorf("ls reported %q for an unrecorded sandbox, want the derived path", got)
+	}
+}
+
+// `brig ls` is where brig learns that a sandbox went away without going
+// through `brig rm` -- removed with the runtime's own CLI, say -- so it is
+// where the index is pruned. An entry whose sandbox is still listed stays,
+// stopped or not: a stopped sandbox is the same session, and its home is where
+// the work is.
+func TestListingPrunesTheSessionsWhoseSandboxIsGone(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("BRIG_STATE_DIR", dir)
+
+	index := filepath.Join(dir, "sessions.json")
+	body := `{` +
+		`"claude-code@kept": {"home": "/ws/kept", "sandbox": "brig-claude-code-kept"},` +
+		`"claude-code@gone": {"home": "/ws/gone", "sandbox": "brig-claude-code-gone"}}`
+	if err := os.WriteFile(index, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	// What the runtime lists: the stopped sandbox brig still has, and one
+	// container of somebody else's, which is why the prune is handed the whole
+	// list rather than brig's own share of it.
+	pruneSessionIndex([]runtime.Instance{
+		{Name: "brig-claude-code-kept", State: "stopped"},
+		{Name: "some-other-container", State: "running"},
+	})
+
+	if got := wrap.WorkspaceOfSandbox("brig-claude-code-kept"); got != "/ws/kept" {
+		t.Errorf("ls pruned a session whose sandbox it just listed: %q", got)
+	}
+	if got := wrap.WorkspaceOfSandbox("brig-claude-code-gone"); got != "" {
+		t.Errorf("ls kept %q for a sandbox the runtime does not have", got)
 	}
 }
 

--- a/internal/wrap/config.go
+++ b/internal/wrap/config.go
@@ -197,8 +197,8 @@ func Load(t profile.Profile, o Options, rt runtime.Runtime) (*Config, error) {
 		return nil, fmt.Errorf("cannot determine the current directory: %w", err)
 	}
 
-	// The sandbox name is settled first because the workspace may be read back
-	// from an index keyed by it. See index.go.
+	// The sandbox name is settled first because the entry read back below is
+	// only good for the sandbox it was recorded against. See index.go.
 	vmName := env.String("NAME", NamePrefix+t.Name)
 	// BRIG_NAME replaces the whole sandbox name, and brig finds its own
 	// sandboxes by the brig- prefix: ls lists what carries it and reset removes
@@ -253,8 +253,12 @@ func Load(t profile.Profile, o Options, rt runtime.Runtime) (*Config, error) {
 	// every flagless verb takes that for a stale share and restarts it -- see
 	// index.go. The suffix is not reapplied: what was recorded is the workspace
 	// as it was finally resolved, slug and all.
+	//
+	// Looked up by ref, which is the profile as it resolved and the slug, so
+	// the entry a run under one spelling of the profile wrote is the entry a
+	// run under its alias reads. Both halves of the key are in hand here.
 	if !given {
-		if remembered := RememberedWorkspace(vmName); remembered != "" {
+		if remembered := rememberedWorkspace(sessionKey(t.Name, slug), vmName); remembered != "" {
 			workspace = remembered
 		}
 	}

--- a/internal/wrap/index.go
+++ b/internal/wrap/index.go
@@ -5,9 +5,13 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+
+	"github.com/brig-sh/brig/internal/session"
 )
 
-// The workspace index: the host directory each sandbox was started with.
+// The session index: what brig has to remember about a session between one
+// invocation and the next, which today is the host directory its sandbox was
+// started with.
 //
 // Every invocation resolves the workspace from scratch -- --workspace, then
 // BRIG_WORKSPACE, then ~/brig/<profile>-<name> -- and EnsureRunning compares
@@ -25,6 +29,34 @@ import (
 // --workspace or BRIG_WORKSPACE still wins -- asking for a different directory
 // is something a user is entitled to do, restart and all.
 //
+// Keyed by the ref: agent@label, and the bare agent for a session that has no
+// label, built from the resolved profile name and the slug. Three things
+// follow from that key, and none of them from the sandbox name this file used
+// to be keyed by:
+//
+//   - A sandbox name cannot be read back. brig-claude-code-refactor is a
+//     refactor session of claude-code and equally the default session of a
+//     profile called claude-code-refactor, and the dash between them cannot
+//     say which. A ref keeps the two apart, because '@' is only ever the one
+//     separator.
+//   - The resolved profile name, so an alias finds one entry: `brig run claude`
+//     and `brig run claude-code` are one profile, and a session started under
+//     either spelling is the entry the other one reads.
+//   - The slug rather than the name as typed, because --name is lenient and
+//     Slug sanitises what it is handed, so the raw name is not a stable
+//     identifier. The slug is what actually names the sandbox and the home.
+//
+// The value is the home and the sandbox: what the session is, and which
+// instance is carrying it just now. Both directions are read -- the home by
+// ref, which is what a flagless verb needs, and the home by sandbox name,
+// which is all `brig ls` and `brig reset` have in hand.
+//
+// Nothing is migrated out of the sandbox-keyed workspaces.json this replaces.
+// Deriving a ref from its keys is precisely the ambiguity above, so a migration
+// would have to guess; the file is deleted on sight instead and each session in
+// it costs one restart, which is what an absent entry has always cost and which
+// is safe because everything persistent lives in the workspace on the host.
+//
 // It lives beside gateway-ips.json, which is the same kind of file for the
 // same kind of reason: small per-sandbox bookkeeping that has to outlive one
 // invocation. Deliberately not a record inside the workspace itself, which
@@ -34,12 +66,37 @@ import (
 //
 // Two brig processes recording at once can lose one of the two entries, since
 // each reads the file, edits its own key and writes the whole map back. The
-// cost is one restart for whichever sandbox lost, which is the cost of not
+// cost is one restart for whichever session lost, which is the cost of not
 // having the index at all -- worth less than a lock file on the path every
 // boot takes.
 
-// workspaceIndexName is the file, inside stateDir.
-const workspaceIndexName = "workspaces.json"
+// sessionIndexName is the file, inside stateDir. legacyWorkspaceIndexName is
+// the sandbox-keyed file it replaces, kept as a name only so it can be
+// deleted; see dropLegacyWorkspaceIndex.
+const (
+	sessionIndexName         = "sessions.json"
+	legacyWorkspaceIndexName = "workspaces.json"
+)
+
+// sessionEntry is what the index records about one session.
+//
+// Home is the guest's home directory on the host -- the same path the run
+// calls the workspace. It is named for what it is to the session rather than
+// for the flag that supplies it, because it is the directory that makes the
+// session the session: an entry with a different home is a different session,
+// and #6 adds the per-run project mount beside it, which is not.
+//
+// Sandbox is the instance carrying the session at the moment, which is the
+// part that is not identity: it is removed and recreated by an ordinary
+// restart. It is here because `brig ls` and `brig reset` work from the
+// runtime's instance list and have no ref to look up -- see WorkspaceOfSandbox
+// and ForgetSandbox -- and because it is what tells an entry about the sandbox
+// this invocation is addressing from one about a differently named sandbox of
+// the same session. See rememberedWorkspace.
+type sessionEntry struct {
+	Home    string `json:"home"`
+	Sandbox string `json:"sandbox"`
+}
 
 // stateDir is where brig keeps what has to outlive a single invocation.
 // BRIG_STATE_DIR moves it, which is what lets a test run without writing into
@@ -64,15 +121,23 @@ func indexPath(name string) (string, error) {
 	return filepath.Join(dir, name), nil
 }
 
-// readIndex returns the string map recorded under name, and an empty one for
-// every way the read can fail.
+// readIndex returns the map recorded under name, and an empty one for every
+// way the read can fail.
+//
+// Generic in the value rather than duplicated per file: the tolerant read and
+// the atomic write below are the whole reason these files behave the same way
+// as each other, and two copies of them would be two chances for one file to
+// stop being atomic or stop being tolerant. The session index records a
+// struct and the slug-claim index a string; nothing else differs.
 //
 // A file that is missing, unreadable or corrupt is not worth failing a command
 // over: at worst an absent entry costs one restart, which is exactly the
 // behaviour of the release before these files existed. Failing instead would
-// make a stray file in ~/.brig able to stop every brig command on the host.
-func readIndex(name string) map[string]string {
-	index := map[string]string{}
+// make a stray file in ~/.brig able to stop every brig command on the host. A
+// file of the wrong shape for V -- an older release's index under a name this
+// one has reused -- is corrupt in exactly that sense and reads as empty too.
+func readIndex[V any](name string) map[string]V {
+	index := map[string]V{}
 	path, err := indexPath(name)
 	if err != nil {
 		return index
@@ -82,13 +147,13 @@ func readIndex(name string) map[string]string {
 		return index
 	}
 	if err := json.Unmarshal(blob, &index); err != nil {
-		return map[string]string{}
+		return map[string]V{}
 	}
 	return index
 }
 
 // writeIndex replaces the file named name with the map it is given.
-func writeIndex(name string, index map[string]string) error {
+func writeIndex[V any](name string, index map[string]V) error {
 	path, err := indexPath(name)
 	if err != nil {
 		return err
@@ -120,45 +185,138 @@ func writeIndex(name string, index map[string]string) error {
 	return os.Rename(tmp.Name(), path)
 }
 
-// readWorkspaceIndex and writeWorkspaceIndex are the workspace index's names
-// for the shared read and write above.
-func readWorkspaceIndex() map[string]string { return readIndex(workspaceIndexName) }
-func writeWorkspaceIndex(index map[string]string) error {
-	return writeIndex(workspaceIndexName, index)
+// readSessionIndex and writeSessionIndex are the session index's names for the
+// shared read and write above.
+func readSessionIndex() map[string]sessionEntry {
+	return readIndex[sessionEntry](sessionIndexName)
 }
 
-// RememberedWorkspace is the workspace a sandbox was started with, or "" when
-// nothing has been recorded for it -- a sandbox created before this index
-// existed, or one whose entry has been pruned.
+func writeSessionIndex(index map[string]sessionEntry) error {
+	return writeIndex(sessionIndexName, index)
+}
+
+// dropLegacyWorkspaceIndex deletes the sandbox-keyed file this index replaces.
 //
-// Exported for the two callers outside a run: `brig ls`, which reports the
-// directory a running sandbox actually has rather than the one its name would
-// derive, and anything that has a sandbox name and no Config.
-func RememberedWorkspace(vmName string) string {
-	return readWorkspaceIndex()[vmName]
+// On sight rather than on upgrade, because brig has no upgrade step to hang it
+// on: it is called from the two paths that already touch the state directory
+// on an ordinary command, recording a session and listing the sandboxes. Its
+// absence is the normal case -- a host that never ran the older release, or one
+// that has already been past here -- so a failed removal is dropped like the
+// rest of the bookkeeping and the only cost of it is a stale file nobody reads.
+func dropLegacyWorkspaceIndex() {
+	path, err := indexPath(legacyWorkspaceIndexName)
+	if err != nil {
+		return
+	}
+	_ = os.Remove(path)
 }
 
-// ForgetWorkspace drops a removed sandbox's entry, so the next sandbox to take
-// that name starts from the ordinary resolution rather than inheriting a
-// directory chosen for a different one.
+// sessionKey is how a session is filed: its ref, from the resolved profile
+// name and the slug. One function so the two callers that build it -- Load,
+// which looks an entry up before there is a Config, and rememberSession, which
+// writes it -- cannot spell the key two ways.
+func sessionKey(agent, slug string) string {
+	return session.Ref{Agent: agent, Label: slug}.String()
+}
+
+// rememberedWorkspace is the workspace the sandbox of this session was started
+// with, or "" when nothing usable has been recorded -- a session created
+// before this index existed, one whose entry has been pruned, or one recorded
+// against a different sandbox.
+//
+// The sandbox has to agree because BRIG_NAME renames the sandbox without
+// changing the ref: the same profile and slug under two sandbox names are two
+// instances, and handing one the directory recorded for the other is the stale
+// share this file exists to avoid.
+func rememberedWorkspace(ref, vmName string) string {
+	entry := readSessionIndex()[ref]
+	if entry.Sandbox != vmName {
+		return ""
+	}
+	return entry.Home
+}
+
+// WorkspaceOfSandbox is the workspace recorded for whichever session is
+// carrying this sandbox, or "" when none is.
+//
+// The other direction of the same lookup, exported for the callers that have a
+// sandbox name and no ref: `brig ls`, which reports the directory a running
+// sandbox actually has rather than the one its name would derive. A sandbox
+// carries one session, so the first entry naming it is the only one -- two
+// refs pointing at one sandbox takes a BRIG_NAME that overrides the sandbox
+// name of both, and a listing could not tell those apart whatever it did here.
+func WorkspaceOfSandbox(vmName string) string {
+	for _, entry := range readSessionIndex() {
+		if entry.Sandbox == vmName {
+			return entry.Home
+		}
+	}
+	return ""
+}
+
+// ForgetSandbox drops the entry of the session carrying a removed sandbox, so
+// the next session to take that name starts from the ordinary resolution
+// rather than inheriting a directory chosen for a different one.
 //
 // Errors are dropped rather than returned, the way releaseGatewayIP drops its
 // own: a removal that worked must not report a failure because a bookkeeping
 // file could not be rewritten.
-func ForgetWorkspace(vmName string) {
-	index := readWorkspaceIndex()
-	if _, ok := index[vmName]; !ok {
+func ForgetSandbox(vmName string) {
+	index := readSessionIndex()
+	dropped := false
+	for key, entry := range index {
+		if entry.Sandbox == vmName {
+			delete(index, key)
+			dropped = true
+		}
+	}
+	if !dropped {
 		return
 	}
-	delete(index, vmName)
-	_ = writeWorkspaceIndex(index)
+	_ = writeSessionIndex(index)
 }
 
-// rememberWorkspace records the directory this sandbox has just been started
-// with, so a later invocation that names none finds it again.
+// PruneSessions drops every entry whose sandbox is not in the list of what the
+// runtime has.
+//
+// `brig ls` is where this runs, because it is the one verb that asks the
+// runtime what exists and so the one place brig learns that a sandbox went
+// away without going through Remove -- removed with the runtime's own CLI, or
+// lost with a runtime that was reinstalled. The cost of being wrong is small
+// in the direction that matters: a list that came back short prunes an entry
+// that was still good, and the session pays one restart for it.
+//
+// Called with every instance the runtime lists rather than only brig's own, so
+// that a sandbox brig would not recognise still counts as present.
+func PruneSessions(live []string) {
+	dropLegacyWorkspaceIndex()
+	index := readSessionIndex()
+	if len(index) == 0 {
+		return
+	}
+	have := make(map[string]bool, len(live))
+	for _, name := range live {
+		have[name] = true
+	}
+	dropped := false
+	for key, entry := range index {
+		if !have[entry.Sandbox] {
+			delete(index, key)
+			dropped = true
+		}
+	}
+	if !dropped {
+		return
+	}
+	_ = writeSessionIndex(index)
+}
+
+// rememberSession records what this run has just started: the ref it is filed
+// under, the directory the sandbox was given as its home, and the sandbox
+// carrying it.
 //
 // Also called when the running sandbox already matches, which is what fills
-// the index in for a sandbox created before it existed: the entry is written
+// the index in for a session created before it existed: the entry is written
 // once, and every invocation after that is a read.
 //
 // A failure to write is a warning rather than an error. The sandbox is up and
@@ -166,13 +324,16 @@ func ForgetWorkspace(vmName string) {
 // succeeded over the note about it -- but the cost lands later and nowhere
 // near this line, on some flagless verb that restarts the sandbox, so it is
 // worth saying out loud where the reason is still visible.
-func (c *Config) rememberWorkspace() {
-	index := readWorkspaceIndex()
-	if index[c.VMName] == c.Workspace {
+func (c *Config) rememberSession() {
+	dropLegacyWorkspaceIndex()
+	key := sessionKey(c.Profile.Name, c.Slug)
+	entry := sessionEntry{Home: c.Workspace, Sandbox: c.VMName}
+	index := readSessionIndex()
+	if index[key] == entry {
 		return
 	}
-	index[c.VMName] = c.Workspace
-	if err := writeWorkspaceIndex(index); err != nil {
+	index[key] = entry
+	if err := writeSessionIndex(index); err != nil {
 		c.warnf("could not record %s as the workspace of %s (%v). A later command "+
 			"that names no workspace will fall back to the default one and restart "+
 			"the sandbox.", c.Workspace, c.VMName, err)

--- a/internal/wrap/index.go
+++ b/internal/wrap/index.go
@@ -136,6 +136,11 @@ func indexPath(name string) (string, error) {
 // make a stray file in ~/.brig able to stop every brig command on the host. A
 // file of the wrong shape for V -- an older release's index under a name this
 // one has reused -- is corrupt in exactly that sense and reads as empty too.
+//
+// The nil check is the one corrupt file the unmarshal accepts: the JSON
+// literal null parses without error and leaves the map nil, which would be a
+// panic at the first write rather than an empty read -- a louder version of
+// the failure this tolerance exists to avoid.
 func readIndex[V any](name string) map[string]V {
 	index := map[string]V{}
 	path, err := indexPath(name)
@@ -146,7 +151,7 @@ func readIndex[V any](name string) map[string]V {
 	if err != nil {
 		return index
 	}
-	if err := json.Unmarshal(blob, &index); err != nil {
+	if err := json.Unmarshal(blob, &index); err != nil || index == nil {
 		return map[string]V{}
 	}
 	return index

--- a/internal/wrap/index_test.go
+++ b/internal/wrap/index_test.go
@@ -382,6 +382,44 @@ func TestAnUnusableIndexIsIgnoredRatherThanFatal(t *testing.T) {
 	}
 }
 
+// The JSON literal `null` is the one corrupt file the unmarshal accepts: it
+// parses without error and leaves the map nil, so a reader that only checks
+// the error hands back a map that cannot be written to. Both writes above are
+// then a panic -- which is a louder version of exactly the failure the
+// tolerant read exists to avoid, since a stray file in ~/.brig would stop
+// every brig command on the host.
+func TestAnIndexHoldingJSONNullIsIgnoredRatherThanFatal(t *testing.T) {
+	dir := isolateState(t)
+
+	for _, name := range []string{sessionIndexName, slugClaimIndexName} {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte("null\n"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// The read itself, which is where the nil would come from.
+	if index := readSessionIndex(); index == nil {
+		t.Error("a session index holding null read back as a nil map")
+	}
+	if index := readIndex[string](slugClaimIndexName); index == nil {
+		t.Error("a claim index holding null read back as a nil map")
+	}
+
+	// And the two writes that would take the nil, which is where the cost of
+	// it actually lands.
+	c := mustLoad(t, Options{Name: "rc23test"})
+	c.rememberSession()
+	if got := WorkspaceOfSandbox(c.VMName); got != c.Workspace {
+		t.Errorf("the session was recorded as %q, want %q", got, c.Workspace)
+	}
+	if err := c.claimSlug(); err != nil {
+		t.Errorf("the claim over a null index was refused: %v", err)
+	}
+	if got := readIndex[string](slugClaimIndexName)[c.VMName]; got != c.RawName {
+		t.Errorf("the sandbox was claimed by %q, want %q", got, c.RawName)
+	}
+}
+
 // Every entry survives a write, so recording one session does not cost another
 // its own -- the file is read, edited and written back whole.
 func TestRecordingOneSessionKeepsTheOthers(t *testing.T) {

--- a/internal/wrap/index_test.go
+++ b/internal/wrap/index_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"testing"
 
@@ -35,14 +36,15 @@ func isolateState(t *testing.T) string {
 	return dir
 }
 
-// mustLoad resolves one invocation the way the command line does. These cases
-// go through Load rather than building a Config, because the resolution order
-// is the thing being tested.
-func mustLoad(t *testing.T, o Options) *Config {
+// mustLoadAs resolves one invocation of the profile a spelling reaches. The
+// spelling is a parameter because `claude` and `claude-code` are one profile
+// through an alias, and a session started under either has to be found under
+// the other.
+func mustLoadAs(t *testing.T, agent string, o Options) *Config {
 	t.Helper()
-	p, ok := profile.Lookup("claude-code")
+	p, ok := profile.Lookup(agent)
 	if !ok {
-		t.Fatal("the claude-code profile is not loaded")
+		t.Fatalf("the %s profile is not loaded", agent)
 	}
 	c, err := Load(p, o, nil)
 	if err != nil {
@@ -51,15 +53,40 @@ func mustLoad(t *testing.T, o Options) *Config {
 	return c
 }
 
+// mustLoad resolves one invocation the way the command line does. These cases
+// go through Load rather than building a Config, because the resolution order
+// is the thing being tested.
+func mustLoad(t *testing.T, o Options) *Config {
+	t.Helper()
+	return mustLoadAs(t, "claude-code", o)
+}
+
+// indexKeys is what the file on disk is keyed by, sorted so a case can name
+// the keys it expects rather than one of several orders.
+func indexKeys(t *testing.T) []string {
+	t.Helper()
+	index := readSessionIndex()
+	keys := make([]string, 0, len(index))
+	for key := range index {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
 // removingRuntime answers the two calls Remove makes and nothing else:
 // anything further panics through the embedded nil interface, which is louder
 // than a stub that quietly succeeds.
 type removingRuntime struct {
 	runtime.Runtime
 	removed []string
+	stopped []string
 }
 
-func (r *removingRuntime) Stop(string) error { return nil }
+func (r *removingRuntime) Stop(name string) error {
+	r.stopped = append(r.stopped, name)
+	return nil
+}
 
 func (r *removingRuntime) Remove(name string) error {
 	r.removed = append(r.removed, name)
@@ -82,7 +109,7 @@ func TestAWorkspaceGivenOnceIsFoundAgainWithoutTheFlag(t *testing.T) {
 	if created.Workspace != ws {
 		t.Fatalf("--workspace resolved to %q, want %q", created.Workspace, ws)
 	}
-	created.rememberWorkspace()
+	created.rememberSession()
 
 	next := mustLoad(t, Options{Name: "rc23test"})
 	if next.VMName != created.VMName {
@@ -103,7 +130,7 @@ func TestAnExplicitWorkspaceBeatsTheRememberedOne(t *testing.T) {
 	remembered, other := t.TempDir(), t.TempDir()
 
 	created := mustLoad(t, Options{Name: "rc23test", Workspace: remembered})
-	created.rememberWorkspace()
+	created.rememberSession()
 
 	byFlag := mustLoad(t, Options{Name: "rc23test", Workspace: other})
 	if want := other + "-rc23test"; byFlag.Workspace != want {
@@ -120,7 +147,8 @@ func TestAnExplicitWorkspaceBeatsTheRememberedOne(t *testing.T) {
 }
 
 // An unnamed run records and reads back its own entry too: the default
-// workspace is one a flag can override just as well.
+// workspace is one a flag can override just as well. Its ref has no label, so
+// it is filed under the bare agent name.
 func TestTheUnnamedSandboxIsRememberedToo(t *testing.T) {
 	isolateState(t)
 	ws := t.TempDir()
@@ -129,36 +157,122 @@ func TestTheUnnamedSandboxIsRememberedToo(t *testing.T) {
 	if created.VMName != "brig-claude-code" {
 		t.Fatalf("the unnamed sandbox is %q", created.VMName)
 	}
-	created.rememberWorkspace()
+	created.rememberSession()
 
+	if got := indexKeys(t); len(got) != 1 || got[0] != "claude-code" {
+		t.Errorf("the unnamed session is filed under %v, want [claude-code]", got)
+	}
 	if got := mustLoad(t, Options{}).Workspace; got != ws {
 		t.Errorf("a flagless verb resolved %q, want %q", got, ws)
 	}
 }
 
-// `brig rm` drops the entry, so the next sandbox to take the name resolves its
-// workspace the ordinary way rather than inheriting a directory chosen for a
-// sandbox that is gone.
-func TestRemoveDropsTheEntry(t *testing.T) {
+// The key is a ref, so the label is what separates the sessions of one agent.
+// A bare agent name and a labelled ref are two entries and two homes: reading
+// either as the other would hand a labelled session the default one's home.
+func TestABareAgentDoesNotCollideWithALabelledSession(t *testing.T) {
+	isolateState(t)
+	bare, labelled := t.TempDir(), t.TempDir()
+
+	mustLoad(t, Options{Workspace: bare}).rememberSession()
+	mustLoad(t, Options{Name: "rc23test", Workspace: labelled}).rememberSession()
+
+	want := []string{"claude-code", "claude-code@rc23test"}
+	got := indexKeys(t)
+	if len(got) != len(want) || got[0] != want[0] || got[1] != want[1] {
+		t.Fatalf("the index is keyed %v, want %v", got, want)
+	}
+	if got := mustLoad(t, Options{}).Workspace; got != bare {
+		t.Errorf("the default session resolved %q, want %q", got, bare)
+	}
+	if got, want := mustLoad(t, Options{Name: "rc23test"}).Workspace, labelled+"-rc23test"; got != want {
+		t.Errorf("the labelled session resolved %q, want %q", got, want)
+	}
+}
+
+// `brig run claude` and `brig run claude-code` are one profile through an
+// alias, so a session started under either spelling has to be the entry the
+// other one finds -- one entry, not two homes that drift apart.
+func TestAnAliasFindsTheSameEntry(t *testing.T) {
+	isolateState(t)
+	base := t.TempDir()
+	ws := base + "-refactor"
+
+	mustLoadAs(t, "claude", Options{Name: "refactor", Workspace: base}).rememberSession()
+
+	// The key is the resolved profile name rather than the token that was
+	// typed, which is what makes this one entry.
+	if got := indexKeys(t); len(got) != 1 || got[0] != "claude-code@refactor" {
+		t.Fatalf("the index is keyed %v, want [claude-code@refactor]", got)
+	}
+	for _, agent := range []string{"claude", "claude-code"} {
+		if got := mustLoadAs(t, agent, Options{Name: "refactor"}).Workspace; got != ws {
+			t.Errorf("addressed as %s, a flagless verb resolved %q, want %q", agent, got, ws)
+		}
+	}
+
+	// And recording again under the other spelling stays one entry, so the two
+	// spellings cannot end up with a home each.
+	mustLoadAs(t, "claude-code", Options{Name: "refactor"}).rememberSession()
+	if got := indexKeys(t); len(got) != 1 {
+		t.Errorf("recording under the other spelling left %v", got)
+	}
+}
+
+// --name is lenient where a ref is strict: it accepts a name that is not
+// slug-clean and Slug sanitises it, so the raw name is not a stable
+// identifier. The slug is what names the sandbox and the home, so it is what
+// the entry is filed under.
+func TestTheKeyIsTheSlugAndNotTheNameAsTyped(t *testing.T) {
+	isolateState(t)
+	base := t.TempDir()
+
+	created := mustLoad(t, Options{Name: "RC23 Test", Workspace: base})
+	if created.Slug != "rc23-test" {
+		t.Fatalf("%q slugged to %q, and this case is written around rc23-test",
+			created.RawName, created.Slug)
+	}
+	created.rememberSession()
+
+	if got := indexKeys(t); len(got) != 1 || got[0] != "claude-code@rc23-test" {
+		t.Fatalf("the index is keyed %v, want [claude-code@rc23-test]", got)
+	}
+	if got, want := mustLoad(t, Options{Name: "RC23 Test"}).Workspace, base+"-rc23-test"; got != want {
+		t.Errorf("a flagless verb resolved %q, want %q", got, want)
+	}
+}
+
+// A stop leaves the session alone -- it is the same session, stopped, and its
+// home is where the work is. A remove is the one that drops the entry, so the
+// next sandbox to take the name resolves its workspace the ordinary way rather
+// than inheriting a directory chosen for a sandbox that is gone.
+func TestAnEntrySurvivesAStopAndGoesOnARemove(t *testing.T) {
 	isolateState(t)
 	base := t.TempDir()
 	ws := base + "-rc23test"
 
 	c := mustLoad(t, Options{Name: "rc23test", Workspace: base})
-	c.rememberWorkspace()
-	if got := RememberedWorkspace(c.VMName); got != ws {
+	c.rememberSession()
+	if got := WorkspaceOfSandbox(c.VMName); got != ws {
 		t.Fatalf("the workspace was recorded as %q, want %q", got, ws)
 	}
 
 	rt := &removingRuntime{}
 	c.Runtime = rt
+	if err := c.Stop(); err != nil {
+		t.Fatalf("stop failed: %v", err)
+	}
+	if got := WorkspaceOfSandbox(c.VMName); got != ws {
+		t.Errorf("a stop dropped the entry: %q", got)
+	}
+
 	if err := c.Remove(); err != nil {
 		t.Fatalf("remove failed: %v", err)
 	}
 	if len(rt.removed) != 1 || rt.removed[0] != c.VMName {
 		t.Errorf("the runtime was asked to remove %v", rt.removed)
 	}
-	if got := RememberedWorkspace(c.VMName); got != "" {
+	if got := WorkspaceOfSandbox(c.VMName); got != "" {
 		t.Errorf("rm left %q recorded for a sandbox it removed", got)
 	}
 	if got := mustLoad(t, Options{Name: "rc23test"}).Workspace; got == ws {
@@ -166,23 +280,48 @@ func TestRemoveDropsTheEntry(t *testing.T) {
 	}
 }
 
-// `brig reset` works from the runtime's instance list, so it prunes by name
-// without a Config -- the entry has to go on that path too, or a reset leaves
-// the index naming every sandbox it just removed.
-func TestForgetWorkspacePrunesByName(t *testing.T) {
+// `brig reset` works from the runtime's instance list, so it prunes by sandbox
+// name without a Config -- the entry has to go on that path too, or a reset
+// leaves the index naming every sandbox it just removed.
+func TestForgetSandboxPrunesBySandboxName(t *testing.T) {
 	isolateState(t)
 	ws := t.TempDir()
 
 	c := mustLoad(t, Options{Name: "rc23test", Workspace: ws})
-	c.rememberWorkspace()
+	c.rememberSession()
 
-	// A name that was never recorded is not an error: reset walks every brig
+	// A sandbox that was never recorded is not an error: reset walks every brig
 	// sandbox, including ones created before the index existed.
-	ForgetWorkspace("brig-claude-code-neverseen")
-	ForgetWorkspace(c.VMName)
+	ForgetSandbox("brig-claude-code-neverseen")
+	ForgetSandbox(c.VMName)
 
-	if got := RememberedWorkspace(c.VMName); got != "" {
+	if got := WorkspaceOfSandbox(c.VMName); got != "" {
 		t.Errorf("reset left %q recorded for %s", got, c.VMName)
+	}
+}
+
+// `brig ls` asks the runtime what exists, so it is the verb that can tell an
+// entry whose sandbox is gone from one whose sandbox is merely stopped. A
+// sandbox removed outside brig never reaches Remove, and its entry would
+// otherwise sit in the file naming a directory for a sandbox nobody has.
+func TestPruningDropsTheSessionsWhoseSandboxIsGone(t *testing.T) {
+	isolateState(t)
+	live, gone := t.TempDir(), t.TempDir()
+
+	kept := mustLoad(t, Options{Name: "kept", Workspace: live})
+	kept.rememberSession()
+	dropped := mustLoad(t, Options{Name: "gone", Workspace: gone})
+	dropped.rememberSession()
+
+	// The list is every instance the runtime has, brig's own and anybody
+	// else's, which is what `brig ls` has in hand.
+	PruneSessions([]string{kept.VMName, "some-other-container"})
+
+	if got := WorkspaceOfSandbox(kept.VMName); got != live+"-kept" {
+		t.Errorf("pruning dropped a session whose sandbox is still there: %q", got)
+	}
+	if got := WorkspaceOfSandbox(dropped.VMName); got != "" {
+		t.Errorf("pruning kept %q for %s, whose sandbox is gone", got, dropped.VMName)
 	}
 }
 
@@ -191,7 +330,7 @@ func TestForgetWorkspacePrunesByName(t *testing.T) {
 // each resolve the default, which is what the release before it did.
 func TestAnUnusableIndexIsIgnoredRatherThanFatal(t *testing.T) {
 	dir := isolateState(t)
-	path := filepath.Join(dir, workspaceIndexName)
+	path := filepath.Join(dir, sessionIndexName)
 
 	// Missing: nothing has been recorded yet, which is every first run.
 	fallback := mustLoad(t, Options{Name: "rc23test"}).Workspace
@@ -203,11 +342,21 @@ func TestAnUnusableIndexIsIgnoredRatherThanFatal(t *testing.T) {
 	if err := os.WriteFile(path, []byte("{not json at all"), 0o600); err != nil {
 		t.Fatal(err)
 	}
-	if got := RememberedWorkspace("brig-claude-code-rc23test"); got != "" {
+	if got := WorkspaceOfSandbox("brig-claude-code-rc23test"); got != "" {
 		t.Errorf("a corrupt index returned %q", got)
 	}
 	if got := mustLoad(t, Options{Name: "rc23test"}).Workspace; got != fallback {
 		t.Errorf("a corrupt index changed the resolved workspace to %q, want %q", got, fallback)
+	}
+	// A file of the right shape but the wrong type is the same class: this is
+	// what an old claim index, which was a map of strings under this name,
+	// looks like to the reader that now expects a session.
+	if err := os.WriteFile(path, []byte(`{"claude-code@rc23test": "/somewhere"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if got := mustLoad(t, Options{Name: "rc23test"}).Workspace; got != fallback {
+		t.Errorf("an index of the wrong shape changed the resolved workspace to %q, want %q",
+			got, fallback)
 	}
 
 	// Unreadable: a directory where the file should be is the shape that takes
@@ -226,28 +375,61 @@ func TestAnUnusableIndexIsIgnoredRatherThanFatal(t *testing.T) {
 	c := mustLoad(t, Options{Name: "rc23test"})
 	said := &bytes.Buffer{}
 	c.Err = said
-	c.rememberWorkspace()
+	c.rememberSession()
 	if !strings.Contains(said.String(), c.VMName) {
 		t.Errorf("an index that cannot be written said %q, which does not name the sandbox",
 			said.String())
 	}
 }
 
-// Every entry survives a write, so recording one sandbox does not cost another
+// Every entry survives a write, so recording one session does not cost another
 // its own -- the file is read, edited and written back whole.
-func TestRecordingOneSandboxKeepsTheOthers(t *testing.T) {
+func TestRecordingOneSessionKeepsTheOthers(t *testing.T) {
 	isolateState(t)
 	first, second := t.TempDir(), t.TempDir()
 
 	a := mustLoad(t, Options{Name: "one", Workspace: first})
-	a.rememberWorkspace()
+	a.rememberSession()
 	b := mustLoad(t, Options{Name: "two", Workspace: second})
-	b.rememberWorkspace()
+	b.rememberSession()
 
-	if want := first + "-one"; RememberedWorkspace(a.VMName) != want {
-		t.Errorf("%s lost its entry: %q", a.VMName, RememberedWorkspace(a.VMName))
+	if want := first + "-one"; WorkspaceOfSandbox(a.VMName) != want {
+		t.Errorf("%s lost its entry: %q", a.VMName, WorkspaceOfSandbox(a.VMName))
 	}
-	if want := second + "-two"; RememberedWorkspace(b.VMName) != want {
-		t.Errorf("%s was recorded as %q, want %q", b.VMName, RememberedWorkspace(b.VMName), want)
+	if want := second + "-two"; WorkspaceOfSandbox(b.VMName) != want {
+		t.Errorf("%s was recorded as %q, want %q", b.VMName, WorkspaceOfSandbox(b.VMName), want)
+	}
+}
+
+// The sandbox-keyed file it replaces is deleted rather than migrated: a
+// brig-claude-code-refactor key cannot be read back into a ref without
+// guessing which of the dashes was the one between the agent and its label.
+// Each session in it costs one restart, which is what an absent entry has
+// always cost.
+func TestTheSandboxKeyedIndexIsDeletedRatherThanMigrated(t *testing.T) {
+	dir := isolateState(t)
+	legacy := filepath.Join(dir, legacyWorkspaceIndexName)
+	body := `{"brig-claude-code-rc23test": "/private/tmp/ws-rc23"}`
+	if err := os.WriteFile(legacy, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	// Nothing is read out of it: the session resolves the default it would
+	// have resolved with no file at all.
+	fresh := mustLoad(t, Options{Name: "rc23test"})
+	if fresh.Workspace == "/private/tmp/ws-rc23" {
+		t.Fatal("the old sandbox-keyed file was read back")
+	}
+	fresh.rememberSession()
+	if _, err := os.Stat(legacy); !os.IsNotExist(err) {
+		t.Errorf("recording a session left %s behind (%v)", legacyWorkspaceIndexName, err)
+	}
+
+	// And its absence is not an error, on either path that clears it: a host
+	// that never ran the older release has no such file.
+	mustLoad(t, Options{Name: "rc23test"}).rememberSession()
+	PruneSessions(nil)
+	if _, err := os.Stat(legacy); !os.IsNotExist(err) {
+		t.Errorf("%s came back (%v)", legacyWorkspaceIndexName, err)
 	}
 }

--- a/internal/wrap/run.go
+++ b/internal/wrap/run.go
@@ -222,7 +222,7 @@ func (c *Config) EnsureRunning(set creds.Set) error {
 			// The guest has confirmed this workspace, so record it. Nothing has
 			// changed for a session brig already knows about; for one created
 			// before the index existed, this is where its entry appears.
-			c.rememberWorkspace()
+			c.rememberSession()
 			// Running a graphical agent again is how you get back to its
 			// window, so the focus is not part of the boot -- it belongs on
 			// every path that leaves a sandbox running.
@@ -328,7 +328,7 @@ func (c *Config) EnsureRunning(set creds.Set) error {
 	// the readiness wait for that reason: a sandbox that boots and never answers
 	// still has this workspace, and the next command has to resolve the same one
 	// to find out.
-	c.rememberWorkspace()
+	c.rememberSession()
 	if !c.waitReady() {
 		return fmt.Errorf("sandbox did not become ready; check '%s'",
 			c.Runtime.LogsHint(c.VMName))
@@ -515,8 +515,8 @@ func (c *Config) Stop() error {
 func (c *Config) Remove() error {
 	_ = c.Runtime.Stop(c.VMName)
 	err := c.Runtime.Remove(c.VMName)
-	ForgetWorkspace(c.VMName)
-	ForgetSession(c.VMName)
+	ForgetSandbox(c.VMName)
+	ForgetSlugClaim(c.VMName)
 	return err
 }
 

--- a/internal/wrap/slugclaim.go
+++ b/internal/wrap/slugclaim.go
@@ -1,6 +1,9 @@
 package wrap
 
-import "fmt"
+import (
+	"fmt"
+	"os"
+)
 
 // The session-claim index: which session name owns each sandbox.
 //
@@ -19,13 +22,81 @@ import "fmt"
 // Keyed by sandbox name, not by the bare slug: the sandbox name carries the
 // profile, and two profiles that shorten to one slug share nothing, since the
 // sandbox and the workspace both include the profile. It is also the key rm and
-// reset already have in hand, so releasing a claim sits beside ForgetWorkspace
-// on both paths. Same file conventions as the workspace index (see index.go):
+// reset already have in hand, so releasing a claim sits beside ForgetSandbox
+// on both paths. Same file conventions as the session index (see index.go):
 // atomic write, an unusable file treated as empty, and a bookkeeping failure
 // never fatal to a command that would otherwise work.
+//
+// A file of its own, and not the session index: this is the one question that
+// cannot be asked of a ref-keyed file, because two colliding names slug the
+// same and so produce the one ref. What is recorded here is which name that
+// ref belongs to, which is the fact a ref has already thrown away.
 
-// sessionIndexName is the file, inside stateDir.
-const sessionIndexName = "sessions.json"
+// slugClaimIndexName is the file, inside stateDir. It held the name
+// sessions.json until the session index took it; see migrateSlugClaims for
+// what happens to the claims an older release left under that name.
+const slugClaimIndexName = "slug-claims.json"
+
+// migrateSlugClaims carries an older release's claims across the rename, when
+// slug-claims.json is not there and sessions.json still holds them.
+//
+// Unlike the session index, which is deliberately not migrated because a
+// sandbox name cannot be split back into an agent and a label without
+// guessing, there is nothing here to resolve: the old file's shape is exactly
+// this file's shape, the same sandbox-name key and the same owning name, so
+// the migration is the rename and no more. Worth doing rather than dropping,
+// because what a claim buys is the refusal in claimSlug -- and dropping the
+// claims turns that refusal off until every session has run again, which is
+// the window in which two agents land in one guest home with whichever
+// credentials arrived last.
+//
+// The safety of it is the parse. A current sessions.json is a map of session
+// entries, whose values are JSON objects, so it cannot parse as a map of
+// strings: readIndex hands back an empty map for it exactly as it does for a
+// corrupt file, and an empty map is nothing to migrate. So this cannot fire on
+// a file the session index owns and cannot delete a session entry -- when it
+// does fire, what it read was claims, and a file of claims holds nothing the
+// session index wants.
+//
+// Idempotent by construction: it runs only when slug-claims.json is absent,
+// and writing that file is the first thing it does. It has to stay ahead of
+// rememberSession, which is the write that would otherwise replace the file
+// the old claims are still in -- see the read in claimSlug, which is where
+// that ordering is arranged.
+func migrateSlugClaims() {
+	path, err := indexPath(slugClaimIndexName)
+	if err != nil {
+		return
+	}
+	// Only a stat that says the file is not there: one that fails some other
+	// way has not established that, and migrating over a claim index brig
+	// merely could not look at would be the one way to lose a claim here.
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		return
+	}
+	claims := readIndex[string](sessionIndexName)
+	if len(claims) == 0 {
+		return
+	}
+	if err := writeIndex(slugClaimIndexName, claims); err != nil {
+		// Dropped like the rest of the bookkeeping: the claims stay where they
+		// are and the next command tries again. Nothing has been deleted yet,
+		// which is why the write comes first.
+		return
+	}
+	old, err := indexPath(sessionIndexName)
+	if err != nil {
+		return
+	}
+	_ = os.Remove(old)
+}
+
+// readSlugClaimIndex is the claim index's name for the shared read, with the
+// migration ahead of it.
+func readSlugClaimIndex() map[string]string {
+	migrateSlugClaims()
+	return readIndex[string](slugClaimIndexName)
+}
 
 // claimSlug records that this run's session name owns its sandbox, and refuses
 // the run when a different name owns it already.
@@ -35,15 +106,21 @@ const sessionIndexName = "sessions.json"
 // claims nothing and is always let through.
 //
 // A failure to write the claim is a warning, not an error, the way
-// rememberWorkspace treats its own: the sandbox this run wants is free, so
+// rememberSession treats its own: the sandbox this run wants is free, so
 // refusing it over a bookkeeping file that could not be rewritten would deny
 // the thing that was actually asked for. The only cost is that a later
 // colliding name goes uncaught.
 func (c *Config) claimSlug() error {
+	// Read before the unnamed run is let through, because the read is what
+	// carries an older release's claims across the rename and an unnamed run
+	// has to do that too: it claims nothing, but the rememberSession later in
+	// this same boot would replace the file those claims are still sitting in.
+	// This is the first thing EnsureRunning does, which is what puts it ahead
+	// of that write on every path. See migrateSlugClaims.
+	index := readSlugClaimIndex()
 	if c.RawName == "" {
 		return nil
 	}
-	index := readIndex(sessionIndexName)
 	owner, taken := index[c.VMName]
 	if taken && owner != c.RawName {
 		return fmt.Errorf("session %q shortens to %q, the sandbox session %q already "+
@@ -55,22 +132,22 @@ func (c *Config) claimSlug() error {
 		return nil
 	}
 	index[c.VMName] = c.RawName
-	if err := writeIndex(sessionIndexName, index); err != nil {
+	if err := writeIndex(slugClaimIndexName, index); err != nil {
 		c.warnf("could not record %s as the owner of %s (%v). A later run whose name "+
 			"shortens to the same sandbox will not be refused.", c.RawName, c.VMName, err)
 	}
 	return nil
 }
 
-// ForgetSession drops a removed sandbox's claim, so the next session name that
-// shortens to it can take it. Errors are dropped the way ForgetWorkspace drops
-// its own: a removal that worked must not report a failure because a
+// ForgetSlugClaim drops a removed sandbox's claim, so the next session name
+// that shortens to it can take it. Errors are dropped the way ForgetSandbox
+// drops its own: a removal that worked must not report a failure because a
 // bookkeeping file could not be rewritten.
-func ForgetSession(vmName string) {
-	index := readIndex(sessionIndexName)
+func ForgetSlugClaim(vmName string) {
+	index := readSlugClaimIndex()
 	if _, ok := index[vmName]; !ok {
 		return
 	}
 	delete(index, vmName)
-	_ = writeIndex(sessionIndexName, index)
+	_ = writeIndex(slugClaimIndexName, index)
 }

--- a/internal/wrap/slugclaim_test.go
+++ b/internal/wrap/slugclaim_test.go
@@ -76,7 +76,7 @@ func TestRemoveReleasesTheClaim(t *testing.T) {
 // `brig reset` works from the instance list, so it releases by name without a
 // Config -- the claim has to go on that path too, or a reset leaves every
 // sandbox it removed still claimed.
-func TestForgetSessionPrunesByName(t *testing.T) {
+func TestForgetSlugClaimPrunesByName(t *testing.T) {
 	isolateState(t)
 
 	prod := mustLoad(t, Options{Name: "acme-corp-prod"})
@@ -85,12 +85,83 @@ func TestForgetSessionPrunesByName(t *testing.T) {
 	}
 
 	// A name never claimed is not an error: reset walks every brig sandbox.
-	ForgetSession("brig-claude-code-neverseen")
-	ForgetSession(prod.VMName)
+	ForgetSlugClaim("brig-claude-code-neverseen")
+	ForgetSlugClaim(prod.VMName)
 
 	staging := mustLoad(t, Options{Name: "acme-corp-staging"})
 	if err := staging.claimSlug(); err != nil {
 		t.Errorf("reset did not release the claim: %v", err)
+	}
+}
+
+// The claims an older release wrote are carried across the rename rather than
+// dropped: the old file's shape is this file's shape, so there is nothing to
+// guess, and dropping them would turn the refusal off until every session had
+// run again -- which is the window in which two agents share one home.
+func TestTheOldClaimsAreCarriedAcrossTheRename(t *testing.T) {
+	dir := isolateState(t)
+
+	// sessions.json as the claim index had it: keyed by the sandbox name, with
+	// the owning session name as the value.
+	body := `{"brig-claude-code-acme-corp": "acme-corp-prod"}`
+	if err := os.WriteFile(filepath.Join(dir, sessionIndexName), []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	// The claim is still in force, which is the whole point of carrying it:
+	// this name shortens to the sandbox acme-corp-prod owns.
+	staging := mustLoad(t, Options{Name: "acme-corp-staging"})
+	if staging.VMName != "brig-claude-code-acme-corp" {
+		t.Fatalf("this case is written around brig-claude-code-acme-corp, and the "+
+			"sandbox is %q", staging.VMName)
+	}
+	err := staging.claimSlug()
+	if err == nil {
+		t.Fatal("the carried claim did not refuse a colliding name")
+	}
+	if !strings.Contains(err.Error(), "acme-corp-prod") {
+		t.Errorf("the refusal does not name the session that owns the sandbox: %v", err)
+	}
+
+	// Moved rather than copied: what is left under the old name is a file the
+	// session index is about to write for itself.
+	if got := readIndex[string](slugClaimIndexName)["brig-claude-code-acme-corp"]; got != "acme-corp-prod" {
+		t.Errorf("the claim was carried over as %q", got)
+	}
+	if _, err := os.Stat(filepath.Join(dir, sessionIndexName)); !os.IsNotExist(err) {
+		t.Errorf("the claims were left behind under the old name (%v)", err)
+	}
+}
+
+// The guard on that migration: a current sessions.json is a map of session
+// entries, whose values are objects rather than strings, so it cannot be read
+// as claims. Nothing is carried over and nothing is deleted -- a session index
+// mistaken for claims would cost every session in it its home.
+func TestASessionIndexIsNotMistakenForClaims(t *testing.T) {
+	dir := isolateState(t)
+
+	path := filepath.Join(dir, sessionIndexName)
+	body := `{"claude-code@rc23test":` +
+		`{"home": "/private/tmp/ws-rc23", "sandbox": "brig-claude-code-rc23test"}}`
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	c := mustLoad(t, Options{Name: "acme-corp-prod"})
+	if err := c.claimSlug(); err != nil {
+		t.Fatalf("a run with a session index and no claims was refused: %v", err)
+	}
+
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("the session index was deleted as though it held claims: %v", err)
+	}
+	if got := WorkspaceOfSandbox("brig-claude-code-rc23test"); got != "/private/tmp/ws-rc23" {
+		t.Errorf("the session entry reads back as %q, want its home", got)
+	}
+	// The only claim is this run's own: nothing was carried over.
+	claims := readIndex[string](slugClaimIndexName)
+	if len(claims) != 1 || claims[c.VMName] != "acme-corp-prod" {
+		t.Errorf("the claim index holds %v, want this run's claim alone", claims)
 	}
 }
 
@@ -99,7 +170,7 @@ func TestForgetSessionPrunesByName(t *testing.T) {
 // file existed.
 func TestACorruptClaimIndexDoesNotBreakARun(t *testing.T) {
 	dir := isolateState(t)
-	path := filepath.Join(dir, sessionIndexName)
+	path := filepath.Join(dir, slugClaimIndexName)
 	if err := os.WriteFile(path, []byte("{not json at all"), 0o600); err != nil {
 		t.Fatal(err)
 	}

--- a/script/smoke.sh
+++ b/script/smoke.sh
@@ -391,6 +391,73 @@ esac
 "$WORK/brig" run claude --name acme-corp-staging -d > /dev/null 2>&1 \
   && ok "rm frees the sandbox for the other name" \
   || bad "the sandbox stayed claimed after rm"
+
+# The claims an older release wrote under sessions.json are carried across to
+# slug-claims.json rather than dropped: the two files have the same shape, so
+# there is nothing to guess, and dropping them would leave the refusal off
+# until every session had run again. Unlike the session index, whose keys
+# cannot be read back into a ref at all.
+"$WORK/brig" reset > /dev/null 2>&1
+rm -f "$BRIG_STATE_DIR/slug-claims.json" "$BRIG_STATE_DIR/sessions.json"
+printf '{"brig-claude-code-acme-corp": "acme-corp-prod"}' > "$BRIG_STATE_DIR/sessions.json"
+out="$("$WORK/brig" run claude --name acme-corp-staging -d 2>&1)"
+case "$out" in
+  *acme-corp-prod*) ok "a claim written under the old file name still refuses" ;;
+  *) bad "the old claim was dropped -- got: $out" ;;
+esac
+grep -q 'acme-corp-prod' "$BRIG_STATE_DIR/slug-claims.json" \
+  && ok "the old claims are carried over to slug-claims.json" \
+  || bad "the old claims are not in slug-claims.json"
+
+# An unnamed run carries them across too. It claims nothing itself, so it could
+# have skipped the claim index entirely -- and then the rememberSession later in
+# that same boot would have replaced the file the claims were still sitting in,
+# which makes a plain `brig run claude` the one command that silently destroys
+# them.
+"$WORK/brig" reset > /dev/null 2>&1
+rm -f "$BRIG_STATE_DIR/slug-claims.json" "$BRIG_STATE_DIR/sessions.json"
+printf '{"brig-claude-code-acme-corp": "acme-corp-prod"}' > "$BRIG_STATE_DIR/sessions.json"
+"$WORK/brig" run claude -d > /dev/null 2>&1
+grep -q 'acme-corp-prod' "$BRIG_STATE_DIR/slug-claims.json" \
+  && ok "an unnamed run carries the old claims across" \
+  || bad "an unnamed run dropped the old claims"
+
+# And claims nothing of its own, which is the other half of that pair: every
+# unnamed run of a profile is meant to be the one session, so there is no name
+# for a later one to collide with and nothing to write down.
+"$WORK/brig" reset > /dev/null 2>&1
+rm -f "$BRIG_STATE_DIR/slug-claims.json" "$BRIG_STATE_DIR/sessions.json"
+"$WORK/brig" run claude -d > /dev/null 2>&1
+[ -e "$BRIG_STATE_DIR/slug-claims.json" ] \
+  && bad "an unnamed run claimed a sandbox -- got: $(cat "$BRIG_STATE_DIR/slug-claims.json")" \
+  || ok "an unnamed run claims nothing"
+
+# The guard on all of that: a current sessions.json holds session entries,
+# whose values are objects rather than the claims' strings, so it cannot be
+# read as claims. Mistaking one for the other deletes the file, and every
+# session in it loses its home.
+"$WORK/brig" reset > /dev/null 2>&1
+rm -f "$BRIG_STATE_DIR/slug-claims.json" "$BRIG_STATE_DIR/sessions.json"
+"$WORK/brig" run claude --name rc23guard -d > /dev/null 2>&1
+if [ -s "$BRIG_STATE_DIR/sessions.json" ]; then
+  cp "$BRIG_STATE_DIR/sessions.json" "$WORK/sessions.before"
+  # Cleared after the session exists, not before: a named run claims its own
+  # slug, so the file it writes is the very thing that would stop the migration
+  # from being attempted. Absent is the condition the migration waits for.
+  rm -f "$BRIG_STATE_DIR/slug-claims.json"
+  # rm of some other session is the instrument: it reads the claim index, which
+  # is where the migration lives, and writes neither index -- so anything that
+  # changes below changed because the migration fired.
+  "$WORK/brig" rm claude --name rc23other > /dev/null 2>&1
+  cmp -s "$WORK/sessions.before" "$BRIG_STATE_DIR/sessions.json" \
+    && ok "a current session index is not mistaken for claims" \
+    || bad "the session index was rewritten by a migration that must not fire"
+  [ -e "$BRIG_STATE_DIR/slug-claims.json" ] \
+    && bad "claims were invented out of session entries -- got: $(tr -d '\n' < "$BRIG_STATE_DIR/slug-claims.json")" \
+    || ok "no claims are invented out of session entries"
+else
+  bad "no session index to guard: $(cat "$BRIG_STATE_DIR/sessions.json" 2>&1)"
+fi
 "$WORK/brig" reset > /dev/null 2>&1
 
 echo "== stop =="
@@ -489,21 +556,71 @@ grep -q '^argv: run ' "$STUB_LOG" \
   && ok "a -w naming a different directory still restarts the sandbox" \
   || bad "a -w naming a different directory still restarts the sandbox"
 
+# The index is keyed by the ref, so a session started under one spelling of the
+# profile is the entry the other spelling reads -- claude and claude-code are
+# one profile through an alias, and two entries would be two homes drifting
+# apart.
+grep -q '"claude-code@rc23"' "$BRIG_STATE_DIR/sessions.json" \
+  && ok "the session is filed under its ref" \
+  || bad "the session is not filed under claude-code@rc23 -- got: $(cat "$BRIG_STATE_DIR/sessions.json" 2>&1)"
+: > "$STUB_LOG"
+brig_bare exec claude-code --name rc23 -- uname -a > /dev/null 2>&1
+grep -q '^argv: run ' "$STUB_LOG" \
+  && bad "the alias did not find the session's workspace" \
+  || ok "the alias finds the workspace the session was created with"
+
 brig_bare rm claude --name rc23 > /dev/null 2>&1
-grep -q 'brig-claude-code-rc23' "$BRIG_STATE_DIR/workspaces.json" \
-  && bad "rm left the sandbox in the workspace index" \
+grep -q 'brig-claude-code-rc23' "$BRIG_STATE_DIR/sessions.json" \
+  && bad "rm left the sandbox in the session index" \
   || ok "rm drops the remembered workspace"
 
 brig_bare create claude --name rc23 -w "$RC" > /dev/null 2>&1
 "$WORK/brig" reset > /dev/null 2>&1
-grep -q 'brig-claude-code-rc23' "$BRIG_STATE_DIR/workspaces.json" \
-  && bad "reset left a sandbox in the workspace index" \
+grep -q 'brig-claude-code-rc23' "$BRIG_STATE_DIR/sessions.json" \
+  && bad "reset left a sandbox in the session index" \
   || ok "reset drops the remembered workspaces"
+
+# A session with no label is filed under the bare agent name -- the ref's own
+# spelling for a session that has no label, rather than a trailing '@' or an
+# invented default one, either of which would be a key no ref types.
+rm -f "$BRIG_STATE_DIR/sessions.json"
+brig_bare create claude -w "$WORK/ws-bare" > /dev/null 2>&1
+grep -q '"claude-code":' "$BRIG_STATE_DIR/sessions.json" \
+  && ok "an unlabelled session is filed under the bare agent name" \
+  || bad "the unlabelled session is not keyed claude-code -- got: $(cat "$BRIG_STATE_DIR/sessions.json" 2>&1)"
+grep -q 'claude-code@' "$BRIG_STATE_DIR/sessions.json" \
+  && bad "the unlabelled session was given a label -- got: $(cat "$BRIG_STATE_DIR/sessions.json")" \
+  || ok "the unlabelled session is given no label"
+"$WORK/brig" reset > /dev/null 2>&1
+
+# And the '@' form on the command line reaches the file: a session created as
+# claude@label is filed exactly as --name label files it, key and value both,
+# so the two spellings address one entry rather than two.
+rm -f "$BRIG_STATE_DIR/sessions.json"
+brig_bare create claude@rc23ref -w "$WORK/ws-ref" > /dev/null 2>&1
+grep -q '"claude-code@rc23ref":' "$BRIG_STATE_DIR/sessions.json" \
+  && ok "a session created as a ref is filed under that ref" \
+  || bad "the ref form is not keyed claude-code@rc23ref -- got: $(cat "$BRIG_STATE_DIR/sessions.json" 2>&1)"
+grep -q '"sandbox": "brig-claude-code-rc23ref"' "$BRIG_STATE_DIR/sessions.json" \
+  && ok "the ref form records the sandbox --name would have named" \
+  || bad "the ref form's sandbox is not brig-claude-code-rc23ref -- got: $(cat "$BRIG_STATE_DIR/sessions.json")"
+"$WORK/brig" reset > /dev/null 2>&1
+
+# The sandbox-keyed file the session index replaces is deleted rather than
+# migrated: its keys cannot be read back into a ref without guessing which dash
+# separated the agent from its label. One restart per session in it, which is
+# what an absent entry has always cost.
+printf '{"brig-claude-code-rc23": "%s"}' "$WORK/ws-legacy" > "$BRIG_STATE_DIR/workspaces.json"
+brig_bare create claude --name rc23 -w "$RC" > /dev/null 2>&1
+[ -e "$BRIG_STATE_DIR/workspaces.json" ] \
+  && bad "the old sandbox-keyed index was left behind" \
+  || ok "the old sandbox-keyed index is deleted on sight"
+"$WORK/brig" reset > /dev/null 2>&1
 
 # The index is bookkeeping, so an unusable one costs a restart and nothing
 # more: every command still works, and the workspace resolves as it did before
 # the file existed.
-printf '{not json at all' > "$BRIG_STATE_DIR/workspaces.json"
+printf '{not json at all' > "$BRIG_STATE_DIR/sessions.json"
 brig_bare run claude -d > "$WORK/corrupt.out" 2>&1
 rc=$?
 [ "$rc" = 0 ] && ok "a corrupt index is ignored rather than fatal" \


### PR DESCRIPTION
## Summary

The session index was keyed by sandbox name, and that key cannot be read back. A sandbox is
`brig-<profile>-<slug>`, so a profile named `claude-code-refactor` and a `refactor` session of
`claude-code` produce the same string, and no rule recovers which reading was meant. Its value was
a single path, which was enough when a session had one directory.

Both change here. The index becomes `~/.brig/sessions.json`, keyed by the ref `#108` introduced and
carrying a typed value.

The key is built from the **resolved** profile name and the slug, which is what makes it stable:
`--name` accepts a name `Slug` then sanitises, so the name as typed is not an identifier, and
`claude` and `claude-code` are one profile through an alias. Keying on the resolution means a
session created under one spelling is found under the other, rather than becoming two entries and
two homes that drift apart.

## Related issues

Fixes #109. Part of #47.

**Stacked on #115** — the base is `feat/108-session-ref-flag-positions`, not `main`, so the diff
shows only this change and GitHub retargets it once #115 lands. Review order is #113, #115, then
this.

Scope narrowed from the issue title: the `project` field moved to #6, which introduces the project
mount and so can pick the field's shape against the real thing instead of guessing. Nothing here
records a project.

## Changes

- `~/.brig/sessions.json` keyed by ref, valued `{home, sandbox}`, replacing the sandbox-keyed
  `workspaces.json`. Every reader moves with it: the remembered-workspace path in `config.go`, the
  two `rememberSession` calls and the removal in `run.go`, and `workspaceOf` plus reset in
  `cmd/brig`.
- `readIndex`/`writeIndex` are generic over the value type rather than duplicated per file. The
  atomic write and the tolerant read are the whole reason these files behave alike; two copies
  would be two chances for one of them to stop being atomic or tolerant.
- Two read directions, because the callers hold different things: a ref-keyed lookup for the run
  path, and a scan by sandbox name for `brig ls`. `ls` deliberately does not re-derive a ref from a
  sandbox name — that is the ambiguity this change removes.
- `PruneSessions` drops entries whose sandbox the runtime no longer lists, on every `brig ls`.
- **`workspaces.json` is deleted rather than migrated**, for the ambiguity above. One restart per
  session in it, which is what an absent entry has always cost, and safe because everything
  persistent lives in the workspace on the host.
- **The slug-claim index keeps its data across a filename change.** It held the name
  `sessions.json`; the session index has taken that, so claims move to `slug-claims.json`. Unlike
  the workspace index this migration is unambiguous — same key, same value, only the filename
  differs — so `migrateSlugClaims` moves them instead of dropping them. Dropping them would turn
  off the refusal that stops two names shortening onto one sandbox, until every session had run
  again.

Three details in that migration worth a reviewer's eye:

1. It proceeds only on `os.IsNotExist` for `slug-claims.json`. A stat that fails another way has
   not established absence, and migrating over a claim index that merely could not be read would be
   the one way to lose a claim here.
2. It writes `slug-claims.json` before removing `sessions.json`, so a failed write leaves the
   claims where they are for the next command to retry.
3. It can only fire on an old file. It reads through `readIndex[string]`, and a current
   `sessions.json` has object values, so it does not parse as a map of strings and the migration
   is skipped. That is the safety property, and it has its own test.

The read that triggers it sits **above** `claimSlug`'s early return for an unnamed run. An unnamed
run claims nothing, but its `rememberSession` is the writer that would replace the old-format file
and take the claims with it, so it has to carry them across too.

## Testing

`script/smoke.sh` gained 13 checks across this change, so most of what a reviewer would do by hand
is now automated:

- the session is filed under its ref; an unlabelled session under the bare agent name; a session
  created as `claude@label` under that ref
- the alias finds the workspace the session was created with
- `rm` and `reset` drop entries; a corrupt index costs a restart and not a failure
- the old sandbox-keyed index is deleted on sight
- the old claims are carried to `slug-claims.json`, and a claim written under the old file name
  still refuses a colliding name
- an unnamed run carries the old claims across, and claims nothing itself
- a current session index is not mistaken for claims, and no claims are invented out of session
  entries

The last two pairs were mutation-tested. Moving `readSlugClaimIndex()` back below the unnamed-run
early return — the plausible tidy-up that would reintroduce the bug — turns
`an unnamed run dropped the old claims` red while `an unnamed run claims nothing` stays green, so
the pair localises the break rather than both failing at once. Weakening the guard's strict read
turns the two guard checks red and names the file it read.

`script/smoke.sh` also has failures that predate this branch and depend on host state. The sets are
byte-identical on this branch and on its parent `930e948`, verified by diffing them, so nothing
here regressed it.

## Manual testing

For anyone who would rather see it than trust the checks. It needs no microVM, no registry and no
credentials: `script/smoke.sh` drives brig against a stub `hull`, and the same stub works by hand.
From a checkout of this branch:

```bash
make build        # builds ./brig

REPO=$(git rev-parse --show-toplevel)
LAB=$(mktemp -d)
a=$(grep -n 'hull" <<' "$REPO/script/smoke.sh" | head -1 | cut -d: -f1)
b=$(awk -v s="$a" 'NR>s && $0=="STUB"{print NR; exit}' "$REPO/script/smoke.sh")
sed -n "$((a+1)),$((b-1))p" "$REPO/script/smoke.sh" > "$LAB/hull"
chmod +x "$LAB/hull"
mkdir -p "$LAB/assets" "$LAB/state" "$LAB/profiles" "$LAB/ws"
for f in Image bzImage container-initrd; do printf 'stand-in\n' > "$LAB/assets/$f"; done
export STUB_LOG="$LAB/argv.log"       STUB_STATE="$LAB/instance"
export BRIG_RUNTIME=hull              BRIG_RUNTIME_BIN="$LAB/hull"
export BRIG_WORKSPACE="$LAB/ws"       BRIG_READY_TIMEOUT=5
export BRIG_STATE_DIR="$LAB/state"    BRIG_VERIFY=off
export BRIG_BOOT_ASSETS="$LAB/assets" BRIG_HYPERVISOR=vz
export BRIG_PROFILE_DIR="$LAB/profiles"
brig()  { "$REPO/brig" "$@"; }
state() { for f in "$BRIG_STATE_DIR"/*.json; do [ -e "$f" ] && \
          { echo "== $(basename "$f")"; cat "$f"; echo; }; done; }
```

Two things to know before reading any output:

- **`brig run` and `brig create` exit 1 in this lab even when they worked.** The stub cannot fake an
  ephemeral mount, so brig's own credential-safety check refuses. That is brig being right about a
  fake runtime. Judge these checks by the contents of the state files, not by the exit status —
  except the collision refusal, where the exit status is the point and is called out.
- Re-run the block above for a fresh lab between checks. Several of these want an empty state
  directory, and the stub tracks a single instance, so a second session in one lab makes the reuse
  check read as a failure that isn't one.

**The index, and the shape of a key**

```bash
brig create claude -d          ; state    # keyed "claude-code"          — bare agent, no "@"
brig create claude@refactor -d ; state    # keyed "claude-code@refactor"
brig create claude --name rc23 -d ; state # keyed "claude-code@rc23"     — same as the @ form
```

Note the key is `claude-code`, the resolved profile, not the `claude` you typed.

**The alias, in a fresh lab with one session**

```bash
brig create claude --name rc23 -d
: > "$STUB_LOG"
brig exec claude-code --name rc23 -- uname -a
grep -c '^argv: run ' "$STUB_LOG"    # must be 0: the sandbox was reused, not rebooted
: > "$STUB_LOG"
brig exec claude-code@rc23 -- uname -a
grep -c '^argv: run ' "$STUB_LOG"    # must be 0 as well
```

**Removal prunes**

```bash
brig rm claude@rc23 ; state          # sessions.json is {}
```

**Upgrading: the old workspace index goes**

```bash
printf '{"brig-claude-code-rc23":"/tmp/old"}' > "$BRIG_STATE_DIR/workspaces.json"
brig create claude --name rc23 -d
ls "$BRIG_STATE_DIR"                 # workspaces.json is gone
```

**Upgrading: the old claims are kept, and still refuse**

```bash
printf '{"brig-claude-code-refactorin":"refactoring-api"}' > "$BRIG_STATE_DIR/sessions.json"
brig create claude --name other -d
cat "$BRIG_STATE_DIR/slug-claims.json"   # holds refactoring-api's claim alongside other's

brig create claude --name refactoring-web -d ; echo "exit=$?"
```

That last command must exit 1 and say `refactoring-web` shortens onto the sandbox
`refactoring-api` already uses. The refusal arrives after the execution envelope has printed,
because the claim is checked as the sandbox comes up — so do not truncate the output looking for
it.

An unnamed run carries the claims across too, and claims nothing of its own: seed the same file,
run `brig run claude -d`, and `slug-claims.json` holds only the seeded claim. In a clean lab an
unnamed run produces no `slug-claims.json` at all.

**The guard: a current index must not be mistaken for claims**

```bash
brig create claude --name keep -d           # a real entry exists
rm -f "$BRIG_STATE_DIR/slug-claims.json"    # after the session exists, not before
brig rm claude --name keep
cat "$BRIG_STATE_DIR/sessions.json"         # unchanged
ls "$BRIG_STATE_DIR"                        # no slug-claims.json invented
```

Clear the claim file *after* creating the session. A named run legitimately claims its own slug, so
clearing first lets that claim reappear and the check reads as a failure that isn't one.

**An unusable index costs a restart, not a failure**

```bash
printf '{not json at all' > "$BRIG_STATE_DIR/sessions.json"
brig run claude -d
cat "$BRIG_STATE_DIR/sessions.json"         # rewritten, well-formed
```

## Checklist

- [x] `make all` passes (vet, test, build)
- [x] `script/smoke.sh` passes
- [x] I have added or updated tests covering the change
- [x] I have run `go test ./... -race`, if the change touches concurrency, subprocesses or the daemon
- [ ] I have exercised the change against a real runtime (`brig run <agent>`), if it touches the run, exec or credential path
- [x] I have updated the affected docs (README, `docs/security.md`, `docs/profiles.md`, `docs/brigd.md`)

Two of those need saying rather than ticking. **`script/smoke.sh`** has failures that predate the
branch and depend on host state; the sets are identical on this branch and on `930e948`, and this
branch adds 13 passing checks. **Real runtime**: not booted. This touches the run path, so the box
applies and is honestly unticked — everything above was verified against the stub runtime, which
exercises the whole code path except the VM. A boot pass under a ref is worth doing before merge.

Docs are ticked because no user-facing behaviour or vocabulary changes here: the file this touches
is internal bookkeeping under `~/.brig`, documented nowhere, and `brig ls` prints exactly what it
printed before.

## Credentials and the sandbox boundary

This affects the second of brig's two promises — that a sandbox gets the credentials it was named
and no others — and it holds it steady rather than widening it.

The concrete risk in this area is two sessions landing on one guest home, where each was handed
different credentials and whichever booted last leaves its own behind. `claimSlug` is what refuses
that, and the claim index is what it reads. Renaming that file without carrying its contents would
have switched the refusal off until every session had run again, so the migration exists for that
reason and is tested from both directions: the carried claim still refuses, and the migration
cannot fire on a current index.

No new mount, no new forwarded variable, no new host path the guest can reach. The index records
host directory paths and does not grant access to them.

## LLM usage

Authored with assistance from Claude Code (Opus 5), which produced the implementation, the commit
message and this description. Verification was re-run independently of the agent that wrote the
change, from a frozen tree: `gofmt`, `make all`, an uncached `-race` pass over `cmd/brig`,
`internal/wrap` and `internal/session`, and the smoke failure sets diffed against `930e948`. The
mutation test described under Testing was reproduced independently in a throwaway worktree rather
than taken on trust, and every command in the Manual testing section was run before being written
down. Accountability for every line remains the author's.
