### PR TITLE
feat(cli): collapse the management commands into noun groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,18 +122,29 @@ separate Linux re-implementation of it.
 | `brig ls` | every brig sandbox, running or merely holding its name, with its workspace |
 | `brig reset` | stop and remove every brig sandbox. Workspaces are untouched |
 | `brig info <agent>` | the boundary a run would trust -- sandbox, workspace, image, credentials **by name only** -- and whether the guest will be authenticated (`brig env` is the old spelling) |
-| `brig profiles` | the profiles, their images, and what each one refuses to forward |
-| `brig profile ls\|export\|import\|edit\|rm` | manage profiles (`brig export` is the short form of `brig profile export`). `export --json` for JSON instead of YAML |
-| `brig policies` | every policy that parses, by name and description |
+| `brig agent ls` | the agents, their images, and what each one refuses to forward |
+| `brig agent show <agent>` | print one agent's spec. `--json` for JSON instead of YAML |
+| `brig agent new <name> --from <agent>` | copy an agent under a new name, ready to edit |
+| `brig agent edit\|rm\|import\|export` | manage agents |
 | `brig policy ls\|create\|edit\|show\|rm` | manage policies. `show --json` for JSON instead of YAML |
 | `brig secret create\|read\|update\|delete\|ls` | keep secrets in your keyring. macOS only for now |
 | `brig secret import <profile>` | fill that profile's secrets from your host, once. macOS only for now |
 | `brig telemetry status\|on\|off` | report what is counted, or turn the counting on or off. See [Telemetry](#telemetry) |
 | `brig version` | |
 
-`brig template …` and `brig agents` are the older spellings and still work
-for one release, each printing a one-line note naming the new one; they no
-longer appear above. There is deliberately no `brig template edit`.
+The older spellings all still work and each prints a one-line note naming the
+new one, so nothing scripted breaks in this release; they no longer appear
+above. `brig profiles` and the whole `brig profile` group are now `brig agent`,
+`brig policies` is `brig policy ls`, and top-level `brig import` and
+`brig export` are `brig agent import` and `brig agent export`. So are the
+undocumented aliases that were never in this table -- `list`, `save`, `load`,
+`secret rm`. `brig template …` and `brig agents` remain from an earlier rename,
+and there is deliberately no `brig template edit`.
+
+`brig secret` keeps `create|read|update|delete`, and that is deliberate rather
+than an oversight. The tidier `set`/`get` pair would make one typo turn a read
+into a write, silently replacing a stored credential with no way back to the
+original value. The inconsistency is the cheaper of the two.
 
 A brig line has three places a token can stand, and they are not the same kind
 of place. Left of the verb are brig's global flags, a closed set -- an unknown
@@ -255,7 +266,7 @@ The verbs line up deliberately, so muscle memory carries over:
 | `sbx create` | `brig create` | |
 | `sbx exec` / `sbx ls` / `sbx stop` / `sbx rm` / `sbx reset` | same | |
 | `sbx cp` | n/a | the workspace is a live host directory, so there is nothing to copy across |
-| `sbx template ls\|save\|load\|rm` | `brig profile ls\|export\|import\|edit\|rm` | brig's profiles describe the *agent*, not just its image, and are YAML like sbx's kits |
+| `sbx template ls\|save\|load\|rm` | `brig agent ls\|export\|import\|edit\|rm` | brig's profiles describe the *agent*, not just its image, and are YAML like sbx's kits |
 | `sbx secret set` | `brig secret create` + a profile's `secrets:` | brig has a store of its own and binds from it. Or point a profile at your existing secret manager: whatever puts a value in brig's environment is enough |
 | `sbx -t/--template` | `brig -t/--image` | |
 | `sbx -m/--memory`, `--cpus`, `-d`, `--name` | same | |
@@ -356,7 +367,7 @@ typo in a name is a message rather than a silently lost secret.
 
 A profile declares the names it wants out of this store, so a stored secret
 reaches a sandbox on its own -- as a file where the agent reads one, and as an
-environment variable where it does not. `brig profiles` prints each profile's
+environment variable where it does not. `brig agent ls` prints each agent's
 list, and which of those names `brig secret import` can fill for you:
 
 ```
@@ -554,34 +565,33 @@ profile just saves you spelling out the image, the guest home and the
 credential variables every time:
 
 ```bash
-brig profile export claude-code mine   # start from the closest one
-brig profile edit mine                 # change the image, forward/deny
+brig agent new mine --from claude-code   # start from the closest one
+brig agent edit mine                     # change the image, forward/deny
 brig run mine
 ```
 
-The second word is a name, not a path: brig writes `~/.config/brig/mine.yaml`,
-which is where a profile file has to be for brig to read it back. It is the
-profile's name as well as the file's -- export writes `name: mine` into the
-file, so `mine` is what every later command takes, `brig profile rm mine`
-included. Everything else in there still describes claude-code, which is what
-the edit on the second line is for. Export
-writes that directory and nowhere else, so a path is refused rather than
-honoured -- redirect stdout (`brig profile export claude-code > mine.yaml`)
-if you want a copy of your own. It also refuses to overwrite an existing file
+The name is a name, not a path: brig writes `~/.config/brig/mine.yaml`, which
+is where a profile file has to be for brig to read it back. It is the agent's
+name as well as the file's -- `new` writes `name: mine` into the file, so `mine`
+is what every later command takes, `brig agent rm mine` included. Everything
+else in there still describes claude-code, which is what the edit on the second
+line is for. `new` writes that directory and nowhere else, so a path is refused
+rather than honoured -- redirect stdout (`brig agent show claude-code >
+mine.yaml`) if you want a copy of your own. It also refuses to overwrite an existing file
 unless you pass `--force`, since an export is generated bytes and the file it
 would replace is not.
 
 Profiles are **YAML or JSON** -- JSON is a subset of YAML, so one parser reads
 both and nothing has to guess. Export writes YAML, because a profile is a
 file a person edits and YAML has comments; the exported file carries a header
-explaining every field. `brig profile export --json` for anything consuming
+explaining every field. `brig agent show --json` for anything consuming
 profiles programmatically.
 
 An imported file is stored byte for byte as you wrote it, so your comments and
 your ordering survive:
 
 ```yaml
-# A brig profile. Edit it, then: brig profile import <this file>
+# A brig profile. Edit it, then: brig agent import <this file>
 # ...
 name: mine
 image: docker.io/me/mine:latest
@@ -597,7 +607,7 @@ otherwise decode into nothing and forward no credentials, which looks exactly
 like a broken sandbox.
 
 A custom profile may take a built-in's name -- that is how you pin your own
-image for an agent brig already knows about. `brig profiles` marks those
+image for an agent brig already knows about. `brig agent ls` marks those
 `(file, overrides built-in)`. Your own live in `$XDG_CONFIG_HOME/brig`
 (default `~/.config/brig`), one file each; the directory starts empty and
 brig never writes there unless you ask it to.

--- a/cmd/brig/agent_test.go
+++ b/cmd/brig/agent_test.go
@@ -1,0 +1,187 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// Every verb of the new group, through run() rather than through the functions
+// underneath it, because the dispatch switch is half of what this change is:
+// a verb that works when called directly and is not wired into `brig agent`
+// is not a spelling anyone can type.
+//
+// The order is the order someone would type them -- new, then edit, then
+// export, then rm -- so the group is exercised as a workflow rather than as
+// seven unrelated calls.
+func TestAgentVerbsWork(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("BRIG_PROFILE_DIR", dir)
+	stubEditor(t, `printf '\n# tuned by hand\n' >> "$1"`)
+
+	for _, args := range [][]string{
+		{"agent", "ls"},
+		{"agent", "show", "claude-code"},
+		{"agent", "show", "claude-code", "--json"},
+		{"agent", "new", "mine", "--from", "claude-code"},
+		{"agent", "edit", "mine"},
+		{"agent", "export", "claude-code"},
+		{"agent", "export", "codex", "spare"},
+		{"agent", "rm", "spare", "-y"},
+		{"agent", "rm", "mine", "-y"},
+	} {
+		if _, err := captureStdout(t, func() error { return run(args) }); err != nil {
+			t.Errorf("brig %s: %v", strings.Join(args, " "), err)
+		}
+	}
+
+	// import takes a file, so it needs one written first. Round-tripping what
+	// show printed is the documented flow and covers both verbs at once.
+	out, err := captureStdout(t, func() error { return run([]string{"agent", "show", "codex"}) })
+	if err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(t.TempDir(), "codex.yaml")
+	if err := os.WriteFile(path, []byte(strings.Replace(out, "name: codex", "name: round", 1)), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := captureStdout(t, func() error { return run([]string{"agent", "import", path}) }); err != nil {
+		t.Errorf("brig agent import: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "round.yaml")); err != nil {
+		t.Errorf("brig agent import wrote nothing: %v", err)
+	}
+}
+
+// The recipe brig prints has to name the verbs brig has. A message that says
+// "profile" sends the reader to a command that answers with a deprecation
+// notice, which is one hop too many.
+func TestAgentUnknownSubcommandNamesTheNewVerbs(t *testing.T) {
+	t.Setenv("BRIG_PROFILE_DIR", t.TempDir())
+	for _, args := range [][]string{{"agent"}, {"agent", "nonsense"}} {
+		err := run(args)
+		if err == nil {
+			t.Fatalf("brig %s was accepted", strings.Join(args, " "))
+		}
+		for _, verb := range []string{"ls", "show", "new", "edit", "rm", "import", "export"} {
+			if !strings.Contains(err.Error(), verb) {
+				t.Errorf("brig %s does not name %s: %v", strings.Join(args, " "), verb, err)
+			}
+		}
+		if strings.Contains(err.Error(), "profile") {
+			t.Errorf("brig %s names the retired noun: %v", strings.Join(args, " "), err)
+		}
+	}
+}
+
+// show prints and writes nothing, so a second word is the old
+// `brig export <p> <name>` habit rather than a destination. Saying which
+// command took that job over is the whole value of the error.
+func TestAgentShowRefusesADestinationAndNamesNew(t *testing.T) {
+	t.Setenv("BRIG_PROFILE_DIR", t.TempDir())
+	err := run([]string{"agent", "show", "claude-code", "mine"})
+	if err == nil {
+		t.Fatal("brig agent show wrote a file")
+	}
+	if !strings.Contains(err.Error(), "brig agent new mine --from claude-code") {
+		t.Errorf("the error does not name the command that copies one: %v", err)
+	}
+}
+
+// new copies an agent, so it has to be told which one. Without --from there is
+// nothing to copy and no sensible default: a blank starter file is a different
+// feature.
+func TestAgentNewNeedsFromAndAName(t *testing.T) {
+	t.Setenv("BRIG_PROFILE_DIR", t.TempDir())
+	for _, args := range [][]string{
+		{"agent", "new", "mine"},
+		{"agent", "new", "--from", "claude-code"},
+		{"agent", "new", "mine", "spare", "--from", "claude-code"},
+	} {
+		if err := run(args); err == nil {
+			t.Errorf("brig %s was accepted", strings.Join(args, " "))
+		}
+	}
+}
+
+// The help text is the only place a reader finds the vocabulary, so it has to
+// carry the group that exists and not the one that is retiring. Asserted on
+// the const rather than on run()'s output because that is where a future edit
+// would put a stale line back.
+func TestUsageTeachesTheAgentGroup(t *testing.T) {
+	for _, want := range []string{"brig agent", "brig policy ls", "brig secret"} {
+		if !strings.Contains(usage, want) {
+			t.Errorf("the usage text does not mention %q", want)
+		}
+	}
+	// The retired spellings keep working and stay out of the help: a reader
+	// who never saw them has no reason to learn one.
+	for _, gone := range []string{"brig profiles", "brig profile ", "brig policies", "brig export "} {
+		if strings.Contains(usage, gone) {
+			t.Errorf("the usage text still teaches %q", gone)
+		}
+	}
+	for _, want := range []string{
+		"brig agent ls", "brig agent show", "brig agent new", "brig agent edit",
+		"brig agent rm", "brig agent import", "brig agent export",
+	} {
+		if !strings.Contains(agentUsage, want) {
+			t.Errorf("brig agent --help does not name %q", want)
+		}
+	}
+}
+
+// `brig agent --help` is a question, not a mistake, and so is the --help a
+// verb's own parser sees. The profile group already answered both this way.
+func TestAgentHelpPrintsUsageAndSucceeds(t *testing.T) {
+	t.Setenv("BRIG_PROFILE_DIR", t.TempDir())
+	for _, args := range [][]string{
+		{"agent", "--help"}, {"agent", "-h"}, {"agent", "help"}, {"agent", "rm", "--help"},
+	} {
+		out, err := captureStdout(t, func() error { return run(args) })
+		if err != nil {
+			t.Errorf("brig %s: %v", strings.Join(args, " "), err)
+		}
+		if !strings.Contains(out, "brig agent rm") {
+			t.Errorf("brig %s printed no usage:\n%s", strings.Join(args, " "), out)
+		}
+	}
+}
+
+// secret keeps create|update|read|delete|ls|import, and that is a decision
+// rather than an oversight this issue missed.
+//
+// The unified verb table would make it set|show|rm, and `set` is the problem:
+// it means createOrUpdate, so a typo in the name writes a second secret
+// instead of failing, and the run that needed the first one fails much later
+// with a credential the sandbox never received. create and update each refuse
+// the case the other is for, which is worth more than one consistent verb set
+// across three nouns.
+//
+// This test exists so that the next reader who notices the inconsistency finds
+// the reason before changing it. If the decision is revisited, revisit it here
+// first.
+func TestSecretKeepsItsOwnVerbSetOnPurpose(t *testing.T) {
+	newFake(t)
+	for _, verb := range []string{"create", "update", "read", "delete", "ls", "import"} {
+		if !strings.Contains(secretUsage, "brig secret "+verb) {
+			t.Errorf("brig secret --help no longer documents %q", verb)
+		}
+		// Documented and dispatched are two different things, and the verb set
+		// is both: an unknown subcommand is the one error that would tell a
+		// reader the exception had been undone.
+		if err := secretCmd(&bytes.Buffer{}, []string{verb}); err != nil &&
+			strings.Contains(err.Error(), "unknown secret subcommand") {
+			t.Errorf("brig secret %s is no longer a subcommand: %v", verb, err)
+		}
+	}
+	// And the verbs the unified table would have introduced are not there.
+	for _, verb := range []string{"set", "show", "get"} {
+		err := secretCmd(&bytes.Buffer{}, []string{verb, "gh-token"})
+		if err == nil || !strings.Contains(err.Error(), "unknown secret subcommand") {
+			t.Errorf("brig secret %s exists, so the exception was undone: %v", verb, err)
+		}
+	}
+}

--- a/cmd/brig/deprecated_test.go
+++ b/cmd/brig/deprecated_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"os"
 	"path/filepath"
 	"strings"
@@ -16,6 +17,135 @@ func TestDeprecatedVerbsStillWork(t *testing.T) {
 	for _, args := range [][]string{{"agents"}, {"template", "ls"}} {
 		if err := run(args); err != nil {
 			t.Errorf("brig %s: %v", strings.Join(args, " "), err)
+		}
+	}
+}
+
+// The whole retired vocabulary, in one table: every spelling this release
+// renames still runs, and every one says what replaces it.
+//
+// Both halves matter and neither is enough alone. A spelling that fails breaks
+// every script that has it; a spelling that works silently never teaches
+// anyone the new word, so the old one is still in those scripts at the release
+// that removes it.
+//
+// The replacement is asserted as a whole command line rather than as the noun,
+// because that is the thing a reader can paste. It also catches a notice
+// pointing at another retired spelling: `brig agents` used to say
+// "is now `brig profiles`", which after this change would have been one hop
+// short of an answer.
+func TestRetiredSpellingsWorkAndNameTheirReplacement(t *testing.T) {
+	for _, c := range []struct {
+		args        []string
+		replacement string
+	}{
+		// The plural nouns.
+		{[]string{"profiles"}, "brig agent ls"},
+		{[]string{"policies"}, "brig policy ls"},
+		// The whole profile group, verb by verb: they retire onto different
+		// words, so a notice naming only the group would leave the reader to
+		// work out which.
+		{[]string{"profile", "ls"}, "brig agent ls"},
+		{[]string{"profile", "export", "codex"}, "brig agent export"},
+		{[]string{"profile", "import", "-"}, "brig agent import"},
+		{[]string{"profile", "edit", "mine"}, "brig agent edit"},
+		{[]string{"profile", "rm", "mine", "-y"}, "brig agent rm"},
+		{[]string{"profile", "--help"}, "brig agent"},
+		// The top-level spellings of a noun command.
+		{[]string{"export", "codex"}, "brig agent export"},
+		{[]string{"import", "-"}, "brig agent import"},
+		// The undocumented second spellings. None of them were ever in the
+		// help text, so they were found by accident and then scripted.
+		{[]string{"profile", "list"}, "brig agent ls"},
+		{[]string{"profile", "save", "codex"}, "brig agent export"},
+		{[]string{"profile", "load", "-"}, "brig agent import"},
+		{[]string{"agent", "list"}, "brig agent ls"},
+		{[]string{"agent", "save", "codex"}, "brig agent export"},
+		{[]string{"agent", "load", "-"}, "brig agent import"},
+		{[]string{"policy", "list"}, "brig policy ls"},
+	} {
+		line := "brig " + strings.Join(c.args, " ")
+		dir := t.TempDir()
+		t.Setenv("BRIG_PROFILE_DIR", dir)
+		t.Setenv("BRIG_POLICY_DIR", t.TempDir())
+		// A profile of the caller's own, for the verbs that need one to work
+		// on. import reads stdin, so it gets the same profile down the pipe.
+		blob := "name: mine\nimage: i\nguestHome: /home/mine\nbinary: m\nmem: 1\ncpus: 1\n"
+		if err := os.WriteFile(filepath.Join(dir, "mine.yaml"), []byte(blob), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		stubEditor(t, "true")
+		pipeStdin(t, blob)
+
+		var err error
+		notice := captureStderr(t, func() {
+			_, err = captureStdout(t, func() error { return run(c.args) })
+		})
+		if err != nil {
+			t.Errorf("%s stopped working: %v", line, err)
+		}
+		if !strings.Contains(notice, c.replacement) {
+			t.Errorf("%s does not name %q as its replacement:\n%s", line, c.replacement, notice)
+		}
+		// The notice is the deprecation notice and not some other line of
+		// stderr that happens to contain the words.
+		if !strings.Contains(notice, "brig: `") {
+			t.Errorf("%s printed no deprecation notice:\n%s", line, notice)
+		}
+	}
+}
+
+// `brig secret rm` is the one retired spelling inside a group whose verb set
+// is otherwise staying: delete is the documented word, rm was the accident.
+// Kept separate from the table above because it needs a store rather than a
+// profile directory.
+func TestSecretRmIsRetiredButStillWorks(t *testing.T) {
+	f := newFake(t)
+	f.seed("gh-token", "value")
+	var err error
+	notice := captureStderr(t, func() {
+		err = secretCmd(&bytes.Buffer{}, []string{"rm", "gh-token", "-y"})
+	})
+	if err != nil {
+		t.Errorf("brig secret rm stopped working: %v", err)
+	}
+	if _, ok := f.items["gh-token"]; ok {
+		t.Error("brig secret rm did not remove the secret")
+	}
+	if !strings.Contains(notice, "brig secret delete") {
+		t.Errorf("brig secret rm does not name what replaces it:\n%s", notice)
+	}
+	// And the documented spelling says nothing.
+	f.seed("gh-token", "value")
+	notice = captureStderr(t, func() {
+		err = secretCmd(&bytes.Buffer{}, []string{"delete", "gh-token", "-y"})
+	})
+	if err != nil {
+		t.Errorf("brig secret delete: %v", err)
+	}
+	if strings.Contains(notice, "is now") {
+		t.Errorf("the documented spelling printed a deprecation notice:\n%s", notice)
+	}
+}
+
+// The current spellings say nothing. A notice on a command that is not going
+// anywhere is how a reader learns to ignore the ones that are.
+func TestCurrentSpellingsPrintNoNotice(t *testing.T) {
+	for _, args := range [][]string{
+		{"agent", "ls"}, {"agent", "show", "codex"}, {"agent", "export", "codex"},
+		{"policy", "ls"}, {"telemetry", "--help"},
+	} {
+		t.Setenv("BRIG_PROFILE_DIR", t.TempDir())
+		t.Setenv("BRIG_POLICY_DIR", t.TempDir())
+		var err error
+		notice := captureStderr(t, func() {
+			_, err = captureStdout(t, func() error { return run(args) })
+		})
+		if err != nil {
+			t.Errorf("brig %s: %v", strings.Join(args, " "), err)
+		}
+		if strings.Contains(notice, "is now") {
+			t.Errorf("brig %s printed a deprecation notice:\n%s", strings.Join(args, " "), notice)
 		}
 	}
 }

--- a/cmd/brig/edit_test.go
+++ b/cmd/brig/edit_test.go
@@ -47,8 +47,8 @@ func TestEditOpensAFileBackedProfile(t *testing.T) {
 	}
 }
 
-// An embedded profile has no file. edit creates nothing -- import and export
-// with a destination stay the only two commands that write into the profile
+// An embedded profile has no file. edit creates nothing -- import, new and
+// export with a destination stay the only commands that write into the profile
 // directory -- and it names the command that would make one.
 func TestEditRefusesAnEmbeddedProfile(t *testing.T) {
 	dir := t.TempDir()
@@ -63,7 +63,7 @@ func TestEditRefusesAnEmbeddedProfile(t *testing.T) {
 		t.Fatal("editing a built-in was allowed")
 	}
 	if !strings.Contains(err.Error(), "built in") ||
-		!strings.Contains(err.Error(), "brig profile export claude-code") {
+		!strings.Contains(err.Error(), "brig agent new claude-code --from claude-code") {
 		t.Errorf("the error does not say how to make a file: %v", err)
 	}
 	entries, _ := os.ReadDir(dir)

--- a/cmd/brig/main.go
+++ b/cmd/brig/main.go
@@ -50,12 +50,8 @@ usage:
   brig info   <profile>                          print the execution envelope and the
                                                  full environment, by name -- fails
                                                  if a declared secret is missing
-  brig profiles                                  list the profiles
-  brig profile ls|export|import|edit|rm          manage profiles
-  brig policies                                  list the policies
+  brig agent ls|show|new|edit|rm|import|export   the agents you can run
   brig policy ls|create|edit|show|rm             manage policies
-  brig export <profile> [name] [--json]          print a profile, or save it
-                                                 as <name> in the profile dir
   brig secret create|read|update|delete|ls       keep secrets in your keyring
   brig secret import <profile>                   fill a profile's secrets from
                                                  your host, once
@@ -86,10 +82,11 @@ run is immediate; state lives in the workspace on the host either way.
 Any Linux CLI in an OCI image runs under brig, if the image also carries the
 utilities brig uses to set the sandbox up and deliver the credential: a shell
 (sh and bash), plus cat, stat, chown, mkdir, mount and /bin/true. A stock
-distro image has them; a scratch image with only your binary does not. A
-profile just saves you spelling out the image and its credential variables
-every time: export the closest one, edit it, import it back. Building an image
-for one is documented at
+distro image has them; a scratch image with only your binary does not. An
+agent entry just saves you spelling out the image and its credential variables
+every time: copy the closest one and edit it, with
+  brig agent new mine --from claude, then brig agent edit mine
+Building an image for one is documented at
   https://github.com/brig-sh/community-images/blob/main/docs/bring-your-own-image.md
 
 settings (BRIG_<AGENT>_<KEY> wins over BRIG_<KEY>; see the README for all):
@@ -174,34 +171,52 @@ func run(args []string) error {
 	case "version", "--version":
 		fmt.Printf("brig %s\n", version)
 		return nil
-	case "profiles":
-		return listProfiles()
-	case "profile":
-		return profileCmd(rest)
-	case "policies":
-		return listPolicies()
+	case "agent":
+		return agentCmd(rest)
 	case "policy":
 		return policyCmd(rest)
 	case "secret":
 		return secretCmd(os.Stdout, rest)
 	case "telemetry":
 		return telemetryCmd(os.Stdout, rest)
+	// Deprecated spellings, absent from the usage text.
+	//
+	// The three grammars this release settles are all here: a plural noun that
+	// is a command of its own, a noun command spelled again at the top level,
+	// and a group renamed. Each keeps working and says the one word that
+	// replaces it, because a spelling has to survive the commit that renames it
+	// or that commit breaks every script anyone has written.
+	case "profiles":
+		deprecated("brig profiles", "brig agent ls")
+		return listProfiles()
+	case "profile":
+		return deprecatedProfileCmd(rest)
+	case "policies":
+		deprecated("brig policies", "brig policy ls")
+		return listPolicies()
 	case "import":
+		deprecated("brig import", "brig agent import")
 		return importProfile(rest)
 	case "export":
+		// Named onto `brig agent export` rather than onto show or new, because
+		// this is the same command: it prints with no destination and writes
+		// with one, and the reader's line keeps working word for word. show and
+		// new are the taught spellings of those two halves, and the usage text
+		// is where someone meets them.
+		deprecated("brig export", "brig agent export")
 		return exportProfile(rest)
-	// Deprecated spellings, absent from the usage text. There is deliberately
-	// no `brig template edit`: the old group carries only the verbs it already
-	// had, so a command that never existed under that name does not gain one.
+	// There is deliberately no `brig template edit`: the old group carries only
+	// the verbs it already had, so a command that never existed under that name
+	// does not gain one.
 	case "agents":
-		deprecated("brig agents", "brig profiles")
+		deprecated("brig agents", "brig agent ls")
 		return listProfiles()
 	case "template":
-		deprecated("brig template", "brig profile")
+		deprecated("brig template", "brig agent")
 		if len(rest) > 0 && rest[0] == "edit" {
-			return fmt.Errorf("there is no `brig template edit`; use `brig profile edit`")
+			return fmt.Errorf("there is no `brig template edit`; use `brig agent edit`")
 		}
-		return profileCmd(rest)
+		return agentCmd(rest)
 	case "ls":
 		return listSandboxes(rest)
 	case "reset":
@@ -222,9 +237,9 @@ func run(args []string) error {
 	if !ok {
 		if profileName == "" {
 			return fmt.Errorf("%s needs a profile, for example `brig %s claude`. "+
-				"`brig profiles` lists them", verb, verb)
+				"`brig agent ls` lists them", verb, verb)
 		}
-		return notFoundf("unknown profile %q. `brig profiles` lists them", profileName)
+		return notFoundf("unknown profile %q. `brig agent ls` lists them", profileName)
 	}
 	// Say why up front. Without this the pull fails against the registry
 	// with a 404 that reads like an outage rather than a decision.
@@ -1160,8 +1175,8 @@ func listProfiles() error {
 		}
 	}
 	fmt.Printf("\nan unmarked profile is built in; your own live in %s\n", profile.Dir())
-	fmt.Printf("to override one:  brig profile export claude-code claude-code, then brig profile edit claude-code\n")
-	fmt.Printf("to add your own:  brig profile export claude-code mytool, then brig profile edit mytool\n")
+	fmt.Printf("to override one:  brig agent new claude-code --from claude-code, then brig agent edit claude-code\n")
+	fmt.Printf("to add your own:  brig agent new mytool --from claude-code, then brig agent edit mytool\n")
 	fmt.Printf("to build an image for one: %s\n", profile.BringYourOwnImageDoc)
 	return nil
 }
@@ -1190,68 +1205,140 @@ func handCreatedNames(p profile.Profile) []string {
 	return names
 }
 
-// profileUsage is what `brig profile --help` prints. Held here rather than in
-// the top-level usage text for the same reason secretUsage is: it names the
-// flags of five verbs, which is more than the one line the command list can
-// give them.
-const profileUsage = `brig profile -- manage profiles
+// agentUsage is what `brig agent --help` prints. Held here rather than in the
+// top-level usage text for the same reason secretUsage is: it names the flags
+// of seven verbs, which is more than the one line the command list can give
+// them.
+const agentUsage = `brig agent -- the agents you can run
 
 usage:
-  brig profile ls                        list the profiles
-  brig profile export <profile>          print one, to edit or to pipe
-  brig profile export <profile> <name>   save it as <name> in the profile dir
-  brig profile import <file>             add one of your own (- reads stdin)
-  brig profile edit <name>               open yours in $VISUAL or $EDITOR
-  brig profile rm <name> [-y]            delete yours, after asking
+  brig agent ls                          list the agents you can run
+  brig agent show <agent> [--json]       print one, to read or to pipe
+  brig agent new <name> --from <agent>   copy one under a name of your own
+  brig agent edit <name>                 open yours in $VISUAL or $EDITOR
+  brig agent rm <name> [-y]              delete yours, after asking
+  brig agent import <file>               add one of your own (- reads stdin)
+  brig agent export <agent> [name]       print one, or save it as <name>
 
 flags:
-      --json        with export: render JSON rather than YAML
-  -f, --force       with export: replace a file that is already there
+      --from AGENT  with new: the agent to copy
+      --json        with show, export and new: JSON rather than YAML
+  -f, --force       with new and export: replace a file that is already there
   -y, --yes         with rm: the answer, given in advance
 
-A destination is a name and never a path: export writes the profile directory
-and nowhere else, because that is the only place a profile file does anything.
-Redirect the no-destination form to put a copy of your own anywhere.
+An agent brig ships is built in and has no file. new gives you a copy that
+does, under a name of your own and with that name written into it, so
+` + "`brig agent edit`" + ` and ` + "`brig run`" + ` both reach it by the name you picked.
 
-A profile saves you spelling out the image, the guest home and the credential
-variables on every run. Export the closest one, edit it, import it back.
-Building an image for one is documented at
+A destination is a name and never a path: brig writes one directory of its own
+and nowhere else, because that is the only place one of these files does
+anything. Redirect ` + "`brig agent show`" + ` to put a copy anywhere of your own.
+
+An agent entry saves you spelling out the image, the guest home and the
+credential variables on every run. Copy the closest one and edit it. Building
+an image for one is documented at
   ` + profile.BringYourOwnImageDoc + `
 `
 
-// profileCmd groups the profile verbs, which is where someone coming from
-// another sandbox tool will look for them.
-func profileCmd(args []string) error {
+// agentCmd groups the verbs that manage the agents brig can run.
+//
+// One noun, one verb set: ls, show, new, edit, rm, import, export. The group
+// was called profile and its listing was also a top-level `brig profiles`,
+// while show and new were two shapes of one `brig export` -- three ways of
+// spelling the same group, none of which told a reader which of the three the
+// next command would want. deprecatedProfileCmd keeps every old spelling
+// working; this is the only one the help text teaches.
+//
+// The noun is the CLI's alone. internal/profile, BRIG_PROFILE_DIR and
+// ~/.brig/profiles/ keep their names: renaming them is a mechanical diff
+// across the tree that would land on top of this one and compete with it for
+// review, and it changes nothing anyone types.
+func agentCmd(args []string) error {
 	if len(args) == 0 {
-		return errors.New("profile needs a subcommand: ls, export, import, edit or rm")
+		return errors.New("agent needs a subcommand: ls, show, new, edit, rm, import or export")
 	}
 	var err error
 	switch args[0] {
 	case "--help", "-h", "help":
-		fmt.Print(profileUsage)
+		fmt.Print(agentUsage)
 		return nil
-	case "ls", "list":
+	case "ls":
 		return listProfiles()
-	case "export", "save":
+	case "show":
+		err = showAgent(args[1:])
+	case "new":
+		err = newAgent(args[1:])
+	case "export":
 		err = exportProfile(args[1:])
-	case "import", "load":
+	case "import":
 		err = importProfile(args[1:])
 	case "edit":
 		err = editProfile(args[1:])
 	case "rm":
 		err = removeProfile(args[1:])
+	// The undocumented second spellings, kept for one release. They were never
+	// in the help text, so they were found by accident and then written into
+	// scripts, which is exactly why they cannot simply disappear.
+	case "list":
+		deprecated("brig agent list", "brig agent ls")
+		return listProfiles()
+	case "save":
+		deprecated("brig agent save", "brig agent export")
+		err = exportProfile(args[1:])
+	case "load":
+		deprecated("brig agent load", "brig agent import")
+		err = importProfile(args[1:])
 	default:
-		return fmt.Errorf("unknown profile subcommand %q (ls, export, import, edit, rm)", args[0])
+		return fmt.Errorf("unknown agent subcommand %q "+
+			"(ls, show, new, edit, rm, import, export)", args[0])
 	}
 	// A verb's own parser reports --help as an error, because that is how the
 	// flag package says it. Asking for help is not a mistake, so it is answered
 	// with the help and an exit code of zero -- the same translation the secret
 	// group makes, and for the same reason.
 	if errors.Is(err, flag.ErrHelp) {
-		fmt.Print(profileUsage)
+		fmt.Print(agentUsage)
 		return nil
 	}
 	return err
+}
+
+// deprecatedProfileCmd is `brig profile <verb>`, which is now
+// `brig agent <verb>`.
+//
+// The notice names the subcommand rather than the group, because the verbs do
+// not all retire onto the same word: export splits into show and new for the
+// two lines people actually type, and a notice reading "`brig profile` is now
+// `brig agent`" would leave the reader to work out which of the two theirs
+// became. Whatever they typed still runs -- agentCmd does the work -- so the
+// notice is the only difference between the old spelling and the new one.
+func deprecatedProfileCmd(args []string) error {
+	if len(args) == 0 {
+		deprecated("brig profile", "brig agent")
+		return agentCmd(args)
+	}
+	// The verb the old spelling maps onto, for the notice. Anything not listed
+	// is a mistake rather than a retired spelling, and agentCmd names the real
+	// verbs for it -- so it hears no notice, which is right: there is nothing
+	// to stop typing.
+	now := map[string]string{
+		"ls": "ls", "list": "ls",
+		"export": "export", "save": "export",
+		"import": "import", "load": "import",
+		"edit": "edit",
+		"rm":   "rm",
+	}
+	verb, known := now[args[0]]
+	if !known {
+		if isHelp(args[0]) {
+			deprecated("brig profile", "brig agent")
+		}
+		return agentCmd(args)
+	}
+	deprecated("brig profile "+args[0], "brig agent "+verb)
+	// Translated to the current verb, so `brig profile save` does not go on to
+	// hear agentCmd's notice for save as well: one command, one notice.
+	return agentCmd(append([]string{verb}, args[1:]...))
 }
 
 // editProfile opens a file-backed profile in your editor.
@@ -1263,19 +1350,19 @@ func profileCmd(args []string) error {
 // version and no longer picking up a deny entry added in a later release.
 func editProfile(args []string) error {
 	if len(args) == 0 {
-		return errors.New("profile edit needs a name, for example `brig profile edit mine`")
+		return errors.New("edit needs a name, for example `brig agent edit mine`")
 	}
 	name := args[0]
 	p, ok := profile.Lookup(name)
 	if !ok {
-		return notFoundf("unknown profile %q. `brig profiles` lists them", name)
+		return notFoundf("unknown profile %q. `brig agent ls` lists them", name)
 	}
 	path, ok := profile.Path(p.Name)
 	if !ok {
 		return fmt.Errorf("%s is built in, so there is no file to edit.\n"+
 			"To override it:\n"+
-			"  brig profile export %s %s\n"+
-			"  brig profile edit %s",
+			"  brig agent new %s --from %s\n"+
+			"  brig agent edit %s",
 			p.Name, p.Name, p.Name, p.Name)
 	}
 
@@ -1313,10 +1400,11 @@ func editorCommand() []string {
 }
 
 // importProfile adds a profile of your own. Reading from - lets it come out of
-// a pipe, which is what makes `brig export x | edit | brig import -` work.
+// a pipe, which is what makes `brig agent show x | edit | brig agent import -`
+// work.
 func importProfile(args []string) error {
 	if len(args) == 0 {
-		return fmt.Errorf("import needs a file, for example `brig profile import mine.yaml` "+
+		return fmt.Errorf("import needs a file, for example `brig agent import mine.yaml` "+
 			"(or - to read stdin). See %s", profile.BringYourOwnImageDoc)
 	}
 	var blob []byte
@@ -1345,7 +1433,7 @@ func importProfile(args []string) error {
 	p, path, err := profile.Import(blob, dir)
 	if err != nil {
 		return fmt.Errorf("%w\n\nA profile needs at least a name, an image, a guest home, "+
-			"a binary, mem and cpus. `brig profile export claude-code` prints a working one "+
+			"a binary, mem and cpus. `brig agent show claude-code` prints a working one "+
 			"to start from, and %s explains how to build the image", err, profile.BringYourOwnImageDoc)
 	}
 	fmt.Printf("imported %s -> %s\n", p.Name, path)
@@ -1357,86 +1445,200 @@ func importProfile(args []string) error {
 	return nil
 }
 
-// exportProfile prints a profile, or writes it to a file. YAML by default,
-// because the result is meant to be edited; --json for anything consuming it
-// programmatically.
+// exportLine is one line of show, new or export after parsing: the bare words
+// in the order they were typed, and the flags that were set.
 //
-// A destination is a name, never a path: `brig profile export codex mine`
-// writes mine.yaml into the profile directory, because that is the only place
-// a profile file does anything. See profile.ExportPath, which owns the rule.
+// The three verbs are one operation with different lines around it -- render a
+// profile, to stdout or into the profile directory -- so they share a parser
+// rather than keeping three copies of the loop below. Which flags a verb offers
+// is passed in, because the message an unknown flag gets has to name that
+// verb's own set: telling `brig agent show` it takes --force would advertise a
+// flag it does not have.
+type exportLine struct {
+	words  []string
+	asJSON bool
+	force  bool
+	from   string
+}
+
+// exportFlags is which of the optional flags a verb offers, and the prose that
+// names them when one is mistyped.
+type exportFlags struct {
+	force bool
+	from  bool
+	takes string
+}
+
+// parseExportLine reads a render verb's arguments.
 //
-// The destination is also the name written into the file. brig keys on the
-// name: field rather than on the file name, so the two disagreeing is the
-// difference between a profile of your own and a copy of someone else's under
-// a misleading file name -- see profile.ExportAs.
+// Parse stops at the first bare word, so a flag written after one -- `export
+// codex mine --json`, the order the docs use -- would otherwise be left
+// sitting in Args. Lift the word and parse on.
 //
-// With no destination it prints, which is what keeps
-// `brig profile export x | brig profile import -` working, what stops the
-// command writing anything you did not ask for, and how you get a copy
-// anywhere else: redirect it.
 // Unlike the run line, nothing here passes through to another program, so an
 // unrecognised flag is a mistake rather than someone else's argument and the
 // flag package can reject it outright. Without that, a mistyped flag falls
 // through to the destination and export writes a file called --jsonn.
-func exportProfile(args []string) error {
-	asJSON, force := false, false
-	fs := flag.NewFlagSet("export", flag.ContinueOnError)
+func parseExportLine(verb string, args []string, offers exportFlags) (exportLine, error) {
+	var line exportLine
+	fs := flag.NewFlagSet(verb, flag.ContinueOnError)
 	fs.SetOutput(io.Discard)
 	fs.Usage = func() {}
-	fs.BoolVar(&asJSON, "json", false, "")
-	fs.BoolVar(&force, "force", false, "")
-	fs.BoolVar(&force, "f", false, "")
-
-	// Parse stops at the first bare word, so a flag written after the
-	// destination -- `export codex mine --json`, the order the docs use --
-	// would otherwise be left sitting in Args. Lift the word and parse on.
-	var words []string
+	fs.BoolVar(&line.asJSON, "json", false, "")
+	if offers.force {
+		fs.BoolVar(&line.force, "force", false, "")
+		fs.BoolVar(&line.force, "f", false, "")
+	}
+	if offers.from {
+		fs.StringVar(&line.from, "from", "", "")
+	}
 	for rest := args; ; {
 		if err := fs.Parse(rest); err != nil {
-			// The unknown flag is export's own case: on the run line one never
-			// reaches the flag package, because it belongs to the agent. Every
-			// other error the parser can raise here is one the run line already
-			// says in brig's voice, so say it the same way.
+			if errors.Is(err, flag.ErrHelp) {
+				return line, err
+			}
+			// The unknown flag is this group's own case: on the run line one
+			// never reaches the flag package, because it belongs to the agent.
+			// Every other error the parser can raise here is one the run line
+			// already says in brig's voice, so say it the same way.
 			msg := err.Error()
 			if name, ok := strings.CutPrefix(msg, "flag provided but not defined: "); ok {
 				msg = "unknown flag " + spell(name)
 			} else {
 				msg = rewriteFlagError(err).Error()
 			}
-			return fmt.Errorf("%s (export takes --json and --force)", msg)
+			return line, fmt.Errorf("%s (%s takes %s)", msg, verb, offers.takes)
 		}
 		if fs.NArg() == 0 {
-			break
+			return line, nil
 		}
-		words = append(words, fs.Arg(0))
+		line.words = append(line.words, fs.Arg(0))
 		rest = fs.Args()[1:]
 	}
+}
+
+// showAgent prints one agent entry and writes nothing. It is the spelling
+// `brig export <profile>` had, under the noun it belongs to.
+//
+// A second word is refused rather than read as a destination, which is the one
+// place show and the old top-level export differ: `brig export claude mine`
+// wrote a file, so anyone with that in their fingers gets the command that took
+// the job over rather than a file they did not ask for.
+func showAgent(args []string) error {
+	line, err := parseExportLine("show", args, exportFlags{takes: "--json"})
+	if err != nil {
+		return err
+	}
+	switch len(line.words) {
+	case 0:
+		return errors.New("show needs an agent, for example `brig agent show claude-code`")
+	case 1:
+	default:
+		return fmt.Errorf("show prints one agent and writes nothing, so it takes no "+
+			"destination. To copy one under a name of your own: brig agent new %s --from %s",
+			line.words[1], line.words[0])
+	}
+	return renderProfile(line.words[0], "", line.asJSON, false)
+}
+
+// newAgent copies an agent entry under a name of your own, which is the
+// spelling `brig export <profile> <name>` had.
+//
+// --from rather than a second bare word, because the two words are not
+// interchangeable and the old line gave a reader no way to tell which order it
+// wanted. The name comes first here for the same reason it does in
+// `brig secret create <name>`: the thing being made is the operand.
+//
+// The name is written into the file, not just onto it -- see profile.ExportAs.
+// That is the defect this rename fixes: the recipe brig prints failed on its
+// own second step, because the copy still declared the profile it came from
+// and `brig agent edit <name>` had nothing of that name to open.
+func newAgent(args []string) error {
+	line, err := parseExportLine("new", args,
+		exportFlags{force: true, from: true, takes: "--from, --json and --force"})
+	if err != nil {
+		return err
+	}
+	switch len(line.words) {
+	case 0:
+		return errors.New("new needs a name, for example " +
+			"`brig agent new mine --from claude-code`")
+	case 1:
+	default:
+		// Both words are named and neither is guessed at. `new mine codex` and
+		// `new codex mine` are both lines someone types -- the second is the
+		// old `brig export codex mine` order -- and picking one would send half
+		// of them a corrected command with the two words the wrong way round.
+		return fmt.Errorf("new takes one name and takes the agent it copies from --from, "+
+			"so it cannot have both %q and %q: brig agent new <name> --from <agent>",
+			line.words[0], line.words[1])
+	}
+	if line.from == "" {
+		return fmt.Errorf("new copies an agent, so it needs one: "+
+			"brig agent new %s --from claude-code. `brig agent ls` lists them", line.words[0])
+	}
+	return renderProfile(line.from, line.words[0], line.asJSON, line.force)
+}
+
+// exportProfile prints a profile, or writes it to a file: the verb `brig agent
+// export` is, and the one `brig profile export` and the top-level `brig export`
+// were. show and new are the taught spellings of its two halves; this is kept
+// because it is the line already in everyone's scripts, word for word.
+func exportProfile(args []string) error {
+	line, err := parseExportLine("export", args,
+		exportFlags{force: true, takes: "--json and --force"})
+	if err != nil {
+		return err
+	}
 	var name, dest string
-	switch len(words) {
+	switch len(line.words) {
 	case 0:
 	case 1:
-		name = words[0]
+		name = line.words[0]
 	case 2:
-		name, dest = words[0], words[1]
+		name, dest = line.words[0], line.words[1]
 	default:
-		return fmt.Errorf("export takes a profile and at most one destination, not %q", words[2])
+		return fmt.Errorf("export takes an agent and at most one destination, not %q",
+			line.words[2])
 	}
 	if name == "" {
-		return errors.New("export needs a profile, for example `brig profile export claude-code`")
+		return errors.New("export needs an agent, for example `brig agent export claude-code`")
 	}
+	return renderProfile(name, dest, line.asJSON, line.force)
+}
+
+// renderProfile is what show, new and export all do: look one profile up and
+// render it, to stdout or into the profile directory. YAML by default, because
+// the result is meant to be edited; --json for anything consuming it
+// programmatically.
+//
+// A destination is a name, never a path: `brig agent new mine --from codex`
+// writes mine.yaml into the profile directory, because that is the only place
+// a profile file does anything. See profile.ExportPath, which owns the rule.
+//
+// The destination is also the name written into the file. brig keys on the
+// name: field rather than on the file name, so the two disagreeing is the
+// difference between an agent of your own and a copy of someone else's under
+// a misleading file name -- see profile.ExportAs.
+//
+// With no destination it prints, which is what keeps
+// `brig agent show x | brig agent import -` working, what stops the command
+// writing anything you did not ask for, and how you get a copy anywhere else:
+// redirect it.
+func renderProfile(name, dest string, asJSON, force bool) error {
 	p, ok := profile.Lookup(name)
 	if !ok {
-		return notFoundf("unknown profile %q. `brig profiles` lists them", name)
+		return notFoundf("unknown profile %q. `brig agent ls` lists them", name)
 	}
 	path, err := profile.ExportPath(dest, asJSON)
 	if err != nil {
 		return err
 	}
-	// The name the exported profile carries: the file's own stem when there is
-	// a file, so that `brig profile export claude-code mytool` writes a profile
-	// called mytool and `brig profile edit mytool` can then open it. With no
-	// destination there is no file to agree with, and the export is the profile
-	// as it stands.
+	// The name the rendered profile carries: the file's own stem when there is
+	// a file, so that `brig agent new mytool --from claude-code` writes a profile
+	// called mytool and `brig agent edit mytool` can then open it. With no
+	// destination there is no file to agree with, and what is printed is the
+	// profile as it stands.
 	as := p.Name
 	if path != "" {
 		as = stemOf(path)
@@ -1447,7 +1649,7 @@ func exportProfile(args []string) error {
 	// name rather than copying one that was already checked.
 	if owner, reserved := profile.Reserved(as); reserved && as != owner {
 		return fmt.Errorf("a profile named %q would collide with the %s profile, which "+
-			"reserves that word. Export it under another name", as, owner)
+			"reserves that word. Copy it under another name", as, owner)
 	}
 	// An alias is the same collision one step further out: the word is already
 	// how people spell a profile, and a profile of that name wins the lookup,
@@ -1457,7 +1659,7 @@ func exportProfile(args []string) error {
 	// a run booting an image nobody chose.
 	if owner, ok := profile.Alias(as); ok {
 		return fmt.Errorf("a profile named %q would collide with %s, which is what brig "+
-			"already runs for that word. Export it under another name", as, owner)
+			"already runs for that word. Copy it under another name", as, owner)
 	}
 	render := profile.ExportAs
 	if asJSON {
@@ -1481,7 +1683,7 @@ func exportProfile(args []string) error {
 				"to replace it with a fresh export of %s", path, p.Name)
 		}
 	}
-	// The directory may not exist yet: `brig profile edit` points a first-time
+	// The directory may not exist yet: `brig agent edit` points a first-time
 	// user straight here, and on a fresh install nothing has created it. 0700
 	// per the XDG spec, and the right mode for files naming credentials.
 	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
@@ -1508,7 +1710,7 @@ func exportProfile(args []string) error {
 	if as != p.Name {
 		fmt.Printf("its image, guest home and comments still describe %s\n", p.Name)
 	}
-	fmt.Printf("edit it with: brig profile edit %s\n", as)
+	fmt.Printf("edit it with: brig agent edit %s\n", as)
 	return nil
 }
 
@@ -1526,7 +1728,7 @@ func stemOf(path string) string {
 // -y is the answer to the question below, given in advance, and it is spelled
 // the way the secret verbs spell it.
 func removeProfile(args []string) error {
-	name, yes, err := nameAndYes("profile rm", "brig profile rm mine", args)
+	name, yes, err := nameAndYes("rm", "brig agent rm mine", args)
 	if err != nil {
 		return err
 	}
@@ -1561,18 +1763,18 @@ func removeProfile(args []string) error {
 //
 // rm resolves the argument through the registry, which is what lets it work on
 // an alias and on a file whose basename says nothing about the profile inside
-// it. That resolution is also how `brig profile rm claude-code` could delete a
+// it. That resolution is also how `brig agent rm claude-code` could delete a
 // file called mytool.yaml and exit 0 without a word: the file the person had a
 // name for and the file brig found were different files, and only brig knew
 // which.
 //
 // So the question is whether brig had to work anything out, and there are two
 // ways it does. The argument may not be the profile's own name, which is the
-// alias case: `brig profile rm claude` deletes whatever backs claude-code, and
+// alias case: `brig agent rm claude` deletes whatever backs claude-code, and
 // a file called claude.yaml declaring claude-code carries the stem the
 // argument spells while being a profile the argument never said. And a file's
 // basename may not be the argument at all, which is the renamed-by-hand case
-// and the second-file-shadowing-the-first case. `brig profile rm mytool`
+// and the second-file-shadowing-the-first case. `brig agent rm mytool`
 // against mytool.yaml declaring mytool is the one combination that is exactly
 // what was typed -- what export writes, and the only case where nothing can
 // surprise you.
@@ -1614,7 +1816,7 @@ func confirmRemoveProfile(arg, resolved string, files []string, yes bool) error 
 	if !wrap.IsTerminal(os.Stdin) {
 		return fmt.Errorf("removing %q would delete %s, which brig worked out from the "+
 			"name you typed rather than being told, and there is no terminal to ask on. "+
-			"Pass -y to answer in advance: brig profile rm %s -y", arg, list, arg)
+			"Pass -y to answer in advance: brig agent rm %s -y", arg, list, arg)
 	}
 	fmt.Fprintf(os.Stderr, "brig: removing %q deletes %s, which %s the %s profile. "+
 		"Remove it? [y/N] ", arg, list, declares, resolved)
@@ -1622,7 +1824,7 @@ func confirmRemoveProfile(arg, resolved string, files []string, yes bool) error 
 	if err != nil {
 		// EOF is the answer a closed stdin gives, and it is not yes.
 		return fmt.Errorf("aborted: nothing was removed. To answer in advance: "+
-			"brig profile rm %s -y", arg)
+			"brig agent rm %s -y", arg)
 	}
 	switch strings.ToLower(strings.TrimSpace(line)) {
 	case "y", "yes":

--- a/cmd/brig/policy.go
+++ b/cmd/brig/policy.go
@@ -22,7 +22,12 @@ func policyCmd(args []string) error {
 		return errors.New("policy needs a subcommand: ls, create, edit, show or rm")
 	}
 	switch args[0] {
-	case "ls", "list":
+	case "ls":
+		return listPolicies()
+	// list was never in the help text, so it was found by accident and then
+	// scripted. Kept for one release, saying which spelling to keep.
+	case "list":
+		deprecated("brig policy list", "brig policy ls")
 		return listPolicies()
 	case "create":
 		return createPolicy(args[1:])
@@ -88,7 +93,7 @@ func lookupPolicy(name string) (policy.Entry, error) {
 	}
 	e, ok := entries[name]
 	if !ok {
-		return policy.Entry{}, fmt.Errorf("unknown policy %q. `brig policies` lists them", name)
+		return policy.Entry{}, fmt.Errorf("unknown policy %q. `brig policy ls` lists them", name)
 	}
 	return e, nil
 }
@@ -296,7 +301,7 @@ func editPolicy(args []string) error {
 	}
 	// The system temp directory, not policy.Dir(): a scratch copy that
 	// failed to clean up would otherwise sit in the policy directory with a
-	// name isPolicyFile matches, and every later `brig policies` would
+	// name isPolicyFile matches, and every later `brig policy ls` would
 	// report it as a broken policy rather than leftover editor debris.
 	scratch, err := os.CreateTemp("", "brig-policy-edit-*"+filepath.Ext(entry.Path))
 	if err != nil {
@@ -353,7 +358,7 @@ func editPolicy(args []string) error {
 	// file is always the old content or the new one, never a partial
 	// write. The name does not end in .yaml/.yml/.json, so a rename that
 	// never happens leaves debris isPolicyFile ignores, not a policy
-	// brig policies reports as broken.
+	// brig policy ls reports as broken.
 	//
 	// os.WriteFile never changed entry.Path's mode -- an existing file
 	// keeps whatever it already had, and only a newly created one takes

--- a/cmd/brig/profile_test.go
+++ b/cmd/brig/profile_test.go
@@ -262,16 +262,17 @@ func TestListProfilesReportsBindingsAndRequiredSecrets(t *testing.T) {
 	}
 }
 
-// ls and list are the same listing. There is no reason to make anyone guess
-// which spelling brig wants.
-func TestProfileLsAndListAreSynonyms(t *testing.T) {
+// ls and list are the same listing. list is retiring and says so -- see
+// TestRetiredSpellingsWorkAndNameTheirReplacement -- but it still lists, which
+// is the half this test is about.
+func TestAgentLsAndListAreSynonyms(t *testing.T) {
 	t.Setenv("BRIG_PROFILE_DIR", t.TempDir())
 	for _, verb := range []string{"ls", "list"} {
-		if err := profileCmd([]string{verb}); err != nil {
-			t.Errorf("brig profile %s: %v", verb, err)
+		if err := agentCmd([]string{verb}); err != nil {
+			t.Errorf("brig agent %s: %v", verb, err)
 		}
 	}
-	if err := profileCmd([]string{"nonsense"}); err == nil {
+	if err := agentCmd([]string{"nonsense"}); err == nil {
 		t.Error("an unknown subcommand was accepted")
 	}
 }
@@ -523,7 +524,7 @@ func TestListProfilesSeparatesImportableSecretsFromHandCreatedOnes(t *testing.T)
 	}
 }
 
-// The recipe brig prints has to work as written: export the closest built-in
+// The recipe brig prints has to work as written: copy the closest built-in
 // under a name of your own, edit it, run it, remove it by the name you chose.
 // Every step addresses that name, which is what did not work while the file
 // was called mytool.yaml and the profile inside it was still claude-code --
@@ -531,14 +532,30 @@ func TestListProfilesSeparatesImportableSecretsFromHandCreatedOnes(t *testing.T)
 // name of the profile it was copied from. The run leg is script/smoke.sh,
 // which has a runtime to boot against; what a run needs from here is that the
 // name resolves to this file, with the settings it was copied from.
-func TestExportedProfileIsEditableAndRemovableByItsNewName(t *testing.T) {
+//
+// Driven through run() and `brig agent new`, which is the command the recipe
+// now names. That is the spelling whose whole reason to exist is the rename in
+// the file, so it is the one worth pinning end to end rather than the library
+// call underneath it.
+func TestNewAgentIsEditableAndRemovableByItsNewName(t *testing.T) {
 	dir := t.TempDir()
 	t.Setenv("BRIG_PROFILE_DIR", dir)
 	if err := profile.Load(profile.Dir()); err != nil {
 		t.Fatal(err)
 	}
-	if err := exportProfile([]string{"claude-code", "mytool"}); err != nil {
+	if _, err := captureStdout(t, func() error {
+		return run([]string{"agent", "new", "mytool", "--from", "claude-code"})
+	}); err != nil {
 		t.Fatal(err)
+	}
+	// The name is written into the file, not merely onto it: brig keys on the
+	// name: field, so a copy still declaring claude-code is a file that only
+	// the profile it came from can reach.
+	if blob, err := os.ReadFile(filepath.Join(dir, "mytool.yaml")); err != nil {
+		t.Fatalf("brig agent new wrote nothing into the profile directory: %v", err)
+	} else if !strings.Contains(string(blob), "name: mytool") ||
+		strings.Contains(string(blob), "name: claude-code") {
+		t.Errorf("the copy does not declare the name it was given:\n%s", blob)
 	}
 	if err := profile.Load(profile.Dir()); err != nil {
 		t.Fatal(err)
@@ -626,10 +643,10 @@ func TestRemoveProfileAsksBeforeDeletingAFileYouDidNotName(t *testing.T) {
 
 // Asking for help is not a mistake. The verbs parse their own flags, and the
 // flag package reports --help as an error, so without translating it here
-// `brig profile rm --help` answers a reasonable question with
+// `brig agent rm --help` answers a reasonable question with
 // `brig: flag: help requested` and exits 1. The secret group already answers
 // its own the other way.
-func TestProfileHelpPrintsUsageAndSucceeds(t *testing.T) {
+func TestAgentGroupHelpPrintsUsageAndSucceeds(t *testing.T) {
 	dir := t.TempDir()
 	t.Setenv("BRIG_PROFILE_DIR", dir)
 	if err := profile.Load(profile.Dir()); err != nil {
@@ -637,13 +654,14 @@ func TestProfileHelpPrintsUsageAndSucceeds(t *testing.T) {
 	}
 	for _, args := range [][]string{
 		{"rm", "--help"}, {"rm", "-h"}, {"--help"}, {"-h"}, {"help"},
+		{"new", "--help"}, {"show", "--help"},
 	} {
-		out, err := captureStdout(t, func() error { return profileCmd(args) })
+		out, err := captureStdout(t, func() error { return agentCmd(args) })
 		if err != nil {
-			t.Errorf("profile %v: %v", args, err)
+			t.Errorf("agent %v: %v", args, err)
 		}
-		if !strings.Contains(out, "brig profile rm") {
-			t.Errorf("profile %v printed no usage:\n%s", args, out)
+		if !strings.Contains(out, "brig agent rm") {
+			t.Errorf("agent %v printed no usage:\n%s", args, out)
 		}
 	}
 }

--- a/cmd/brig/secret.go
+++ b/cmd/brig/secret.go
@@ -21,6 +21,16 @@ var openStore = secret.Open
 
 // secretCmd groups the secret verbs.
 //
+// create|update|read|delete|ls|import, and not the ls|show|set|rm the other
+// nouns settled on. That is a decision rather than the one group nobody got
+// round to: `set` means createOrUpdate, so a typo in the name writes a second
+// secret instead of failing, and the run that needed the first one fails much
+// later with a credential the sandbox never received. create and update each
+// refuse the case the other is for, and a secret is the one thing here where
+// silently writing the wrong item costs more than an inconsistent verb.
+// TestSecretKeepsItsOwnVerbSetOnPurpose pins it, so that the next reader who
+// notices the inconsistency finds the reason before changing it.
+//
 // Output goes to a writer rather than straight to stdout, because `read`
 // writes a credential: a test that could not capture it would have to assert
 // on the store instead, which is the one thing these tests are not about.
@@ -39,9 +49,20 @@ func secretCmd(out io.Writer, args []string) error {
 		err = writeSecret(args[1:], "update")
 	case "read":
 		err = readSecret(out, args[1:])
-	case "delete", "rm":
+	case "delete":
 		err = deleteSecret(out, args[1:])
-	case "ls", "list":
+	case "ls":
+		err = listSecrets(out, args[1:])
+	// The undocumented second spellings, kept for one release. delete and ls
+	// are the words this group settled on -- see the note on secretUsage about
+	// why the verb set here is not the one the other nouns use -- and rm and
+	// list were never in the help text, so they were found by accident and then
+	// written into scripts.
+	case "rm":
+		deprecated("brig secret rm", "brig secret delete")
+		err = deleteSecret(out, args[1:])
+	case "list":
+		deprecated("brig secret list", "brig secret ls")
 		err = listSecrets(out, args[1:])
 	case "import":
 		err = importSecrets(out, args[1:])
@@ -324,7 +345,7 @@ func readAnswer(r io.Reader) (string, error) {
 // `delete gh-token -y` are both lines people type, and Parse stops at the
 // first bare word.
 //
-// The verb and the example it prints are parameters because `brig profile rm`
+// The verb and the example it prints are parameters because `brig agent rm`
 // asks a question of its own now, and every word of these messages is about
 // the command the person typed. Two copies of the loop below would drift.
 func nameAndYes(verb, example string, args []string) (name string, yes bool, err error) {

--- a/cmd/brig/secretimport.go
+++ b/cmd/brig/secretimport.go
@@ -460,7 +460,7 @@ func unknownImportTarget(name string) error {
 				"declares it: brig secret import %s %s", name, p.Name, name)
 		}
 	}
-	return fmt.Errorf("unknown profile %q. `brig profiles` lists them", name)
+	return fmt.Errorf("unknown profile %q. `brig agent ls` lists them", name)
 }
 
 // describe renders a locator for a person. A command's provenance is the bare

--- a/internal/profile/file.go
+++ b/internal/profile/file.go
@@ -19,9 +19,9 @@ import (
 // credential variables every time.
 //
 // They live as one file per profile in a directory, which makes them
-// diffable, reviewable and easy to share -- and means `brig export` followed
-// by an edit is the way to write one, rather than starting from a blank file
-// and a guess about the field names.
+// diffable, reviewable and easy to share -- and means `brig agent show`
+// followed by an edit is the way to write one, rather than starting from a
+// blank file and a guess about the field names.
 //
 // YAML or JSON, read the same way: JSON is a subset of YAML, so one parser
 // handles both and nothing has to guess at a format. Export writes YAML,
@@ -254,7 +254,7 @@ const firstHeaderLine = "# A brig profile."
 // exportHeader is what makes an exported profile a starting point rather
 // than a puzzle. It is the one thing JSON could not carry, and the reason
 // export writes YAML: the fields are explained where you are editing them.
-const exportHeader = firstHeaderLine + ` Edit it, then: brig profile import <this file>
+const exportHeader = firstHeaderLine + ` Edit it, then: brig agent import <this file>
 #
 #   name       the profile name. Also the workspace directory and the sandbox
 #              name, so: lowercase letters, digits, dot, dash, underscore
@@ -361,7 +361,7 @@ func Files(name string) []string {
 // deleted.
 //
 // Every file, not only the one that loaded. Deleting the winner alone promotes
-// whichever file was shadowed by it, so `brig profile rm codex` would report
+// whichever file was shadowed by it, so `brig agent rm codex` would report
 // success and leave codex listed exactly as before -- the one outcome an rm
 // must not have.
 func Remove(name string) ([]string, error) {
@@ -422,7 +422,7 @@ func LegacyHint() string {
 		return ""
 	}
 	return fmt.Sprintf("%d profile(s) in %s are not read any more; they live in %s now. "+
-		"`brig profile import %s` moves one across.",
+		"`brig agent import %s` moves one across.",
 		n, old, Dir(), filepath.Join(old, "<file>"))
 }
 
@@ -436,9 +436,9 @@ func LegacyHint() string {
 // scatter files across the host on a typo.
 //
 // Wanting a copy somewhere else is a real thing to want, and it already has a
-// spelling: with no destination export writes stdout, so `brig profile export
-// codex > mine.yaml` puts it wherever you like, under the shell's rules rather
-// than brig's.
+// spelling: `brig agent show` writes stdout, so `brig agent show codex >
+// mine.yaml` puts it wherever you like, under the shell's rules rather than
+// brig's.
 //
 // An empty destination stays empty: that is the stdout case, and the caller
 // decides what to do with it.
@@ -448,7 +448,7 @@ func ExportPath(dest string, asJSON bool) (string, error) {
 	}
 	if looksLikePath(dest) {
 		return "", fmt.Errorf("%q is a path, and export takes a name: it writes into %s "+
-			"and nowhere else. Use `brig profile export <profile> > %s` to put a copy "+
+			"and nowhere else. Use `brig agent show <agent> > %s` to put a copy "+
 			"somewhere of your own", dest, Dir(), dest)
 	}
 	base := dest
@@ -485,7 +485,7 @@ func looksLikePath(s string) bool {
 // reference prepended.
 //
 // Verbatim, because starting from the closest existing profile is the
-// documented way to write one: `brig profile export claude-code` should hand
+// documented way to write one: `brig agent show claude-code` should hand
 // you the annotated file brig ships, not an alphabetised struct dump with
 // every comment stripped. A profile built in Go rather than read from a file
 // has no bytes to return, so that case still marshals.
@@ -513,7 +513,7 @@ func Export(p Profile) ([]byte, error) {
 // Starting from the closest existing profile is the documented way to write
 // one, and the recipe brig prints for it stopped at its second step until this
 // existed: export wrote the file under the name you gave it while the profile
-// inside kept the name it came from, so `brig profile edit mytool` had no such
+// inside kept the name it came from, so `brig agent edit mytool` had no such
 // profile to open and the only command that could reach the file named a
 // different profile and deleted it without asking.
 //
@@ -524,7 +524,7 @@ func Export(p Profile) ([]byte, error) {
 // sentences gone.
 //
 // An empty name, or the profile's own, renders unchanged -- that is the plain
-// `brig profile export claude-code` case, where nothing was asked to be
+// `brig agent show claude-code` case, where nothing was asked to be
 // renamed.
 func ExportAs(p Profile, name string) ([]byte, error) {
 	blob, err := Export(p)

--- a/internal/profile/profile.go
+++ b/internal/profile/profile.go
@@ -88,7 +88,7 @@ type Profile struct {
 	// Name is the profile name, the community-images image name, and the
 	// taxonomer AgentRuntime value: one string, three uses.
 	Name string `json:"name"`
-	// Desc is one line for `brig agents`.
+	// Desc is one line for `brig agent ls`.
 	Desc string `json:"desc,omitempty"`
 	// Binary is the agent CLI inside the guest.
 	Binary string `json:"binary,omitempty"`

--- a/internal/profile/registry.go
+++ b/internal/profile/registry.go
@@ -35,7 +35,7 @@ type entry struct {
 	path   string // the file this entry was read from; empty for a built-in
 
 	// shadowed are the files that also claim this name and lost. Kept
-	// because they are still on disk and still claim it: `brig profile rm`
+	// because they are still on disk and still claim it: `brig agent rm`
 	// has to take them too, or removing the winner just promotes the next
 	// one and the profile appears not to have been removed at all.
 	shadowed []string

--- a/script/smoke.sh
+++ b/script/smoke.sh
@@ -781,16 +781,16 @@ grep -q -- '-- bash -lc uname -a' "$STUB_LOG" \
 grep -q -- ':/root/work' "$STUB_LOG" \
   && ok "ubuntu mounts the workspace at /root/work" || bad "ubuntu mounts at /root/work"
 
-echo "== profiles =="
-# YAML is the default spelling, and the header is what makes an export a
+echo "== agents =="
+# YAML is the default spelling, and the header is what makes a printed agent a
 # starting point rather than a puzzle.
-"$WORK/brig" profile export claude-code > "$WORK/mine.yaml" 2>/dev/null
+"$WORK/brig" agent show claude-code > "$WORK/mine.yaml" 2>/dev/null
 grep -q '^# A brig profile' "$WORK/mine.yaml" \
-  && ok "export explains its own fields" || bad "export explains its own fields"
+  && ok "show explains its own fields" || bad "show explains its own fields"
 printf '\n# why: the vendored CLI needs a bigger guest\n' >> "$WORK/mine.yaml"
 sed -i.bak 's/^name: claude-code$/name: mine/; s|ghcr.io/brig-sh/claude-code[^ ]*|docker.io/me/mine:latest|' \
   "$WORK/mine.yaml"
-"$WORK/brig" profile import "$WORK/mine.yaml" > "$WORK/import.out" 2>&1 \
+"$WORK/brig" agent import "$WORK/mine.yaml" > "$WORK/import.out" 2>&1 \
   && ok "an edited YAML export imports back" || bad "an edited YAML export imports back: $(cat "$WORK/import.out")"
 grep -q 'why: the vendored CLI' "$BRIG_PROFILE_DIR/mine.yaml" 2>/dev/null \
   && ok "import keeps the comments you wrote" || bad "import keeps the comments you wrote"
@@ -798,11 +798,11 @@ grep -q 'why: the vendored CLI' "$BRIG_PROFILE_DIR/mine.yaml" 2>/dev/null \
 # JSON still parses, since it is a subset of YAML.
 printf '{"name":"jsonagent","image":"docker.io/me/j:latest","guestHome":"/home/j","binary":"j","mem":1024,"cpus":1}' \
   > "$WORK/j.json"
-"$WORK/brig" profile import "$WORK/j.json" > /dev/null 2>&1 \
+"$WORK/brig" agent import "$WORK/j.json" > /dev/null 2>&1 \
   && ok "a JSON profile still imports" || bad "a JSON profile still imports"
 [ -f "$BRIG_PROFILE_DIR/jsonagent.json" ] \
   && ok "a JSON profile keeps its own extension" || bad "JSON profile keeps its extension"
-profiles="$("$WORK/brig" profiles 2>/dev/null)"
+profiles="$("$WORK/brig" agent ls 2>/dev/null)"
 case "$profiles" in
   *"mine"*"(file)"*) ok "a profile of your own is listed, and marked" ;;
   *) bad "a profile of your own is listed -- got: $profiles" ;;
@@ -811,17 +811,17 @@ grep -q 'cannot verify its signature' "$WORK/import.out" \
   && ok "import says an outside image cannot be verified" \
   || bad "import says an outside image cannot be verified: $(cat "$WORK/import.out")"
 case "$profiles" in
-  *bring-your-own-image*) ok "profiles points at the image documentation" ;;
-  *) bad "profiles points at the image documentation" ;;
+  *bring-your-own-image*) ok "agent ls points at the image documentation" ;;
+  *) bad "agent ls points at the image documentation" ;;
 esac
 # A name that would escape the profile directory, or collide with a path.
 printf 'name: ../evil\nimage: i\nguestHome: /home/x\nbinary: x\nmem: 1\ncpus: 1\n' \
-  | "$WORK/brig" profile import - > /dev/null 2>&1 \
+  | "$WORK/brig" agent import - > /dev/null 2>&1 \
   && bad "an unsafe profile name was accepted" || ok "an unsafe profile name is refused"
 # A misspelled field would forward no credentials, which looks exactly like a
 # broken sandbox.
 printf 'name: typo\nimage: i\nguestHome: /home/x\nbinary: x\nmem: 1\ncpus: 1\nforwards: [GH_TOKEN]\n' \
-  | "$WORK/brig" profile import - > /dev/null 2>&1 \
+  | "$WORK/brig" agent import - > /dev/null 2>&1 \
   && bad "a misspelled field was accepted" || ok "a misspelled field is refused"
 
 # The built-ins are embedded, so nothing is pre-seeded: every profile comes from
@@ -830,18 +830,36 @@ printf 'name: typo\nimage: i\nguestHome: /home/x\nbinary: x\nmem: 1\ncpus: 1\nfo
   && bad "brig pre-seeded the profile directory" \
   || ok "brig does not pre-seed the profile directory"
 
-# Export writes the file brig ships, comments and all -- that is what makes
-# "start from the closest profile" work rather than handing back a struct dump.
-# With no destination it goes to stdout, which is also how you get a copy
-# anywhere other than the profile directory.
-"$WORK/brig" profile export codex > "$WORK/codex.yaml" 2>/dev/null
+# show writes the file brig ships, comments and all -- that is what makes
+# "start from the closest agent" work rather than handing back a struct dump.
+# It goes to stdout, which is also how you get a copy anywhere other than the
+# profile directory.
+"$WORK/brig" agent show codex > "$WORK/codex.yaml" 2>/dev/null
 grep -q 'metered path' "$WORK/codex.yaml" 2>/dev/null \
-  && ok "export keeps the comments explaining the deny list" \
-  || bad "export keeps the comments explaining the deny list"
+  && ok "show keeps the comments explaining the deny list" \
+  || bad "show keeps the comments explaining the deny list"
+
+# show prints one agent and writes nothing, so a second word is the old
+# `brig export <p> <name>` habit rather than a destination. It says which
+# command took that job over.
+"$WORK/brig" agent show codex spare > "$WORK/showdest.out" 2>&1 \
+  && bad "agent show took a destination" || ok "agent show refuses a destination"
+grep -q 'brig agent new spare --from codex' "$WORK/showdest.out" \
+  && ok "agent show names the command that copies one" \
+  || bad "agent show names the command that copies one: $(cat "$WORK/showdest.out")"
+[ -f "$BRIG_PROFILE_DIR/spare.yaml" ] \
+  && bad "agent show wrote a file" || ok "agent show wrote nothing"
+
+# new copies an agent, so it has to be told which one.
+"$WORK/brig" agent new lonely > "$WORK/nofrom.out" 2>&1 \
+  && bad "agent new was accepted without --from" || ok "agent new needs --from"
+grep -q -- '--from' "$WORK/nofrom.out" \
+  && ok "agent new names the flag it wants" \
+  || bad "agent new names the flag it wants: $(cat "$WORK/nofrom.out")"
 
 # A destination is a name and nothing else. brig writes one directory, so a
 # path -- or a typo that looks like one -- is refused rather than honoured.
-"$WORK/brig" profile export codex "$WORK/escape.yaml" > /dev/null 2>&1 \
+"$WORK/brig" agent export codex "$WORK/escape.yaml" > /dev/null 2>&1 \
   && bad "export wrote to a path outside the profile directory" \
   || ok "export refuses a path destination"
 [ -f "$WORK/escape.yaml" ] \
@@ -849,17 +867,17 @@ grep -q 'metered path' "$WORK/codex.yaml" 2>/dev/null \
   || ok "export writes the profile directory and nowhere else"
 
 # A bare destination is a name, and brig resolves it in the profile directory.
-"$WORK/brig" profile export codex bare > /dev/null 2>&1
+"$WORK/brig" agent export codex bare > /dev/null 2>&1
 [ -f "$BRIG_PROFILE_DIR/bare.yaml" ] \
   && ok "a bare export destination lands in the profile directory" \
   || bad "a bare export destination lands in the profile directory"
-"$WORK/brig" profile export codex bare > /dev/null 2>&1 \
+"$WORK/brig" agent export codex bare > /dev/null 2>&1 \
   && bad "export overwrote an existing file" \
   || ok "export refuses to overwrite without --force"
-"$WORK/brig" profile export codex bare --force > /dev/null 2>&1 \
+"$WORK/brig" agent export codex bare --force > /dev/null 2>&1 \
   && ok "--force overwrites" || bad "--force overwrites"
 # A mistyped flag must not become a file name.
-"$WORK/brig" profile export codex --jsonn > /dev/null 2>&1 \
+"$WORK/brig" agent export codex --jsonn > /dev/null 2>&1 \
   && bad "a mistyped flag was taken as a destination" \
   || ok "a mistyped flag is refused rather than written"
 ls "$BRIG_PROFILE_DIR" | grep -q -- '--json' \
@@ -868,26 +886,26 @@ ls "$BRIG_PROFILE_DIR" | grep -q -- '--json' \
 # The destination is the name written into the file, and a profile of that name
 # wins the lookup over an alias -- so exporting onto one would take every
 # `brig run claude` from claude-code.
-"$WORK/brig" profile export claude-code claude > /dev/null 2>&1 \
+"$WORK/brig" agent export claude-code claude > /dev/null 2>&1 \
   && bad "export wrote a profile named after an alias" \
   || ok "export refuses a destination that is an alias"
 [ -f "$BRIG_PROFILE_DIR/claude.yaml" ] \
   && bad "the aliased destination was written anyway" \
   || ok "no file is written for an aliased destination"
 # Asking for help is not a mistake, though the flag package calls it an error.
-"$WORK/brig" profile rm --help > "$WORK/rmhelp.out" 2>&1 \
-  && ok "profile rm --help exits 0" \
-  || bad "profile rm --help exits 0: $(cat "$WORK/rmhelp.out")"
-grep -q 'brig profile rm' "$WORK/rmhelp.out" \
-  && ok "profile rm --help prints the usage" \
-  || bad "profile rm --help prints the usage: $(cat "$WORK/rmhelp.out")"
+"$WORK/brig" agent rm --help > "$WORK/rmhelp.out" 2>&1 \
+  && ok "agent rm --help exits 0" \
+  || bad "agent rm --help exits 0: $(cat "$WORK/rmhelp.out")"
+grep -q 'brig agent rm' "$WORK/rmhelp.out" \
+  && ok "agent rm --help prints the usage" \
+  || bad "agent rm --help prints the usage: $(cat "$WORK/rmhelp.out")"
 # rm resolves the name inside the file, not the file name: rename what
 # bare.yaml declares, and codex is the word that reaches it. Nothing is deleted
 # for that word without a question first, though -- the file it would take is
 # not the file anyone named, and stdin here has nobody on it to ask.
 sed 's/^name: bare$/name: codex/' "$BRIG_PROFILE_DIR/bare.yaml" > "$WORK/bare.yaml"
 cp "$WORK/bare.yaml" "$BRIG_PROFILE_DIR/bare.yaml"
-"$WORK/brig" profile rm codex < /dev/null > "$WORK/rm.out" 2>&1 \
+"$WORK/brig" agent rm codex < /dev/null > "$WORK/rm.out" 2>&1 \
   && bad "rm deleted a file nobody named, without asking" \
   || ok "rm refuses to delete a file you did not name with no terminal to ask on"
 grep -q 'bare.yaml' "$WORK/rm.out" \
@@ -896,7 +914,7 @@ grep -q 'bare.yaml' "$WORK/rm.out" \
 [ -f "$BRIG_PROFILE_DIR/bare.yaml" ] \
   && ok "the file nobody named is still there" \
   || bad "the file nobody named was deleted anyway"
-"$WORK/brig" profile rm codex -y < /dev/null > /dev/null 2>&1
+"$WORK/brig" agent rm codex -y < /dev/null > /dev/null 2>&1
 [ -f "$BRIG_PROFILE_DIR/bare.yaml" ] \
   && bad "rm did not resolve the profile inside the file" \
   || ok "rm resolves the profile a file declares, not its file name"
@@ -904,42 +922,45 @@ grep -q 'bare.yaml' "$WORK/rm.out" \
 # Two files can declare one profile, because a file need not be named after the
 # profile in it. brig says which won, and rm takes both -- removing only the
 # winner would promote the other and leave the profile listed.
-"$WORK/brig" profile export codex dup > /dev/null 2>&1
+"$WORK/brig" agent export codex dup > /dev/null 2>&1
 sed 's/^name: dup$/name: dupagent/' "$BRIG_PROFILE_DIR/dup.yaml" > "$WORK/dup2.yaml"
 cp "$WORK/dup2.yaml" "$BRIG_PROFILE_DIR/dup.yaml"
 cp "$WORK/dup2.yaml" "$BRIG_PROFILE_DIR/dupother.yaml"
-"$WORK/brig" profiles > "$WORK/dup.out" 2>&1
+"$WORK/brig" agent ls > "$WORK/dup.out" 2>&1
 grep -q 'duplicate profile name' "$WORK/dup.out" \
   && ok "two files claiming one profile are reported" \
   || bad "two files claiming one profile are reported: $(cat "$WORK/dup.out")"
 # -y: neither file is named after the profile they both declare, and rm asks
 # before deleting a file the argument did not name.
-"$WORK/brig" profile rm dupagent -y < /dev/null > /dev/null 2>&1
+"$WORK/brig" agent rm dupagent -y < /dev/null > /dev/null 2>&1
 { [ -f "$BRIG_PROFILE_DIR/dup.yaml" ] || [ -f "$BRIG_PROFILE_DIR/dupother.yaml" ]; } \
   && bad "rm left a file still declaring the profile" \
   || ok "rm takes every file declaring the profile"
 
 # A file of your own shadows the built-in, and the listing says so rather than
 # leaving you to wonder which image is booting.
-"$WORK/brig" profile export claude-code claude-code > /dev/null 2>&1
+"$WORK/brig" agent export claude-code claude-code > /dev/null 2>&1
 sed -i.bak 's|ghcr.io/brig-sh/claude-code:[^ ]*|docker.io/me/pinned:latest|' \
   "$BRIG_PROFILE_DIR/claude-code.yaml"
 rm -f "$BRIG_PROFILE_DIR/claude-code.yaml.bak"
-case "$("$WORK/brig" profiles 2>/dev/null)" in
+case "$("$WORK/brig" agent ls 2>/dev/null)" in
   *"overrides built-in"*) ok "a file shadowing a built-in is marked as one" ;;
   *) bad "a file shadowing a built-in is marked as one" ;;
 esac
 rm -f "$BRIG_PROFILE_DIR/claude-code.yaml"
 
 # edit needs a file. A built-in has none, and nothing is created for it.
-EDITOR=true "$WORK/brig" profile edit codex > "$WORK/edit.out" 2>&1 \
-  && bad "profile edit accepted a built-in" || ok "profile edit refuses a built-in"
+EDITOR=true "$WORK/brig" agent edit codex > "$WORK/edit.out" 2>&1 \
+  && bad "agent edit accepted a built-in" || ok "agent edit refuses a built-in"
 grep -q 'built in' "$WORK/edit.out" \
-  && ok "profile edit says how to make a file" \
-  || bad "profile edit says how to make a file: $(cat "$WORK/edit.out")"
+  && ok "agent edit says how to make a file" \
+  || bad "agent edit says how to make a file: $(cat "$WORK/edit.out")"
+grep -q 'brig agent new codex --from codex' "$WORK/edit.out" \
+  && ok "agent edit names the command that makes one" \
+  || bad "agent edit names the command that makes one: $(cat "$WORK/edit.out")"
 [ -f "$BRIG_PROFILE_DIR/codex.yaml" ] \
-  && bad "profile edit created a file for a built-in" \
-  || ok "profile edit creates nothing for a built-in"
+  && bad "agent edit created a file for a built-in" \
+  || ok "agent edit creates nothing for a built-in"
 
 # ...and opens one that exists, honouring the editor's own arguments.
 mkdir -p "$WORK/bin"
@@ -948,52 +969,114 @@ cat > "$WORK/bin/fake-editor" <<'EDIT'
 printf '\n# edited by the smoke test\n' >> "$1"
 EDIT
 chmod +x "$WORK/bin/fake-editor"
-EDITOR="$WORK/bin/fake-editor" "$WORK/brig" profile edit mine > /dev/null 2>&1 \
-  && ok "profile edit opens a file-backed profile" \
-  || bad "profile edit opens a file-backed profile"
+EDITOR="$WORK/bin/fake-editor" "$WORK/brig" agent edit mine > /dev/null 2>&1 \
+  && ok "agent edit opens a file-backed profile" \
+  || bad "agent edit opens a file-backed profile"
 grep -q 'edited by the smoke test' "$BRIG_PROFILE_DIR/mine.yaml" \
-  && ok "profile edit saves what the editor wrote" \
-  || bad "profile edit saves what the editor wrote"
+  && ok "agent edit saves what the editor wrote" \
+  || bad "agent edit saves what the editor wrote"
 
-# The recipe brig prints, end to end: export the closest built-in under a name
-# of your own, edit it, run it, remove it by the name you chose. Every step
-# addresses the name the person picked, which is why export writes that name
-# into the file rather than leaving the profile called what it was copied from.
-"$WORK/brig" profile export claude-code mytool > /dev/null 2>&1
+# The recipe brig prints, end to end: copy the closest built-in under a name of
+# your own, edit it, run it, remove it by the name you chose. Every step
+# addresses the name the person picked, which is why new writes that name into
+# the file rather than leaving the profile called what it was copied from.
+"$WORK/brig" agent new mytool --from claude-code > /dev/null 2>&1
 grep -q '^name: mytool$' "$BRIG_PROFILE_DIR/mytool.yaml" 2>/dev/null \
-  && ok "export writes the name it was given into the file" \
-  || bad "export writes the name it was given into the file"
+  && ok "agent new writes the name it was given into the file" \
+  || bad "agent new writes the name it was given into the file"
+grep -q '^name: claude-code$' "$BRIG_PROFILE_DIR/mytool.yaml" 2>/dev/null \
+  && bad "the copy still declares the agent it came from" \
+  || ok "the copy no longer declares the agent it came from"
 grep -q 'outrank' "$BRIG_PROFILE_DIR/mytool.yaml" 2>/dev/null \
-  && ok "a renamed export still carries the comments" \
-  || bad "a renamed export still carries the comments"
-EDITOR="$WORK/bin/fake-editor" "$WORK/brig" profile edit mytool > /dev/null 2>&1 \
-  && ok "the exported profile edits under the name it was exported as" \
-  || bad "the exported profile edits under the name it was exported as"
+  && ok "a renamed copy still carries the comments" \
+  || bad "a renamed copy still carries the comments"
+EDITOR="$WORK/bin/fake-editor" "$WORK/brig" agent edit mytool > /dev/null 2>&1 \
+  && ok "the copy edits under the name it was given" \
+  || bad "the copy edits under the name it was given"
 : > "$STUB_LOG"
 "$WORK/brig" run mytool -w "$WORK/ws-mytool" -p hi > /dev/null 2>&1
 grep -q -- '--name brig-mytool' "$STUB_LOG" \
-  && ok "the exported profile runs under the name it was exported as" \
-  || bad "the exported profile runs under the name it was exported as"
+  && ok "the copy runs under the name it was given" \
+  || bad "the copy runs under the name it was given"
 grep -q -- '-- claude -p hi' "$STUB_LOG" \
-  && ok "the run is the profile it was copied from, renamed" \
-  || bad "the run is the profile it was copied from, renamed"
-"$WORK/brig" profile rm mytool < /dev/null > /dev/null 2>&1
+  && ok "the run is the agent it was copied from, renamed" \
+  || bad "the run is the agent it was copied from, renamed"
+"$WORK/brig" agent rm mytool < /dev/null > /dev/null 2>&1
 [ -f "$BRIG_PROFILE_DIR/mytool.yaml" ] \
-  && bad "rm did not remove the profile under the name it was exported as" \
-  || ok "rm removes the profile under the name it was exported as, asking nothing"
+  && bad "rm did not remove the copy under the name it was given" \
+  || ok "rm removes the copy under the name it was given, asking nothing"
 "$WORK/brig" reset > /dev/null 2>&1
 
-# The old spellings keep working for one release, and say so.
-"$WORK/brig" agents > "$WORK/dep.out" 2>&1
-grep -q 'is now `brig profiles`' "$WORK/dep.out" \
-  && ok "brig agents works and names the new spelling" \
-  || bad "brig agents works and names the new spelling: $(cat "$WORK/dep.out")"
-"$WORK/brig" template ls > "$WORK/dep2.out" 2>&1
-grep -q 'is now `brig profile`' "$WORK/dep2.out" \
-  && ok "brig template works and names the new spelling" \
-  || bad "brig template works and names the new spelling"
+# Every spelling this release retires keeps working, and says the one that
+# replaces it. Both halves matter: a spelling that fails breaks every script
+# that has it, and one that works silently never teaches anyone the new word.
+#
+# The replacement is matched as a whole command line, which also catches a
+# notice pointing at another retired spelling -- `brig agents` used to say
+# "is now `brig profiles`", one hop short of an answer.
+"$WORK/brig" agent new dep --from codex > /dev/null 2>&1
+while IFS='|' read -r line replacement; do
+  [ -n "$line" ] || continue
+  # shellcheck disable=SC2086 -- the table holds whole command lines.
+  "$WORK/brig" $line < /dev/null > "$WORK/dep.out" 2>&1
+  rc=$?
+  [ "$rc" = 0 ] \
+    && ok "brig $line still works" \
+    || bad "brig $line still works -- exit $rc: $(cat "$WORK/dep.out")"
+  grep -q "is now \`$replacement\`" "$WORK/dep.out" \
+    && ok "brig $line names $replacement" \
+    || bad "brig $line names $replacement -- got: $(cat "$WORK/dep.out")"
+done <<'TABLE'
+profiles|brig agent ls
+policies|brig policy ls
+agents|brig agent ls
+profile ls|brig agent ls
+profile list|brig agent ls
+profile export codex|brig agent export
+profile save codex|brig agent export
+agent list|brig agent ls
+agent save codex|brig agent export
+policy list|brig policy ls
+export codex|brig agent export
+template ls|brig agent
+TABLE
+# import reads a file rather than stdin, so it is spelled out rather than
+# driven from the table above.
+for spelling in "import" "profile import" "profile load" "agent load"; do
+  # shellcheck disable=SC2086 -- $spelling is a command line, not a word.
+  "$WORK/brig" $spelling "$WORK/codex.yaml" > "$WORK/dep.out" 2>&1 \
+    && ok "brig $spelling still works" \
+    || bad "brig $spelling still works: $(cat "$WORK/dep.out")"
+  grep -q 'is now `brig agent import`' "$WORK/dep.out" \
+    && ok "brig $spelling names brig agent import" \
+    || bad "brig $spelling names brig agent import -- got: $(cat "$WORK/dep.out")"
+done
+# The verbs that need a file of their own to work on, so they run last: edit
+# and rm each take the copy made above.
+EDITOR=true "$WORK/brig" profile edit dep > "$WORK/dep.out" 2>&1 \
+  && ok "brig profile edit still works" \
+  || bad "brig profile edit still works: $(cat "$WORK/dep.out")"
+grep -q 'is now `brig agent edit`' "$WORK/dep.out" \
+  && ok "brig profile edit names brig agent edit" \
+  || bad "brig profile edit names brig agent edit -- got: $(cat "$WORK/dep.out")"
+"$WORK/brig" profile rm dep -y < /dev/null > "$WORK/dep.out" 2>&1 \
+  && ok "brig profile rm still works" \
+  || bad "brig profile rm still works: $(cat "$WORK/dep.out")"
+grep -q 'is now `brig agent rm`' "$WORK/dep.out" \
+  && ok "brig profile rm names brig agent rm" \
+  || bad "brig profile rm names brig agent rm -- got: $(cat "$WORK/dep.out")"
 "$WORK/brig" template edit mine > /dev/null 2>&1 \
   && bad "brig template edit exists" || ok "there is no brig template edit"
+
+# And the current spellings say nothing. A notice on a command that is not
+# going anywhere is how a reader learns to ignore the ones that are.
+for line in "agent ls" "agent show codex" "policy ls"; do
+  # shellcheck disable=SC2086 -- $line is a command line, not a word.
+  "$WORK/brig" $line > "$WORK/cur.out" 2>&1
+  grep -q 'is now' "$WORK/cur.out" \
+    && bad "brig $line printed a deprecation notice: $(cat "$WORK/cur.out")" \
+    || ok "brig $line printed no deprecation notice"
+done
 
 echo "== image verification =="
 # A stub cosign, so the decision table is exercised without a network.


### PR DESCRIPTION
## Summary

brig had three grammars at once and no way to tell from a command line which applied. A plural noun
was a command of its own (`brig profiles`), two noun commands were also spelled at the top level
(`brig import`, `brig export`), the verb set differed under every noun, and several operations had a
second undocumented spelling (`list`, `save`, `load`) that could only be found by accident and then
written into a script.

This settles the management half: one noun, one verb set, one spelling per operation.

`profile` becomes `agent` **at the CLI surface only**. `internal/profile`, `profile.Profile`,
`BRIG_PROFILE_DIR` and `~/.brig/profiles/` keep their names, so a ~99-file mechanical rename does
not land inside a grammar change and compete with it for review attention. That leaves two words
correct at once for a while, which is a real cost and a smaller one than the alternative.

## Related issues

Fixes #13. Part of #47.

**Stacked on #117** — base is `feat/109-session-index-by-ref`, so the diff shows only this change.
Merge order: #113, #115, #117, then this. It has no logical dependency on the ref work, but #115
rewrote the dispatch switch and the `usage` const that this edits, so a sibling branch off `main`
would have conflicted in exactly those two places for no benefit.

## Changes

`brig agent ls|show|new|edit|rm|import|export`, mapping onto commands that already existed:

| today | vNext |
| --- | --- |
| `brig profiles`, `brig profile ls`, `brig profile list` | `brig agent ls` |
| `brig export <p>` (prints, takes `--json`) | `brig agent show <a>` |
| `brig export <p> <name>` (saves under a new name) | `brig agent new <name> --from <a>` |
| `brig profile import`, `brig profile load`, `brig import` | `brig agent import` |
| `brig profile export`, `brig profile save` | `brig agent export` |
| `brig profile edit`, `brig profile rm` | `brig agent edit`, `brig agent rm` |
| `brig policies` | `brig policy ls` |

**One real fix, not a rename.** `brig agent new <name> --from <a>` rewrites `name:` inside the file
it writes. Starting from the closest existing agent is the documented way to author one, and the
recipe brig printed for it failed on its own second step: the copy was written under the new name
while the profile inside kept the old one, so `brig agent edit <name>` had nothing to open and the
only command that could reach the file named a different agent and deleted it without asking.

**Every retired spelling still works** and prints one line naming its replacement, using the
`deprecated()` mechanism already in the tree. That includes the undocumented aliases: `list`,
`save`, `load`, `secret list`, `secret rm` and `policy list` are out of the vocabulary but not out
of the binary — §5 of the issue says they "go", which is right about the vocabulary and would break
scripts inside the window #47 sets if read as removal in 0.2.

**`brig secret` keeps `create|update|read|delete|ls|import`.** This is a deliberate exception to
"one verb set under every noun", agreed on #47, and it has a test pinning it so the next reader does
not complete #13 by changing it back. The reason is in the Credentials section below.

**`brig policy` and `brig telemetry` keep their verb sets.** `policy` was already conformant; only
the plural retires. `telemetry status|on|off` is already noun-verb. Both were absent from #47's
command tree because they landed after it was filed.

**Not in scope:** `brig agent secrets`, which #47's tree lists but nothing in the tree does today —
new capability rather than a rename, so it wants its own issue. And no `brig start`: `brig run` is
how a stopped session is returned to.

### Two places this reached beyond the CLI, deliberately

`brig agents` and `brig template` keep their commands and behaviour untouched, but their
deprecation notices pointed at `brig profiles` and `brig profile` — spellings this commit retires.
A notice whose replacement answers with another notice is worse than no notice, so only the strings
they name changed.

Three files under `internal/profile/` changed, and every line is a user-facing string or a comment
naming a retired command. No identifier, type, package, env var or directory moved. The two that
matter: `exportHeader`, which is written **into every exported agent file** ("Edit it, then: brig
agent import <this file>"), and `LegacyHint()`, which is printed to anyone with files in the
pre-profile directory. Leaving those would have brig instructing people to run deprecated commands.

## Testing

`script/smoke.sh` goes from 149 to 193 passing checks. The `== profiles ==` section is now
`== agents ==` in the new vocabulary, plus a table-driven deprecation matrix and checks for each new
spelling. Its style is kept — output captured to a file before asserting, never piped into
`grep -q`, for the SIGPIPE reason documented at the top of that file.

Unit tests: `cmd/brig/agent_test.go` covers the new spellings, the unknown-subcommand wording,
`show` refusing a destination, `new` requiring `--from`, the help text vocabulary, and the `secret`
exception pin. `cmd/brig/deprecated_test.go` gains three tables: the retired-spelling matrix, the
`secret rm` alias, and a negative test asserting current spellings print **nothing** — which is the
one that catches a notice fired on the wrong path.

`script/smoke.sh` also has failures that predate this branch and depend on host state. The sets are
identical on this branch and on its parent `fd87d67`, with one textual difference: an assertion
label renamed from "the run is the profile it was copied from" to "…the agent…". Same assertion,
same cause, no change in which checks fail.

## Manual testing

Unlike the rest of this stack, none of this needs a runtime — these commands do not boot anything.
From a checkout of this branch:

```bash
make build                              # builds ./brig
export BRIG_PROFILE_DIR=$(mktemp -d)    # keep your own agents out of the way
```

**The new vocabulary**

```bash
./brig agent ls
./brig agent show claude                # prints the annotated profile; --json also works
./brig agent ls --help
```

**Every retired spelling still works, and says what replaced it**

```bash
./brig profiles          # brig: `brig profiles` is now `brig agent ls`
./brig profile ls        # brig: `brig profile ls` is now `brig agent ls`
./brig policies          # brig: `brig policies` is now `brig policy ls`
./brig import            # brig: `brig import` is now `brig agent import`
./brig export claude     # brig: `brig export` is now `brig agent export`
./brig secret rm         # brig: `brig secret rm` is now `brig secret delete`
```

Each prints its notice on stderr and then does the job. Confirm the second half too — a notice that
replaced the behaviour would be a regression, not a deprecation.

**The notices that used to point at a deprecated spelling**

```bash
./brig agents            # must say `brig agent ls`, not `brig profiles`
./brig template ls       # must say `brig agent`, not `brig profile`
```

**The `secret` exception**

```bash
./brig secret ls         # no notice: this verb set is unchanged on purpose
```

**The fix: `name:` is rewritten in the copy**

```bash
./brig agent new mytool --from claude
grep '^name:' "$BRIG_PROFILE_DIR"/mytool.yaml     # must print: name: mytool
./brig agent edit mytool                          # must find it (this is what used to fail)
./brig agent rm mytool
```

`brig agent new mytool` with no `--from` should explain that it copies an agent and so needs one.

## Checklist

- [x] `make all` passes (vet, test, build)
- [x] `script/smoke.sh` passes
- [x] I have added or updated tests covering the change
- [x] I have run `go test ./... -race`, if the change touches concurrency, subprocesses or the daemon
- [ ] ~~I have exercised the change against a real runtime (`brig run <agent>`), if it touches the run, exec or credential path~~
- [x] I have updated the affected docs (README, `docs/security.md`, `docs/profiles.md`, `docs/brigd.md`)

**`script/smoke.sh`**: as described under Testing — failures predate the branch, sets identical, 44
checks added.

**Real runtime**: struck through. These verbs boot nothing. The dispatch they route through is
shared with the lifecycle verbs, and `script/smoke.sh` exercises that whole path against a stub
runtime with no change in behaviour.

**Docs**: `usage` and the group help texts are updated, because they are in the file being edited
and cannot not change. `README.md` and `docs/profiles.md` are **not**, and this makes them more
wrong than they already were — the flag table was stale after #115 and now the command vocabulary
is too. #111 owns that rewrite and has a comment recording both. Flagging it here so a reviewer is
not misled into reading those files as current.

## Credentials and the sandbox boundary

No new mount, no new forwarded variable, no new host path the guest can reach. Two things worth
stating anyway, both about the credential store rather than the guest.

**Why `brig secret` keeps its verbs.** The unified set in the issue would have made `set` mean
create-or-update and `get` mean read. A typo that turns a read into a create-or-update silently
overwrites a stored credential, and the recovery is to go and find the original value again. The
inconsistency is cheaper than that failure, which is why the exception exists and why it is pinned
by a test rather than left to judgement.

**`brig agent show` and `brig agent export` print an agent's spec, which names its secrets and never
their values** — the same rule the command already followed under its old spelling. The tests assert
on the rendered bytes, so a value appearing in a field would fail them.

## LLM usage

Authored with assistance from Claude Code (Opus 5), which produced the implementation, the commit
message and this description. Verification was re-run independently of the agent that wrote the
change, from a frozen tree: `gofmt`, `make all`, and the smoke failure sets diffed against
`fd87d67`. Every command in the Manual testing section was run against the built binary before
being written down, including the `name:` rewrite and each deprecation notice. Two of the agent's
decisions were reviewed against the diff rather than taken on trust: the changed replacement strings
in `brig agents`/`brig template`, and every line it touched under `internal/profile/`.
Accountability for every line remains the author's.
