### PR TITLE
feat(cli): switch the lifecycle verbs to session refs

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,15 +113,13 @@ separate Linux re-implementation of it.
 
 | command | what it does |
 | --- | --- |
-| `brig run <agent> [args…]` | start the sandbox if needed, then run the agent. Arguments pass through untouched |
-| `brig create <agent>` | start the sandbox without attaching; prints its name |
-| `brig shell <agent> [cmd…]` | a login shell inside the sandbox, or one command in it |
-| `brig exec <agent> -- cmd…` | run one command inside the sandbox |
-| `brig stop <agent>` | stop the sandbox, keep it. Starting it again is a boot, not a fresh creation |
-| `brig rm <agent>` | stop and remove the sandbox. The workspace is untouched |
-| `brig ls` | every brig sandbox, running or merely holding its name, with its workspace |
-| `brig reset` | stop and remove every brig sandbox. Workspaces are untouched |
-| `brig info <agent>` | the boundary a run would trust -- sandbox, workspace, image, credentials **by name only** -- and whether the guest will be authenticated (`brig env` is the old spelling) |
+| `brig run <ref> [args…]` | start the sandbox if needed, then run the agent. Arguments pass through untouched. `-d` starts it and exits, printing its name |
+| `brig sh <ref> [cmd…]` | a login shell inside the sandbox, or one command in it |
+| `brig stop <ref>` | stop the sandbox, keep it. Starting it again is a boot, not a fresh creation |
+| `brig rm <ref>` | stop and remove the sandbox. The workspace is untouched |
+| `brig rm --all` | stop and remove every brig sandbox. Workspaces are untouched |
+| `brig ls [-q]` | every brig sandbox, running or merely holding its name, with its ref and workspace. `-q` prints the refs alone, for a script |
+| `brig info <ref>` | the boundary a run would trust -- sandbox, workspace, image, credentials **by name only** -- and whether the guest will be authenticated |
 | `brig agent ls` | the agents, their images, and what each one refuses to forward |
 | `brig agent show <agent>` | print one agent's spec. `--json` for JSON instead of YAML |
 | `brig agent new <name> --from <agent>` | copy an agent under a new name, ready to edit |
@@ -132,6 +130,10 @@ separate Linux re-implementation of it.
 | `brig telemetry status\|on\|off` | report what is counted, or turn the counting on or off. See [Telemetry](#telemetry) |
 | `brig version` | |
 
+A `<ref>` is the session: `claude` is that agent's default session, and
+`claude@refactor` is a session of its own. `brig ls` prints the ref of every
+sandbox, and every verb above takes one -- see [Named sessions](#named-sessions).
+
 The older spellings all still work and each prints a one-line note naming the
 new one, so nothing scripted breaks in this release; they no longer appear
 above. `brig profiles` and the whole `brig profile` group are now `brig agent`,
@@ -140,6 +142,15 @@ above. `brig profiles` and the whole `brig profile` group are now `brig agent`,
 undocumented aliases that were never in this table -- `list`, `save`, `load`,
 `secret rm`. `brig template …` and `brig agents` remain from an earlier rename,
 and there is deliberately no `brig template edit`.
+
+The lifecycle verbs collapsed in the same way. `brig exec` and `brig shell` are
+both `brig sh`, which runs a command when you give it one and opens a login
+shell when you do not -- one verb, and which of the two you get is said by the
+line rather than by the word you reached for. `brig create` is `brig run -d`,
+`brig reset` is `brig rm --all`, and `brig env` is `brig info`. `-n`/`--name` is
+the label: `brig run claude@refactor` is what `brig run claude --name refactor`
+was. That one is mapped and warned about rather than quietly reinterpreted,
+because `--name` is also Claude Code's own flag.
 
 `brig secret` keeps `create|read|update|delete`, and that is deliberate rather
 than an oversight. The tidier `set`/`get` pair would make one typo turn a read
@@ -196,7 +207,8 @@ working; one that wants to branch on the reason now can.
 ```bash
 brig run claude -p "summarise this repo"   # headless, arguments passed through
 brig run claude -- --name not-a-session    # --name reaches claude, not brig
-brig shell codex 'ls -la ~'                # one command, in a login shell
+brig sh codex 'ls -la ~'                   # one command, in a login shell
+brig sh codex                              # a login shell, no command
 ```
 
 ### Named sessions
@@ -227,26 +239,46 @@ you did not ask for. `--name` keeps its older, lenient behaviour.
 everywhere it did:
 
 ```bash
-brig exec claude@refactor -- git status
+brig sh   claude@refactor git status
 brig stop claude@refactor
 brig rm   claude@refactor      # removes the sandbox, keeps the workspace
 ```
 
-`brig ls` shows the session as `brig-claude-code-refactor`, but that string is
-the sandbox's own name and is not what the verbs take -- `brig rm refactor`
-and `brig rm brig-claude-code-refactor` both fail with "unknown agent". Pass
-the agent and `--name`, as above.
+**`brig ls` prints the ref**, in the first column, and that is the string every
+verb takes:
+
+```
+REF                   SANDBOX                    STATE     WORKSPACE
+claude-code           brig-claude-code           running   /Users/you/brig/claude-code
+claude-code@refactor  brig-claude-code-refactor  stopped   /Users/you/brig/claude-code-refactor
+```
+
+`brig ls -q` prints the refs alone, one to a line, so a script can read the
+listing and hand what it finds straight back to a verb:
+
+```bash
+brig ls -q | while read -r ref; do brig stop "$ref"; done
+```
+
+The `SANDBOX` column is the sandbox's own name, which is not a ref: `brig rm
+brig-claude-code-refactor` fails with "unknown profile", and it is there to be
+recognised in the runtime's own output rather than to be typed at brig. A
+sandbox brig has no session recorded for and cannot read a ref out of the name
+of -- one renamed with `BRIG_NAME`, say -- shows a `-` in the `REF` column and is
+left out of `brig ls -q` entirely, because every line of that output is meant to
+be a word a verb takes. `brig rm --all` is what clears one of those.
 
 To drop the workspace too, remove the directory `brig info` prints. And
-`brig reset` stops and removes every brig sandbox at once, named ones
+`brig rm --all` stops and removes every brig sandbox at once, named ones
 included, leaving all workspaces alone.
 
 **`-w` is remembered.** A session created with `--workspace` keeps that
-directory for every later verb, so `brig exec claude --name refactor -- ls`
-finds it without repeating the flag. brig records it in
-`~/.brig/sessions.json`, filed under the session's ref, and reads it back when
-neither `--workspace` nor `BRIG_WORKSPACE` names one; `brig rm` and `brig reset`
-drop the entry with the sandbox, and `brig ls` drops any whose sandbox has gone.
+directory for every later verb, so `brig sh claude@refactor ls` finds it
+without repeating the flag. brig records it in `~/.brig/sessions.json`, filed
+under the session's ref, and reads it back when neither `--workspace` nor
+`BRIG_WORKSPACE` names one; `brig rm` drops the entry with the sandbox, and
+`brig ls` drops any whose sandbox has gone. That file is also where `brig ls`
+reads the ref it prints.
 
 That file is an index and not a record of the truth: the runtime stays the
 authority on what is actually mounted, and an unreadable index costs one restart
@@ -263,13 +295,16 @@ The verbs line up deliberately, so muscle memory carries over:
 | `sbx` | `brig` | note |
 | --- | --- | --- |
 | `sbx run <agent> [path]` | `brig run <agent> [-w path]` | brig takes the workspace as a flag rather than a positional, so it never has to guess where agent arguments begin |
-| `sbx create` | `brig create` | |
-| `sbx exec` / `sbx ls` / `sbx stop` / `sbx rm` / `sbx reset` | same | |
+| `sbx create` | `brig run -d` | starts the sandbox and exits, printing its name |
+| `sbx ls` / `sbx stop` / `sbx rm` | same | |
+| `sbx exec` | `brig sh` | one verb for a command and for a login shell |
+| `sbx reset` | `brig rm --all` | the same removal as `brig rm`, over every sandbox |
 | `sbx cp` | n/a | the workspace is a live host directory, so there is nothing to copy across |
 | `sbx template ls\|save\|load\|rm` | `brig agent ls\|export\|import\|edit\|rm` | brig's profiles describe the *agent*, not just its image, and are YAML like sbx's kits |
 | `sbx secret set` | `brig secret create` + a profile's `secrets:` | brig has a store of its own and binds from it. Or point a profile at your existing secret manager: whatever puts a value in brig's environment is enough |
 | `sbx -t/--template` | `brig -t/--image` | |
-| `sbx -m/--memory`, `--cpus`, `-d`, `--name` | same | |
+| `sbx -m/--memory`, `--cpus`, `-d` | same | |
+| `sbx --name <name>` | `brig <agent>@<name>` | brig's `--name` still works and says what replaces it |
 | `sbx --publish`, `--deny-network` | n/a | not yet; brig does not manage guest networking, and sandboxes share one network -- see [docs/security.md](docs/security.md#things-brig-does-not-claim) |
 | `sbx --clone` | n/a | not yet; the workspace is mounted directly |
 | `sbx login` | n/a | nothing to sign in to |
@@ -395,9 +430,9 @@ brig:   GH_TOKEN(secret)
 ```
 
 The block at the top is the execution envelope: the boundary the run would
-trust, printed before the sandbox boots. `brig run` and `brig create` print the
-same block before they start one, so what you preview is what you get. Names
-only, never values. `--quiet` drops it.
+trust, printed before the sandbox boots. `brig run` prints the same block before
+it starts one, so what you preview is what you get. Names only, never values.
+`--quiet` drops it.
 
 A secret a profile declares but the store does not have fails the run before
 any sandbox is created, naming every one that is missing and the command that

--- a/cmd/brig/deprecated_test.go
+++ b/cmd/brig/deprecated_test.go
@@ -280,3 +280,114 @@ func TestDeprecatedShortFlagsStillWork(t *testing.T) {
 		t.Errorf("a --name value read as a deprecated flag:\n%s", warning)
 	}
 }
+
+// The retired lifecycle spellings: still working, and each naming the one that
+// replaces it. Kept apart from the table above because these verbs need a
+// runtime to finish their work, and the tests must not have one -- `brig reset`
+// on a machine with sandboxes on it removes every one of them.
+//
+// So what is asserted is the half that is about vocabulary: brig recognised the
+// spelling, said what it is now, and did not refuse the line. Everything after
+// that is the same code path the current spelling takes, and script/smoke.sh
+// drives it against a stub runtime.
+func TestRetiredLifecycleSpellingsWorkAndNameTheirReplacement(t *testing.T) {
+	for _, c := range []struct {
+		args        []string
+		replacement string
+	}{
+		{[]string{"create", "claude"}, "brig run -d"},
+		{[]string{"exec", "claude", "--", "true"}, "brig sh"},
+		{[]string{"shell", "claude"}, "brig sh"},
+		{[]string{"shell", "claude", "echo", "hi"}, "brig sh"},
+		{[]string{"reset"}, "brig rm --all"},
+		{[]string{"env", "claude"}, "brig info"},
+	} {
+		line := "brig " + strings.Join(c.args, " ")
+		scratchHost(t)
+		var err error
+		notice := captureStderr(t, func() {
+			_, err = captureStdout(t, func() error { return run(c.args) })
+		})
+		if !took(err) {
+			t.Errorf("%s stopped working: %v", line, err)
+		}
+		if !strings.Contains(notice, c.replacement) {
+			t.Errorf("%s does not name %q as its replacement:\n%s", line, c.replacement, notice)
+		}
+		if !strings.Contains(notice, "brig: `") {
+			t.Errorf("%s printed no deprecation notice:\n%s", line, notice)
+		}
+	}
+}
+
+// The current lifecycle spellings say nothing. This is the other half of the
+// contract above: a notice on a command that is not going anywhere is how a
+// reader learns to ignore the ones that are.
+//
+// The verbless ref is here too. It is accepted and taught nowhere, which is not
+// the same as retired -- there is no older spelling of it to stop typing, so
+// there is nothing for brig to say.
+func TestCurrentLifecycleSpellingsPrintNoNotice(t *testing.T) {
+	for _, args := range [][]string{
+		{"run", "claude", "-d"}, {"sh", "claude"}, {"sh", "claude", "echo", "hi"},
+		{"stop", "claude"}, {"rm", "claude"}, {"rm", "--all"}, {"info", "claude"},
+		{"claude"}, {"claude@refactor"},
+	} {
+		scratchHost(t)
+		var err error
+		notice := captureStderr(t, func() {
+			_, err = captureStdout(t, func() error { return run(args) })
+		})
+		if !took(err) {
+			t.Errorf("brig %s was refused: %v", strings.Join(args, " "), err)
+		}
+		if strings.Contains(notice, "is now") {
+			t.Errorf("brig %s printed a deprecation notice:\n%s",
+				strings.Join(args, " "), notice)
+		}
+	}
+}
+
+// -n and --name are mapped onto the label rather than aliased to it, and the
+// mapping is said out loud. Both halves are deliberate: the flag is Claude
+// Code's own as well as brig's, so a line that carries it keeps working, and
+// silently reinterpreting it would be worse than either failing or saying so.
+func TestNameFlagRetiresOntoTheLabel(t *testing.T) {
+	for _, c := range []struct{ args []string }{
+		{[]string{"claude", "-n", "refactor"}},
+		{[]string{"claude", "--name", "refactor"}},
+		{[]string{"claude", "--name=refactor"}},
+	} {
+		var (
+			o   options
+			err error
+		)
+		notice := captureStderr(t, func() { o, _, _, err = parse(c.args) })
+		if err != nil {
+			t.Errorf("parse(%q): %v", c.args, err)
+			continue
+		}
+		// Mapped: the label the flag carried is the label the run uses.
+		if o.load.Name != "refactor" || !o.nameGiven {
+			t.Errorf("parse(%q) stopped naming the session: %+v", c.args, o.load)
+		}
+		spelling, _, _ := strings.Cut(c.args[1], "=")
+		if !strings.Contains(notice, spelling) || !strings.Contains(notice, "@") {
+			t.Errorf("parse(%q) did not point %s at the label form:\n%s",
+				c.args, spelling, notice)
+		}
+	}
+	// The label form is the current spelling, so it says nothing.
+	notice := captureStderr(t, func() {
+		o, _, _, err := parse([]string{"claude@refactor"})
+		if err != nil {
+			t.Errorf("parse: %v", err)
+		}
+		if o.load.Name != "refactor" {
+			t.Errorf("the label did not land as the session name: %+v", o.load)
+		}
+	})
+	if notice != "" {
+		t.Errorf("the label form printed a notice:\n%s", notice)
+	}
+}

--- a/cmd/brig/hygiene_test.go
+++ b/cmd/brig/hygiene_test.go
@@ -60,31 +60,35 @@ func TestRejectTail(t *testing.T) {
 			t.Errorf("rejectTail(%q): %v, want it to name the token", verb, err)
 		}
 	}
-	for _, verb := range []string{"run", "shell", "exec"} {
+	for _, verb := range []string{"run", "sh", "shell", "exec"} {
 		if err := rejectTail(verb, []string{"-p", "hi"}); err != nil {
 			t.Errorf("rejectTail(%q) refused an agent tail: %v", verb, err)
 		}
 	}
 	// No tail is fine for every verb.
-	for _, verb := range []string{"create", "stop", "rm", "env", "run", "shell", "exec"} {
+	for _, verb := range []string{"create", "stop", "rm", "env", "run", "sh", "shell", "exec"} {
 		if err := rejectTail(verb, nil); err != nil {
 			t.Errorf("rejectTail(%q, nil): %v", verb, err)
 		}
 	}
 }
 
-// ls and reset name no profile and take no flags, so an argument is a token
-// they would read and drop. reset is the sharp one: `brig reset --dry-run`
-// reads like a preview and removes everything, so it must refuse before it
-// reaches the runtime.
-func TestLsAndResetRefuseArguments(t *testing.T) {
+// ls names no session and takes only -q, and `rm --all` takes nothing at all,
+// so any other argument is a token they would read and drop. `rm --all` is the
+// sharp one: `brig rm --all --dry-run` reads like a preview and removes
+// everything, so it must refuse before it reaches the runtime. reset is the
+// retired spelling of the same command and refuses on the same terms.
+func TestLsAndRemoveAllRefuseArguments(t *testing.T) {
 	for _, tc := range []struct {
 		name string
 		fn   func([]string) error
 		args []string
 	}{
 		{"ls", listSandboxes, []string{"claude"}},
-		{"reset", reset, []string{"--dry-run"}},
+		{"rm --all", func(args []string) error { return removeAll("brig rm --all", args) },
+			[]string{"--dry-run"}},
+		{"reset", func(args []string) error { return removeAll("brig reset", args) },
+			[]string{"--dry-run"}},
 	} {
 		err := tc.fn(tc.args)
 		if err == nil {

--- a/cmd/brig/lifecycle_test.go
+++ b/cmd/brig/lifecycle_test.go
@@ -1,0 +1,142 @@
+package main
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// scratchHost points brig's whole environment at directories of the test's own
+// and takes the runtime away, so a lifecycle verb reaches the point where it
+// would need one and stops there.
+//
+// Taking the runtime away is what makes these tests safe to run on a machine
+// that has sandboxes on it: `brig rm --all` with a runtime on PATH removes
+// every sandbox the person running the test owns. With none, detection fails
+// before any of these verbs touches an instance, and what is left to observe is
+// exactly what these tests are about -- whether brig accepted the line.
+func scratchHost(t *testing.T) {
+	t.Helper()
+	t.Setenv("BRIG_PROFILE_DIR", t.TempDir())
+	t.Setenv("BRIG_STATE_DIR", t.TempDir())
+	t.Setenv("BRIG_WORKSPACE", t.TempDir())
+	t.Setenv("BRIG_RUNTIME", "")
+	emptyPath(t)
+}
+
+// took reports whether brig accepted the line it was given, as opposed to
+// refusing the words in it. A verb that got as far as needing a runtime, or a
+// credential, has accepted its operand: the only two errors that mean the
+// operand itself was refused are the usage error and the not-found error, which
+// is why they carry exit codes of their own.
+func took(err error) bool {
+	var ue *usageError
+	var nf *notFoundError
+	return !errors.As(err, &ue) && !errors.As(err, &nf)
+}
+
+// brig sh is one verb for what exec and shell were two of: with a command it
+// runs that command, with none it opens a login shell. Both shapes have to
+// reach the sandbox, so neither may be refused on the way in -- which is the
+// half that can be asserted without a runtime. That the command lands as
+// `bash -lc` and a bare sh as `bash -l` is argv, and script/smoke.sh asserts it
+// against the stub.
+func TestShAcceptsACommandAndNoCommand(t *testing.T) {
+	for _, args := range [][]string{
+		{"sh", "claude"},
+		{"sh", "claude", "echo", "hi"},
+		{"sh", "claude@refactor"},
+		{"sh", "claude@refactor", "--", "git", "status"},
+	} {
+		scratchHost(t)
+		_, err := captureStdout(t, func() error { return run(args) })
+		if !took(err) {
+			t.Errorf("brig %s was refused: %v", strings.Join(args, " "), err)
+		}
+	}
+	// And a tail is the guest's command rather than a stray token, which is the
+	// decision rejectTail makes for every verb.
+	if err := rejectTail("sh", []string{"git", "status"}); err != nil {
+		t.Errorf("rejectTail(sh) refused a guest command: %v", err)
+	}
+}
+
+// `brig rm --all` is what `brig reset` was: every brig sandbox, workspaces left
+// alone. It is read before the run line, because --all names no session and the
+// run-line parser would refuse it as a brig flag that does not exist.
+//
+// The refusals are the point of the test as much as the acceptance. A flag
+// typed to make a destructive command safer must not be read past and ignored,
+// and a ref beside --all is two different requests on one line.
+func TestRemoveAllTakesNothingElse(t *testing.T) {
+	scratchHost(t)
+	if err := run([]string{"rm", "--all"}); !took(err) {
+		t.Errorf("brig rm --all was refused: %v", err)
+	}
+	for _, args := range [][]string{
+		{"rm", "--all", "claude"},
+		{"rm", "claude", "--all"},
+		{"rm", "--all", "--dry-run"},
+	} {
+		scratchHost(t)
+		err := run(args)
+		var ue *usageError
+		if !errors.As(err, &ue) {
+			t.Errorf("brig %s: %v, want a usageError", strings.Join(args, " "), err)
+			continue
+		}
+		// Named, so the reader knows which word to take off the line.
+		stray := args[len(args)-1]
+		if stray == "--all" {
+			stray = args[1]
+		}
+		if !strings.Contains(err.Error(), stray) {
+			t.Errorf("brig %s: %v, want it to name %q", strings.Join(args, " "), err, stray)
+		}
+	}
+}
+
+// A bare ref with no verb is accepted, and a verb is still a verb. Both halves
+// matter: the second is what keeps the surface from becoming data-dependent,
+// because a ref is only tried once every verb has been ruled out. Without that
+// ordering, installing an agent called `ls` would change what `brig ls` means.
+func TestVerblessRefIsLastInTheChain(t *testing.T) {
+	for _, args := range [][]string{{"claude"}, {"claude-code"}, {"claude@refactor"}} {
+		scratchHost(t)
+		_, err := captureStdout(t, func() error { return run(args) })
+		if !took(err) {
+			t.Errorf("brig %s was refused: %v", strings.Join(args, " "), err)
+		}
+	}
+
+	// An agent whose name is one of brig's verbs. `brig ls` has to stay the
+	// listing: with no runtime on PATH that reports an empty list and exits 0,
+	// where running the agent could only have failed for want of one.
+	scratchHost(t)
+	dir := os.Getenv("BRIG_PROFILE_DIR")
+	blob := "name: ls\nimage: i\nguestHome: /home/ls\nbinary: ls\nmem: 1\ncpus: 1\n"
+	if err := os.WriteFile(filepath.Join(dir, "ls.yaml"), []byte(blob), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	out, err := captureStdout(t, func() error { return run([]string{"ls"}) })
+	if err != nil {
+		t.Fatalf("brig ls with an agent called ls: %v", err)
+	}
+	if !strings.Contains(out, "SANDBOX") {
+		t.Errorf("brig ls ran the agent called ls rather than listing:\n%s", out)
+	}
+
+	// And a token that is neither a verb nor an agent is an unknown command,
+	// not a missing profile: the reader typed a word brig does not have, and
+	// the message that names the vocabulary is the one that helps.
+	scratchHost(t)
+	err = run([]string{"nosuchthing"})
+	if err == nil {
+		t.Fatal("brig nosuchthing was accepted")
+	}
+	if !strings.Contains(err.Error(), "unknown command") {
+		t.Errorf("brig nosuchthing: %v, want it to report an unknown command", err)
+	}
+}

--- a/cmd/brig/lifecycle_test.go
+++ b/cmd/brig/lifecycle_test.go
@@ -140,3 +140,42 @@ func TestVerblessRefIsLastInTheChain(t *testing.T) {
 		t.Errorf("brig nosuchthing: %v, want it to report an unknown command", err)
 	}
 }
+
+// A ref-shaped token that brig cannot use is diagnosed as the ref it plainly
+// is, and not as a command nobody typed.
+//
+// The separator is what settles it. '@' is brig's, reserved in
+// internal/session for exactly one job, and no verb has one -- so a token
+// carrying one has a single possible reading, and "unknown command" would be a
+// wrong answer rather than a cautious one. The bare word above keeps the
+// cautious answer, because `brig nosuchthing` really could be either.
+//
+// Asserted as equality with the verbed form rather than against fixed text.
+// The two spellings ask the same question, so a change to how brig answers it
+// has to reach both or the pair stops matching -- which no assertion on the
+// wording of one of them would catch.
+func TestARefShapedTokenIsDiagnosedAsARef(t *testing.T) {
+	for _, ref := range []string{
+		"claude@BAD",      // a label that is not slug-clean
+		"claude@a@b",      // two separators
+		"claude@",         // a label the typing stopped short of
+		"@refactor",       // no agent
+		"nosuch@refactor", // an agent brig does not have
+	} {
+		scratchHost(t)
+		verbless := run([]string{ref})
+		scratchHost(t)
+		verbed := run([]string{"run", ref})
+
+		if verbless == nil || verbed == nil {
+			t.Errorf("brig %s was accepted", ref)
+			continue
+		}
+		if verbless.Error() != verbed.Error() {
+			t.Errorf("brig %s said\n  %v\nbut brig run %s said\n  %v", ref, verbless, ref, verbed)
+		}
+		if strings.Contains(verbless.Error(), "unknown command") {
+			t.Errorf("brig %s was reported as an unknown command: %v", ref, verbless)
+		}
+	}
+}

--- a/cmd/brig/listing_test.go
+++ b/cmd/brig/listing_test.go
@@ -1,0 +1,157 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/brig-sh/brig/internal/runtime"
+	"github.com/brig-sh/brig/internal/session"
+)
+
+// The listing prints the ref every other verb takes. That is the defect this
+// issue was filed about: the column used to hold the sandbox's own name, which
+// no verb accepts, so a reader who copied what they saw got an error.
+func TestListingPrintsTheRef(t *testing.T) {
+	t.Setenv("BRIG_PROFILE_DIR", t.TempDir())
+	dir := t.TempDir()
+	t.Setenv("BRIG_STATE_DIR", dir)
+	t.Setenv("BRIG_WORKSPACE", t.TempDir())
+
+	// Two sessions brig recorded, one of them the agent's default session, and
+	// one sandbox that was never indexed.
+	index := `{` +
+		`"claude-code@refactor": {"home": "/ws/refactor", "sandbox": "brig-claude-code-refactor"},` +
+		`"claude-code": {"home": "/ws/default", "sandbox": "brig-claude-code"}}`
+	if err := os.WriteFile(filepath.Join(dir, "sessions.json"), []byte(index), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	rows := sandboxRows([]runtime.Instance{
+		{Name: "brig-claude-code", State: "running"},
+		{Name: "brig-claude-code-refactor", State: "stopped"},
+		// Indexed by nothing and derivable from nothing: the name after the
+		// prefix matches no agent brig has.
+		{Name: "brig-mystery", State: "running"},
+		// Not brig's, so not in the listing at all.
+		{Name: "someone-elses-container", State: "running"},
+	}, nil)
+
+	want := map[string]string{
+		"brig-claude-code":          "claude-code",
+		"brig-claude-code-refactor": "claude-code@refactor",
+		"brig-mystery":              "",
+	}
+	if len(rows) != len(want) {
+		t.Fatalf("the listing has %d rows, want %d: %+v", len(rows), len(want), rows)
+	}
+	for _, r := range rows {
+		if got, ok := want[r.name]; !ok {
+			t.Errorf("the listing holds %q, which is not brig's", r.name)
+		} else if r.ref != got {
+			t.Errorf("%s is listed as ref %q, want %q", r.name, r.ref, got)
+		}
+	}
+
+	// A sandbox with no ref to print says so with a placeholder rather than an
+	// empty column, and never with a guess: the table is read by a person, and
+	// a blank cell reads like a bug in brig rather than a fact about that
+	// sandbox.
+	var table bytes.Buffer
+	printSandboxes(&table, rows)
+	if !strings.Contains(table.String(), "REF") {
+		t.Errorf("the listing has no REF column:\n%s", table.String())
+	}
+	for _, line := range strings.Split(strings.TrimSpace(table.String()), "\n") {
+		if !strings.HasPrefix(line, "brig-mystery") {
+			continue
+		}
+		if !strings.Contains(line, noRef) {
+			t.Errorf("a sandbox with no ref is listed as %q, want %q in it", line, noRef)
+		}
+	}
+}
+
+// `brig ls -q` prints refs and nothing else, which is the form a script reads.
+// No header, no state, no workspace -- and nothing for a sandbox that has no
+// ref, because every line of this output is meant to be a word another verb
+// takes.
+func TestListingQuietPrintsRefsOnly(t *testing.T) {
+	var buf bytes.Buffer
+	printRefs(&buf, []sandboxRow{
+		{name: "brig-claude-code", ref: "claude-code", state: "running", workspace: "/ws"},
+		{name: "brig-mystery", ref: "", state: "running", workspace: "/ws"},
+	})
+	if got := strings.Fields(buf.String()); len(got) != 1 || got[0] != "claude-code" {
+		t.Errorf("ls -q printed %q, want the one ref on its own", buf.String())
+	}
+	// -q is a flag on ls, and the only one. Anything else is still refused.
+	scratchHost(t)
+	for _, args := range [][]string{{"-q"}, {"--quiet"}} {
+		if _, err := captureStdout(t, func() error { return listSandboxes(args) }); err != nil {
+			t.Errorf("brig ls %s: %v", args[0], err)
+		}
+	}
+	if _, err := captureStdout(t, func() error { return listSandboxes([]string{"-x"}) }); err == nil {
+		t.Error("brig ls -x was accepted")
+	}
+}
+
+// The acceptance criterion for the whole change: every ref `brig ls -q` prints
+// is a word every verb takes. If this can fail, a user who pipes the listing
+// into a verb gets an error out of brig's own output, which is the fault the
+// issue was filed about.
+//
+// Driven through run() rather than through the parser, so what is asserted is
+// the command line as someone would type it -- the verb, the operand, and the
+// dispatch between them.
+func TestListingRefsRoundTripThroughEveryVerb(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("BRIG_STATE_DIR", dir)
+	index := `{` +
+		`"claude-code@refactor": {"home": "/ws/refactor", "sandbox": "brig-claude-code-refactor"},` +
+		`"claude-code": {"home": "/ws/default", "sandbox": "brig-claude-code"}}`
+	if err := os.WriteFile(filepath.Join(dir, "sessions.json"), []byte(index), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	rows := sandboxRows([]runtime.Instance{
+		{Name: "brig-claude-code", State: "running"},
+		{Name: "brig-claude-code-refactor", State: "stopped"},
+		{Name: "brig-mystery", State: "running"},
+	}, nil)
+	var buf bytes.Buffer
+	printRefs(&buf, rows)
+	refs := strings.Fields(buf.String())
+	if len(refs) < 2 {
+		t.Fatalf("ls -q printed %d refs, want the sessions in the index: %q", len(refs), refs)
+	}
+
+	// Every verb that takes a session, in the spelling the help text teaches
+	// and in the spellings it retires, plus the verbless form. exec is the one
+	// that needs a command of its own.
+	lines := func(ref string) [][]string {
+		return [][]string{
+			{"run", ref}, {"sh", ref}, {"stop", ref}, {"rm", ref}, {"info", ref},
+			{"create", ref}, {"shell", ref}, {"env", ref}, {"exec", ref, "--", "true"},
+			{ref},
+		}
+	}
+	for _, ref := range refs {
+		// A ref brig printed has to parse as one before anything else can be
+		// true of it.
+		if _, err := session.ParseRef(ref); err != nil {
+			t.Errorf("ls -q printed %q, which is not a ref: %v", ref, err)
+			continue
+		}
+		for _, args := range lines(ref) {
+			scratchHost(t)
+			_, err := captureStdout(t, func() error { return run(args) })
+			if !took(err) {
+				t.Errorf("brig %s refused a ref brig ls -q printed: %v",
+					strings.Join(args, " "), err)
+			}
+		}
+	}
+}

--- a/cmd/brig/main.go
+++ b/cmd/brig/main.go
@@ -45,7 +45,7 @@ usage:
   brig stop <ref>                                stop the sandbox, keep it
   brig rm   <ref>                                stop and remove the sandbox
   brig rm   --all                                stop and remove every brig sandbox
-  brig ls                                        list sandboxes
+  brig ls   [-q]                                 list sandboxes; -q prints the refs
   brig info <ref>                                print the execution envelope and the
                                                  full environment, by name -- fails
                                                  if a declared secret is missing
@@ -71,7 +71,8 @@ flags (before the agent's own arguments; -- ends brig's parsing):
       --cpus N           guest vCPUs
   -d, --detach           with run: start the sandbox and exit
   -q, --quiet            with run: do not print the execution envelope before
-                         the agent starts
+                         the agent starts. With ls: print the refs and nothing
+                         else, one per line, for a script to read
       --skills           project your own ~/.claude skills and plugins into
                          the guest, read-only (or BRIG_SKILLS=1)
       --network MODE     shared, isolated or offline (or BRIG_NETWORK)
@@ -952,13 +953,30 @@ func spell(name string) string {
 // listSandboxes shows what is running, and what is merely holding a name. A
 // stopped sandbox still owns its name, which is exactly the thing to see
 // before wondering why a name is taken.
+//
+// It leads with the ref, which is what every other verb takes: a listing whose
+// identifier no verb accepts is a listing a reader cannot act on, and copying
+// what it printed used to be an error.
 func listSandboxes(args []string) error {
-	// ls names no session and takes no flags, so anything here is a token it
-	// would otherwise read and discard -- `brig ls claude` looks like it filters
-	// to one agent and does not. Refuse it rather than answer a question that
-	// was not asked.
-	if len(args) > 0 {
-		return usagef("unexpected argument %q; `brig ls` takes no arguments", args[0])
+	// ls names no session and -q is the only flag it has, so anything else here
+	// is a token it would otherwise read and discard -- `brig ls claude` looks
+	// like it filters to one agent and does not. Refuse it rather than answer a
+	// question that was not asked.
+	//
+	// Read here rather than through the flag package because ls is dispatched
+	// before the run line is parsed: it has no ref to parse, and the run line's
+	// parser exists to find where brig's arguments stop, which on this verb is
+	// immediately. Both spellings, because -q and --quiet are one flag
+	// everywhere else brig reads them.
+	quiet := false
+	for _, a := range args {
+		switch a {
+		case "-q", "--quiet":
+			quiet = true
+		default:
+			return usagef("unexpected argument %q; `brig ls` takes no arguments "+
+				"other than -q", a)
+		}
 	}
 	rt, err := runtime.Detect()
 	if err != nil {
@@ -977,6 +995,13 @@ func listSandboxes(args []string) error {
 		// shape of `brig ls` does not change with the runtime, and surface the
 		// platform-specific way to get one -- the hint run gives -- so a fresh
 		// box is told how rather than only that there is nothing.
+		//
+		// Except under -q, which is read by a script: no sandboxes is an empty
+		// list, and the note about why would be a line the loop reading this had
+		// to recognise and skip.
+		if quiet {
+			return nil
+		}
 		printSandboxes(os.Stdout, nil)
 		fmt.Println("(none -- no runtime found on PATH, so there are no sandboxes)")
 		fmt.Printf("  %s\n", strings.TrimPrefix(err.Error(), "no runtime found on PATH: "))
@@ -990,6 +1015,25 @@ func listSandboxes(args []string) error {
 	// an entry for a sandbox that went away without going through `brig rm`
 	// can be dropped. See wrap.PruneSessions.
 	pruneSessionIndex(list)
+	rows := sandboxRows(list, rt)
+	if quiet {
+		printRefs(os.Stdout, rows)
+		return nil
+	}
+	printSandboxes(os.Stdout, rows)
+	if len(rows) == 0 {
+		fmt.Println("(none -- `brig run claude` starts one)")
+	}
+	return nil
+}
+
+// sandboxRows turns what the runtime has into the listing: brig's own
+// sandboxes, in name order, each with the ref and the workspace it answers to.
+//
+// Separate from listSandboxes because it is the whole of what the listing
+// decides, and the only part of it a test can drive without a runtime: what the
+// two printers below are handed is exactly this.
+func sandboxRows(list []runtime.Instance, rt runtime.Runtime) []sandboxRow {
 	sort.Slice(list, func(i, j int) bool { return list[i].Name < list[j].Name })
 	rows := make([]sandboxRow, 0, len(list))
 	for _, inst := range list {
@@ -997,16 +1041,13 @@ func listSandboxes(args []string) error {
 			continue
 		}
 		rows = append(rows, sandboxRow{
+			ref:       refOf(inst.Name),
 			name:      inst.Name,
 			state:     inst.State,
 			workspace: workspaceOf(inst.Name, rt),
 		})
 	}
-	printSandboxes(os.Stdout, rows)
-	if len(rows) == 0 {
-		fmt.Println("(none -- `brig run claude` starts one)")
-	}
-	return nil
+	return rows
 }
 
 // pruneSessionIndex hands the session index every instance the runtime has, so
@@ -1024,33 +1065,152 @@ func pruneSessionIndex(list []runtime.Instance) {
 }
 
 // sandboxRow is one line of the listing, gathered before anything is printed
-// so the name column can be sized to the names it will actually hold.
+// so the two variable-width columns can be sized to what they will hold.
+//
+// ref is the session this sandbox is carrying, and empty when brig has none to
+// print for it -- see refOf. It is a string rather than a session.Ref because
+// the listing only ever writes it out, and an empty string is the one state a
+// Ref cannot hold: a Ref with an empty agent is not a ref, and it would have to
+// be checked for at every use rather than once, here.
 type sandboxRow struct {
+	ref       string
 	name      string
 	state     string
 	workspace string
 }
 
-// printSandboxes writes the listing, header included, with the name column as
-// wide as the names in it.
+// noRef is what the table shows for a sandbox with no ref to print.
+//
+// A dash rather than a blank, because the two say different things to whoever
+// is reading: an empty cell in a column that is full on every other line reads
+// as brig having lost the value, and this is brig saying it has none. Nothing
+// is guessed into the gap -- see refOf for what is derived and where the
+// deriving stops -- and the SANDBOX column beside it still names the thing, so
+// `brig rm --all` remains the way to be rid of it.
+const noRef = "-"
+
+// refCell is the ref as the table prints it, placeholder included.
+func refCell(ref string) string {
+	if ref == "" {
+		return noRef
+	}
+	return ref
+}
+
+// printSandboxes writes the listing, header included, with the ref and name
+// columns each as wide as what is in it.
+//
+// The ref leads, because it is the column that is also the identifier: it is
+// what every other verb takes, so it is the word a reader is here to copy. The
+// sandbox name is beside it for recognising brig's own sandboxes in the
+// runtime's output, which is the only thing that name is good for.
 //
 // The width was a constant, and no constant is right: a sandbox is named after
 // its profile plus a session slug, so brig-claude-desktop with a ten-character
 // slug is already 30 characters against the 28 that were reserved -- and a
 // profile read from a file can be called anything, so a wider constant only
-// moves where it breaks. Measuring the names costs a pass over a list brig has
+// moves where it breaks. Measuring the values costs a pass over a list brig has
 // in hand and cannot be outgrown.
 func printSandboxes(w io.Writer, rows []sandboxRow) {
-	name := len("SANDBOX")
+	ref, name := len("REF"), len("SANDBOX")
 	for _, r := range rows {
+		if n := len(refCell(r.ref)); n > ref {
+			ref = n
+		}
 		if len(r.name) > name {
 			name = len(r.name)
 		}
 	}
-	fmt.Fprintf(w, "%-*s %-10s %s\n", name, "SANDBOX", "STATE", "WORKSPACE")
+	fmt.Fprintf(w, "%-*s %-*s %-10s %s\n", ref, "REF", name, "SANDBOX", "STATE", "WORKSPACE")
 	for _, r := range rows {
-		fmt.Fprintf(w, "%-*s %-10s %s\n", name, r.name, r.state, r.workspace)
+		fmt.Fprintf(w, "%-*s %-*s %-10s %s\n",
+			ref, refCell(r.ref), name, r.name, r.state, r.workspace)
 	}
+}
+
+// printRefs writes the refs and nothing else, one to a line: `brig ls -q`, the
+// form a script reads.
+//
+// A row with no ref is left out rather than printed as the table's placeholder.
+// Every line of this output is meant to be a word another verb takes, and a
+// loop reading it must not be handed one that is not -- which is the promise the
+// round-trip test pins. The table is where a person sees that the sandbox is
+// there at all.
+func printRefs(w io.Writer, rows []sandboxRow) {
+	for _, r := range rows {
+		if r.ref == "" {
+			continue
+		}
+		fmt.Fprintln(w, r.ref)
+	}
+}
+
+// refOf is the ref of whichever session is carrying a sandbox: the one brig
+// recorded, and otherwise the one the sandbox's own name decomposes into. Empty
+// when neither answers, which is the case the table prints noRef for.
+//
+// The recorded ref is the answer whenever there is one: the index is filed by
+// ref, so an entry naming this sandbox holds that sandbox's ref by
+// construction. The derivation is for a sandbox with no entry -- one created
+// before the index existed, or one whose entry was pruned -- and it is the same
+// decomposition the workspace column has always fallen back to.
+//
+// Deriving beats leaving the column empty because the derived ref cannot
+// address a sandbox other than the one on its row: a sandbox is named
+// <prefix><agent>-<slug>, so resolving the ref it decomposes into builds that
+// same name straight back. The ambiguity in a sandbox name -- claude-code plus
+// the slug "refactor" reads equally as an agent called claude-code-refactor
+// with no slug -- picks between two refs that reach the one sandbox either way.
+// What it can get wrong is which agent, and so which workspace the session
+// resolves to by default, and the cost of that is one restart.
+//
+// Whatever comes out is then checked rather than trusted, on both counts the
+// listing promises: it has to parse as a ref, and its agent has to be one brig
+// still has. A sandbox named through BRIG_NAME can decompose into a label no
+// verb would accept, and an agent whose file has been deleted leaves a ref that
+// every verb answers "unknown profile" to. Neither is a word to hand a script,
+// so neither is printed, and the check is what makes that structural instead of
+// something to remember.
+func refOf(vmName string) string {
+	ref := wrap.RefOfSandbox(vmName)
+	if ref == "" {
+		agent, slug, ok := splitSandboxName(vmName)
+		if !ok {
+			return ""
+		}
+		ref = session.Ref{Agent: agent, Label: slug}.String()
+	}
+	parsed, err := session.ParseRef(ref)
+	if err != nil {
+		return ""
+	}
+	if _, ok := profile.Lookup(parsed.Agent); !ok {
+		return ""
+	}
+	return ref
+}
+
+// splitSandboxName reads a sandbox name back into the profile and the session
+// slug it was built from, and reports whether any profile brig has fits.
+//
+// Longest profile name first, so claude-code wins over a hypothetical claude
+// when both could prefix-match. An unnamed sandbox is named exactly after its
+// profile, so there is no slug to recover: without the equality case here,
+// TrimPrefix would leave the profile name intact and the caller would answer
+// about a session called "claude-code", which is not the one running.
+func splitSandboxName(vmName string) (profileName, slug string, ok bool) {
+	rest := strings.TrimPrefix(vmName, sandboxPrefix)
+	names := profile.Names()
+	sort.Slice(names, func(i, j int) bool { return len(names[i]) > len(names[j]) })
+	for _, name := range names {
+		switch {
+		case rest == name:
+			return name, "", true
+		case strings.HasPrefix(rest, name+"-"):
+			return name, strings.TrimPrefix(rest, name+"-"), true
+		}
+	}
+	return "", "", false
 }
 
 // workspaceOf recovers the workspace for a sandbox: what it was started with
@@ -1067,31 +1227,16 @@ func workspaceOf(vmName string, rt runtime.Runtime) string {
 	if ws := wrap.WorkspaceOfSandbox(vmName); ws != "" {
 		return ws
 	}
-	rest := strings.TrimPrefix(vmName, sandboxPrefix)
-	// Longest profile name first, so claude-code wins over a hypothetical
-	// claude when both could prefix-match.
-	names := profile.Names()
-	sort.Slice(names, func(i, j int) bool { return len(names[i]) > len(names[j]) })
-	for _, name := range names {
-		if rest != name && !strings.HasPrefix(rest, name+"-") {
-			continue
-		}
-		t, _ := profile.Lookup(name)
-		// An unnamed sandbox is named exactly after its profile, so there is
-		// no session name to recover. TrimPrefix would leave the profile
-		// name intact here and we would report the workspace of a session
-		// called "claude-code", which is not the one running.
-		session := ""
-		if rest != name {
-			session = strings.TrimPrefix(rest, name+"-")
-		}
-		cfg, err := wrap.Load(t, wrap.Options{Name: session}, rt)
-		if err != nil {
-			return ""
-		}
-		return cfg.Workspace
+	name, slug, ok := splitSandboxName(vmName)
+	if !ok {
+		return ""
 	}
-	return ""
+	t, _ := profile.Lookup(name)
+	cfg, err := wrap.Load(t, wrap.Options{Name: slug}, rt)
+	if err != nil {
+		return ""
+	}
+	return cfg.Workspace
 }
 
 // takeAll reads --all off a command line and reports whether it was there.

--- a/cmd/brig/main.go
+++ b/cmd/brig/main.go
@@ -32,22 +32,21 @@ var version = "dev"
 
 // sandboxPrefix is how brig recognises its own sandboxes in a runtime that
 // may be running other things. It is the same mark wrap stamps onto every
-// sandbox name, taken from there so the two cannot drift: ls and reset select
-// on exactly what Load refuses to let BRIG_NAME drop.
+// sandbox name, taken from there so the two cannot drift: ls and `rm --all`
+// select on exactly what Load refuses to let BRIG_NAME drop.
 const sandboxPrefix = wrap.NamePrefix
 
 const usage = `brig -- run a coding agent in a sandbox
 
 usage:
-  brig run    <profile> [flags] [agent args...]  start the sandbox and run it
-  brig create <profile> [flags]                  start the sandbox without attaching
-  brig exec   <profile> -- cmd [args...]         run one command inside the sandbox
-  brig shell  <profile> [cmd...]                 open a shell inside the sandbox
-  brig stop   <profile>                          stop the sandbox, keep it
-  brig rm     <profile>                          stop and remove the sandbox
+  brig run  <ref> [flags] [agent args...]        start the sandbox and run it
+  brig sh   <ref> [command...]                   a login shell inside the sandbox,
+                                                 or one command in it
+  brig stop <ref>                                stop the sandbox, keep it
+  brig rm   <ref>                                stop and remove the sandbox
+  brig rm   --all                                stop and remove every brig sandbox
   brig ls                                        list sandboxes
-  brig reset                                     stop and remove every brig sandbox
-  brig info   <profile>                          print the execution envelope and the
+  brig info <ref>                                print the execution envelope and the
                                                  full environment, by name -- fails
                                                  if a declared secret is missing
   brig agent ls|show|new|edit|rm|import|export   the agents you can run
@@ -59,17 +58,20 @@ usage:
                                                  turn the counting on or off
   brig version
 
+A <ref> is the session. claude is that agent's default session, and
+claude@refactor is a session of its own -- its own workspace, its own sandbox,
+and the label reaching the agent as its display name. A label brig would have
+to shorten is refused rather than shortened. brig ls prints the ref of every
+sandbox, and every verb above takes one.
+
 flags (before the agent's own arguments; -- ends brig's parsing):
-  -n, --name NAME        a session of its own: own workspace, own sandbox.
-                         Also written <profile>@<label>, which refuses a label
-                         it would have to shorten rather than shortening it
       --image IMAGE      guest image to boot
   -w, --workspace PATH   host directory to mount as the guest home
       --mem MB           guest memory
       --cpus N           guest vCPUs
   -d, --detach           with run: start the sandbox and exit
-  -q, --quiet            with run or create: do not print the execution
-                         envelope before the agent starts
+  -q, --quiet            with run: do not print the execution envelope before
+                         the agent starts
       --skills           project your own ~/.claude skills and plugins into
                          the guest, read-only (or BRIG_SKILLS=1)
       --network MODE     shared, isolated or offline (or BRIG_NETWORK)
@@ -220,10 +222,72 @@ func run(args []string) error {
 	case "ls":
 		return listSandboxes(rest)
 	case "reset":
-		return reset(rest)
-	case "run", "create", "exec", "shell", "stop", "rm", "info", "env":
+		// reset was the one verb whose name did not say what it acts on, which
+		// is the whole of its problem: it removes every sandbox brig has, and it
+		// was spelled as if it were a setting being restored. --all is that
+		// word, on the verb that already removes one.
+		deprecated("brig reset", "brig rm --all")
+		return removeAll("brig reset", rest)
+	case "rm":
+		// --all is read here rather than on the run line, because it names no
+		// session: split would refuse it as a brig flag standing where brig's
+		// own flags go, and it is not one. Without --all this falls through to
+		// the run line and removes the one sandbox the ref names.
+		if others, all := takeAll(rest); all {
+			return removeAll("brig rm --all", others)
+		}
+	case "run", "sh", "stop", "info":
+		// The taught lifecycle spellings. They fall through to the run line
+		// below, which is where the ref and the flags are read.
+	case "create":
+		// create is `run -d`: start the sandbox, print its name, attach to
+		// nothing. It keeps a branch of its own below rather than being
+		// rewritten into run here, because run hands a trailing word to the
+		// agent and create has no agent to hand one to -- a word after the ref
+		// is still a mistake, and translating the verb would have swallowed it.
+		deprecated("brig create", "brig run -d")
+	case "exec", "shell":
+		// Two verbs for one question: exec ran a command, shell opened a login
+		// shell or ran one. sh is both, because which of the two you want is
+		// said by whether you typed a command, not by which word you reached
+		// for.
+		//
+		// Both keep their own branch below rather than being translated to sh.
+		// exec runs its argv directly where sh runs it through `bash -lc`, so a
+		// script that relies on its own quoting keeps it -- a rename must not
+		// change what a working line does.
+		deprecated("brig "+verb, "brig sh")
+	case "env":
+		// Kept for one release as a spelling of `brig info`. The bug report
+		// template used to send reporters to `brig status`, which was never a
+		// command; info is the name that work settled on.
+		//
+		// Said here rather than beside the report it prints, so the notice
+		// arrives whether or not the profile behind it resolves. What is retired
+		// is the word, and the word is known before anything is looked up.
+		deprecated("brig env", "brig info")
 	default:
-		return fmt.Errorf("unknown command %q (try `brig help`)", verb)
+		// A bare ref with no verb, and it is tried last on purpose. A token
+		// becomes a ref only once it has matched no verb, so a verb is always a
+		// verb: install an agent called `ls` and `brig ls` is still the listing.
+		// Read the other way round, brig's own vocabulary would depend on which
+		// agents happen to be on the host, and the same command line would mean
+		// two things on two machines.
+		//
+		// Deliberately in no help text and no example. Two spellings of one
+		// thing is what the rest of this change is undoing; this one exists
+		// because `brig claude@refactor` is what people type, not because brig
+		// is teaching it.
+		ref, refErr := session.ParseRef(verb)
+		_, known := profile.Lookup(ref.Agent)
+		if refErr != nil || !known {
+			// Reported as a command and not as a ref, whichever of the two it
+			// failed as. The reader typed the token where a command goes, and
+			// the ref parser's complaint about a mistyped verb would answer a
+			// question nobody asked.
+			return fmt.Errorf("unknown command %q (try `brig help`)", verb)
+		}
+		verb, rest = "run", verbLine
 	}
 
 	opts, profileName, tail, err := parse(rest)
@@ -303,9 +367,9 @@ func run(args []string) error {
 
 	// The execution envelope: the boundary this run is about to trust, printed
 	// before the sandbox boots so the user sees it before it matters. Only run
-	// and create print it. exec and shell continue an existing session and stay
-	// quiet; when there is no sandbox yet they let EnsureRunning start one
-	// without printing the block, so a scripted brig exec is not interrupted.
+	// and create print it. sh continues an existing session and stays quiet;
+	// when there is no sandbox yet it lets EnsureRunning start one without
+	// printing the block, so a scripted `brig sh` is not interrupted.
 	// --quiet drops it for a script or a returning session.
 	if (verb == "run" || verb == "create") && !opts.quiet {
 		cfg.PrintPreRunEnvelope(set)
@@ -316,11 +380,8 @@ func run(args []string) error {
 		cfg.Info(set)
 		return nil
 	case "env":
-		// Kept for one release as a spelling of `brig info`, with the single
-		// line the other deprecated verbs print. The bug report template used
-		// to send reporters to `brig status`, which was never a command; info
-		// is the name that work settled on.
-		deprecated("brig env", "brig info")
+		// The retired spelling of the same report; the notice for it is printed
+		// by the dispatch above.
 		cfg.Info(set)
 		return nil
 	case "create":
@@ -329,7 +390,10 @@ func run(args []string) error {
 		}
 		fmt.Println(cfg.VMName)
 		return nil
-	case "shell":
+	case "sh", "shell":
+		// One command or none, which is the whole of sh's grammar: Shell runs
+		// the trailing words through a login shell and opens one when there are
+		// no trailing words.
 		if err := cfg.EnsureRunning(set); err != nil {
 			return err
 		}
@@ -351,7 +415,7 @@ func runAgent(cfg *wrap.Config, set creds.Set, t profile.Profile, tail []string,
 	// through and nothing to exec into: starting it IS the command.
 	if t.IsGUI() && len(tail) > 0 {
 		return fmt.Errorf("%s is a graphical agent, so it takes no arguments "+
-			"(use `brig shell %s` or `brig stop %s`)", t.Name, t.Name, t.Name)
+			"(use `brig sh %s` or `brig stop %s`)", t.Name, t.Name, t.Name)
 	}
 	if err := cfg.EnsureRunning(set); err != nil {
 		return err
@@ -453,15 +517,26 @@ var brigFlags = []struct {
 	{long: "quiet", short: "q", position: posRun},
 }
 
-// deprecatedShorts are the short spellings on their way out, and the long ones
-// that replace them. #47 ships both grammars in v0.2 and removes the short
-// forms in v0.3, so these keep working and say so -- the same contract the
-// retiring verbs have. -n and -w are the other two; they are absent here
-// because #5 and #6 introduce what replaces them, and pointing at a flag that
-// does not exist yet is worse than saying nothing.
-var deprecatedShorts = map[string]string{
-	"-t": "--image",
-	"-m": "--mem",
+// deprecatedFlags are the spellings on their way out, and what replaces each.
+// #47 ships both grammars in v0.2 and removes these in v0.3, so they keep
+// working and say so -- the same contract the retiring verbs have.
+//
+// -n and --name retire onto the label rather than onto another flag: the ref is
+// what names a session now, and `brig run claude@refactor` is what `brig run
+// claude --name refactor` was. Both spellings are mapped and both are named,
+// rather than the long one being aliased quietly, because --name is also Claude
+// Code's own flag -- `brig run claude -- --name x` is the agent's --name today
+// -- and silently reinterpreting a flag two programs share is worse than saying
+// which of them read it.
+//
+// -w is the other short form going. It is absent here because #6 introduces
+// what replaces it, and pointing at a flag that does not exist yet is worse
+// than saying nothing.
+var deprecatedFlags = map[string]string{
+	"-t":     "--image",
+	"-m":     "--mem",
+	"-n":     "<agent>@<label>",
+	"--name": "<agent>@<label>",
 }
 
 // ours reports whether a token is one of brig's flags in the position it was
@@ -615,8 +690,8 @@ func split(args []string) (mine []string, ref session.Ref, tail []string, err er
 			// named before the value is taken, so the notice is never about a
 			// value that reads like a flag: `--name -t` is a session called -t
 			// and reaches this loop as a value, not as a token.
-			if spelling, _, _ := strings.Cut(a, "="); deprecatedShorts[spelling] != "" {
-				deprecated(spelling, deprecatedShorts[spelling])
+			if spelling, _, _ := strings.Cut(a, "="); deprecatedFlags[spelling] != "" {
+				deprecated(spelling, deprecatedFlags[spelling])
 			}
 			mine = append(mine, a)
 			if takesValue && i+1 < len(args) {
@@ -658,19 +733,20 @@ func agentTail(tail []string) []string {
 
 // rejectTail refuses a token a verb has no use for, rather than dropping it.
 //
-// run forwards the tail to the agent, and shell and exec turn it into the guest
-// command, so those keep whatever follows the profile. create, stop, rm and env
-// take a profile and nothing after it: a word left there is a mistake to name,
-// not an operand to swallow. create is grouped with the others rather than with
-// run because it does not attach -- split hands it the same agent tail run gets,
-// but there is no agent here to receive it, so a tail is still a mistake.
+// run forwards the tail to the agent, and sh -- with shell and exec, the two
+// spellings it replaces -- turns it into the guest command, so those keep
+// whatever follows the ref. create, stop, rm and env take a ref and nothing
+// after it: a word left there is a mistake to name, not an operand to swallow.
+// create is grouped with the others rather than with run because it does not
+// attach -- split hands it the same agent tail run gets, but there is no agent
+// here to receive it, so a tail is still a mistake.
 func rejectTail(verb string, tail []string) error {
 	switch verb {
-	case "run", "shell", "exec":
+	case "run", "sh", "shell", "exec":
 		return nil
 	}
 	if len(tail) > 0 {
-		return usagef("unexpected argument %q; `brig %s` takes a profile and nothing more", tail[0], verb)
+		return usagef("unexpected argument %q; `brig %s` takes a ref and nothing more", tail[0], verb)
 	}
 	return nil
 }
@@ -877,9 +953,9 @@ func spell(name string) string {
 // stopped sandbox still owns its name, which is exactly the thing to see
 // before wondering why a name is taken.
 func listSandboxes(args []string) error {
-	// ls names no profile and takes no flags, so anything here is a token it
+	// ls names no session and takes no flags, so anything here is a token it
 	// would otherwise read and discard -- `brig ls claude` looks like it filters
-	// to one profile and does not. Refuse it rather than answer a question that
+	// to one agent and does not. Refuse it rather than answer a question that
 	// was not asked.
 	if len(args) > 0 {
 		return usagef("unexpected argument %q; `brig ls` takes no arguments", args[0])
@@ -1018,19 +1094,46 @@ func workspaceOf(vmName string, rt runtime.Runtime) string {
 	return ""
 }
 
-// reset stops and removes every sandbox brig started. Workspaces are left
+// takeAll reads --all off a command line and reports whether it was there.
+//
+// A flag on rm rather than a verb of its own, because it is the same removal:
+// `brig rm <ref>` takes one sandbox and `brig rm --all` takes every one. The
+// long spelling only -- a short -a would be a second way to ask for the most
+// destructive thing brig does, and #47 is retiring short flags rather than
+// adding them.
+//
+// What is left of the line is handed back rather than dropped, so removeAll can
+// refuse it by name: `brig rm claude --all` is two different requests written on
+// one line, and picking either would act on something the line does not read
+// like.
+func takeAll(args []string) (rest []string, all bool) {
+	for _, a := range args {
+		if a == "--all" {
+			all = true
+			continue
+		}
+		rest = append(rest, a)
+	}
+	return rest, all
+}
+
+// removeAll stops and removes every sandbox brig started. Workspaces are left
 // alone: they are on the host, they hold your work, and this is a command
 // about sandboxes.
-func reset(args []string) error {
-	// reset stops and removes every brig sandbox, so a flag typed to make it
-	// safer -- `brig reset --dry-run` -- must not be read past and ignored,
+//
+// spelling is the command as it was typed, for the message: this is reached as
+// `brig rm --all` and as the retired `brig reset`, and an error about the wrong
+// one of those sends the reader to fix a line they did not write.
+func removeAll(spelling string, args []string) error {
+	// This stops and removes every brig sandbox, so a flag typed to make it
+	// safer -- `brig rm --all --dry-run` -- must not be read past and ignored,
 	// which is exactly how a command meant to preview ends up removing
-	// everything. It has no flags and no operands today; refuse anything here so
-	// a flag that gains a meaning later is one this release declined rather than
-	// silently swallowed.
+	// everything. It has no flags and no operands beyond --all itself; refuse
+	// anything here so a flag that gains a meaning later is one this release
+	// declined rather than silently swallowed.
 	if len(args) > 0 {
-		return usagef("unexpected argument %q; `brig reset` takes no arguments and removes "+
-			"every brig sandbox", args[0])
+		return usagef("unexpected argument %q; `%s` takes no arguments and removes "+
+			"every brig sandbox", args[0], spelling)
 	}
 	rt, err := runtime.Detect()
 	if err != nil {
@@ -1047,10 +1150,11 @@ func reset(args []string) error {
 		}
 		_ = rt.Stop(inst.Name)
 		err := rt.Remove(inst.Name)
-		// The same pruning `brig rm` does, for the same reason and on the same
-		// terms: this goes through the runtime directly rather than through a
-		// Config, because reset works from the instance list and a stopped
-		// sandbox need not correspond to a profile brig can still look up.
+		// The same pruning `brig rm` of one sandbox does, for the same reason
+		// and on the same terms: this goes through the runtime directly rather
+		// than through a Config, because it works from the instance list and a
+		// stopped sandbox need not correspond to a profile brig can still look
+		// up.
 		wrap.ForgetSandbox(inst.Name)
 		wrap.ForgetSlugClaim(inst.Name)
 		if err != nil {
@@ -1062,9 +1166,9 @@ func reset(args []string) error {
 	}
 	fmt.Fprintf(os.Stderr, "brig: removed %d sandbox(es). Workspaces are untouched.\n", removed)
 	// A network whose sandbox was removed outside brig is not reachable
-	// through Remove, because that sandbox is not in the list any more. reset
-	// is the verb that leaves nothing behind, so it prunes those too. Only the
-	// runtimes that make a network per sandbox implement this; the rest are
+	// through Remove, because that sandbox is not in the list any more. This is
+	// the one command that leaves nothing behind, so it prunes those too. Only
+	// the runtimes that make a network per sandbox implement this; the rest are
 	// skipped rather than asked.
 	if p, ok := rt.(runtime.NetworkPruner); ok {
 		// Asked again rather than reusing the list above: that one was taken

--- a/cmd/brig/main.go
+++ b/cmd/brig/main.go
@@ -281,13 +281,25 @@ func run(args []string) error {
 		// is teaching it.
 		ref, refErr := session.ParseRef(verb)
 		_, known := profile.Lookup(ref.Agent)
-		if refErr != nil || !known {
-			// Reported as a command and not as a ref, whichever of the two it
-			// failed as. The reader typed the token where a command goes, and
-			// the ref parser's complaint about a mistyped verb would answer a
-			// question nobody asked.
+		if (refErr != nil || !known) && !session.IsRefShaped(verb) {
+			// A bare word that failed is reported as a command and not as a
+			// ref. The reader typed it where a command goes, and it is a
+			// mistyped verb as readily as a mistyped agent -- so the ref
+			// parser's complaint would answer a question nobody asked.
 			return fmt.Errorf("unknown command %q (try `brig help`)", verb)
 		}
+		// A token carrying the separator is a ref that did not work, because
+		// nothing else it could be has an '@' in it. Answering that with the
+		// vocabulary of commands would send the reader looking for a verb they
+		// did not type, past a diagnosis that already names what is wrong with
+		// the ref.
+		if refErr != nil {
+			return refErr
+		}
+		// An agent brig does not have falls through to the run line rather
+		// than being reported here, which is where the verbed form reports it
+		// too. One message, not two spellings of one that have to be kept in
+		// step.
 		verb, rest = "run", verbLine
 	}
 

--- a/cmd/brig/main_test.go
+++ b/cmd/brig/main_test.go
@@ -395,28 +395,36 @@ func TestListingPrunesTheSessionsWhoseSandboxIsGone(t *testing.T) {
 	}
 }
 
-// The name column holds names, so it is as wide as the names it is printing.
-// A constant was wrong at both ends: brig-claude-desktop plus a ten-character
-// session slug is 30 characters, which ran into the state and pushed the rest
-// of the row out, and a listing of short names paid for the width anyway. A
-// profile from a file can be called anything, so there is no constant that
-// fits every name brig can generate.
-func TestSandboxListingSizesTheNameColumnToItsNames(t *testing.T) {
+// The two variable-width columns hold what is in them, so each is as wide as
+// its own widest value. A constant was wrong at both ends: brig-claude-desktop
+// plus a ten-character session slug is 30 characters, which ran into the state
+// and pushed the rest of the row out, and a listing of short names paid for the
+// width anyway. An agent from a file can be called anything, so there is no
+// constant that fits every name brig can generate -- nor every ref, which is
+// that name plus a label of up to ten characters.
+func TestSandboxListingSizesItsColumnsToTheirContents(t *testing.T) {
 	long := sandboxPrefix + "claude-desktop-" + strings.Repeat("s", 10)
+	longRef := "claude-desktop@" + strings.Repeat("s", 10)
+	short := sandboxPrefix + "codex"
 	for _, c := range []struct {
-		what  string
-		rows  []sandboxRow
-		width int
+		what      string
+		rows      []sandboxRow
+		ref, name int
 	}{
 		{"the longest name brig can generate", []sandboxRow{
-			{name: long, state: "stopped", workspace: "/ws/long"},
-		}, len(long)},
-		{"names shorter than the heading", []sandboxRow{
-			{name: sandboxPrefix + "codex", state: "running", workspace: "/ws/codex"},
-		}, len(sandboxPrefix + "codex")},
+			{ref: longRef, name: long, state: "stopped", workspace: "/ws/long"},
+		}, len(longRef), len(long)},
+		{"values shorter than their headings", []sandboxRow{
+			{ref: "codex", name: short, state: "running", workspace: "/ws/codex"},
+		}, len("codex"), len(short)},
+		// A sandbox with no ref prints the placeholder, and a column of
+		// placeholders is as wide as the heading over it.
+		{"a sandbox with no ref", []sandboxRow{
+			{name: short, state: "running", workspace: "/ws/codex"},
+		}, len("REF"), len(short)},
 		// The no-runtime case prints the header and no rows, and a header with
-		// nothing under it is as wide as the heading.
-		{"a header on its own", nil, len("SANDBOX")},
+		// nothing under it is as wide as the headings.
+		{"a header on its own", nil, len("REF"), len("SANDBOX")},
 	} {
 		var buf bytes.Buffer
 		printSandboxes(&buf, c.rows)
@@ -426,16 +434,23 @@ func TestSandboxListingSizesTheNameColumnToItsNames(t *testing.T) {
 				c.what, len(lines), len(c.rows), buf.String())
 		}
 		for i, line := range lines {
-			name, state := "SANDBOX", "STATE"
+			ref, name, state := "REF", "SANDBOX", "STATE"
 			if i > 0 {
-				name, state = c.rows[i-1].name, c.rows[i-1].state
+				r := c.rows[i-1]
+				ref, name, state = refCell(r.ref), r.name, r.state
 			}
-			if !strings.HasPrefix(line, name) {
-				t.Errorf("%s: line %d is %q, want it to start with %q", c.what, i, line, name)
+			// The ref leads the row: it is the column that is also the
+			// identifier every other verb takes.
+			if !strings.HasPrefix(line, ref) {
+				t.Errorf("%s: line %d is %q, want it to start with %q", c.what, i, line, ref)
 			}
-			if got := strings.Index(line, state); got != c.width+1 {
+			if got := strings.Index(line, name); got != c.ref+1 {
 				t.Errorf("%s: line %d puts %q at column %d, want %d:\n%s",
-					c.what, i, state, got, c.width+1, buf.String())
+					c.what, i, name, got, c.ref+1, buf.String())
+			}
+			if got := strings.Index(line, state); got != c.ref+1+c.name+1 {
+				t.Errorf("%s: line %d puts %q at column %d, want %d:\n%s",
+					c.what, i, state, got, c.ref+1+c.name+1, buf.String())
 			}
 		}
 	}

--- a/internal/session/ref.go
+++ b/internal/session/ref.go
@@ -90,6 +90,18 @@ func ParseRef(s string) (Ref, error) {
 	return Ref{Agent: agent, Label: label}, nil
 }
 
+// IsRefShaped reports whether a token carries the separator, which is the one
+// thing that tells a mistyped ref from a mistyped verb.
+//
+// It is here rather than a strings.Contains at the call site so that refSep
+// keeps one definition. The question it answers is only worth asking because
+// the separator is brig's: no verb has one, and ParseRef cuts on the first, so
+// an agent name cannot have one either. A token with an '@' in it therefore
+// has a single possible reading, however badly it is spelled.
+func IsRefShaped(s string) bool {
+	return strings.Contains(s, refSep)
+}
+
 // String writes a ref the way it is typed, so ParseRef reads back what String
 // prints. A ref with no label is the agent on its own rather than an agent
 // with a bare '@' after it, which ParseRef refuses.

--- a/internal/wrap/index.go
+++ b/internal/wrap/index.go
@@ -259,6 +259,26 @@ func WorkspaceOfSandbox(vmName string) string {
 	return ""
 }
 
+// RefOfSandbox is the ref of whichever session is carrying this sandbox, or ""
+// when none is.
+//
+// The key rather than the value, which is the other thing `brig ls` has to
+// recover from a sandbox name: the listing prints the ref every other verb
+// takes, and a sandbox name is not one -- brig-claude-code-refactor cannot say
+// which of its dashes separated the agent from the label, and that is the
+// ambiguity this index was keyed by ref to remove.
+//
+// Read on the same terms as WorkspaceOfSandbox: a sandbox carries one session,
+// so the first entry naming it is the only one.
+func RefOfSandbox(vmName string) string {
+	for ref, entry := range readSessionIndex() {
+		if entry.Sandbox == vmName {
+			return ref
+		}
+	}
+	return ""
+}
+
 // ForgetSandbox drops the entry of the session carrying a removed sandbox, so
 // the next session to take that name starts from the ordinary resolution
 // rather than inheriting a directory chosen for a different one.

--- a/script/smoke.sh
+++ b/script/smoke.sh
@@ -498,6 +498,47 @@ case "$listing" in
   *) bad "ls names the workspace -- got: $listing" ;;
 esac
 
+# The listing leads with the ref, which is the identifier every other verb
+# takes. The sandbox's own name is not one, and printing only that is the fault
+# this was filed as: a reader who copied what they saw got "unknown profile".
+case "$listing" in
+  REF*SANDBOX*STATE*WORKSPACE*) ok "ls heads the listing with the ref" ;;
+  *) bad "ls heads the listing with the ref -- got: $listing" ;;
+esac
+"$WORK/brig" ls -q > "$WORK/refs.out" 2>&1
+[ "$(cat "$WORK/refs.out")" = claude-code ] \
+  && ok "ls -q prints the ref and nothing else" \
+  || bad "ls -q prints the ref and nothing else -- got: $(cat "$WORK/refs.out")"
+
+# The round trip, against the real binary: every ref the listing prints is a
+# word every verb takes.
+#
+# "Takes" is the absence of a refusal rather than a successful run, and the exit
+# codes are what say which: 2 is a usage error and 3 is a name that resolves to
+# nothing, so those two are brig declining the operand. Anything else is the verb
+# having gone on to do its work, which the cases around this one assert. Read
+# that way the loop does not depend on the host's credentials, which is what
+# makes it a check about the grammar.
+takes_ref() {
+  local what="$1"; shift
+  "$WORK/brig" "$@" > "$WORK/rt.out" 2>&1
+  local rc=$?
+  case "$rc" in
+    2|3) bad "$what refused a ref that ls -q printed -- rc $rc: $(cat "$WORK/rt.out")" ;;
+    *)   ok "$what takes a ref that ls -q printed" ;;
+  esac
+}
+while read -r ref; do
+  takes_ref "brig run"   run "$ref" -d
+  takes_ref "brig sh"    sh "$ref" -- true
+  takes_ref "brig info"  info "$ref"
+  takes_ref "brig stop"  stop "$ref"
+  takes_ref "brig rm"    rm "$ref"
+  # And the verbless form, which is taught nowhere and accepted anyway. Last,
+  # because it is what puts the sandbox back for the cases below.
+  takes_ref "brig <ref>" "$ref" -d
+done < "$WORK/refs.out"
+
 # A stopped sandbox still holds its name, which is the thing worth seeing.
 "$WORK/brig" stop claude > /dev/null 2>&1
 listing="$("$WORK/brig" ls 2>/dev/null)"
@@ -687,6 +728,21 @@ case "$out" in
   *) bad "the refusal names the required prefix -- got: $out" ;;
 esac
 
+# A sandbox brig cannot name a session for: BRIG_NAME took it off the
+# <prefix><agent>-<slug> shape the name would otherwise decompose along, and the
+# index entry that knew which session it was carrying is gone. The listing says
+# so with a dash rather than guessing, and `ls -q` leaves the row out entirely --
+# every line of that output has to be a word a verb takes.
+BRIG_NAME=brig-mystery "$WORK/brig" run claude -d > /dev/null 2>&1
+rm -f "$BRIG_STATE_DIR/sessions.json"
+"$WORK/brig" ls > "$WORK/mystery.out" 2>/dev/null
+grep -q '^-  *brig-mystery ' "$WORK/mystery.out" \
+  && ok "a sandbox with no ref is listed with a dash" \
+  || bad "a sandbox with no ref is listed with a dash -- got: $(cat "$WORK/mystery.out")"
+"$WORK/brig" ls -q > "$WORK/mystery-refs.out" 2>/dev/null
+[ -s "$WORK/mystery-refs.out" ] \
+  && bad "ls -q printed a line for a sandbox with no ref: $(cat "$WORK/mystery-refs.out")" \
+  || ok "ls -q leaves out a sandbox with no ref"
 "$WORK/brig" rm --all > /dev/null 2>&1
 
 echo "== no runtime =="

--- a/script/smoke.sh
+++ b/script/smoke.sh
@@ -243,7 +243,7 @@ echo "== network =="
 # The posture the run resolved to is the posture the runtime is told about.
 # Net was a hardcoded "shared" for the whole life of the field, so this is the
 # check that the resolved value actually travels.
-"$WORK/brig" reset > /dev/null 2>&1
+"$WORK/brig" rm --all > /dev/null 2>&1
 : > "$STUB_LOG"
 "$WORK/brig" run claude --offline -d > "$WORK/off.out" 2>&1
 grep -q -- '--net none' "$STUB_LOG" \
@@ -253,7 +253,7 @@ grep -q '^NETWORK .*offline' "$WORK/off.out" \
   && ok "the envelope says the sandbox is offline" \
   || bad "the envelope says the sandbox is offline -- got: $(cat "$WORK/off.out")"
 
-"$WORK/brig" reset > /dev/null 2>&1
+"$WORK/brig" rm --all > /dev/null 2>&1
 : > "$STUB_LOG"
 "$WORK/brig" run claude -d > "$WORK/on.out" 2>&1
 grep -q -- '--net shared' "$STUB_LOG" \
@@ -267,7 +267,7 @@ grep -q '^NETWORK .*shared' "$WORK/on.out" \
 # hull stand-in, so what is checked here is that the posture reaches the
 # runtime; that two sandboxes on separate networks genuinely cannot reach each
 # other is a real-runtime fact, recorded in docs/manual-tests.
-"$WORK/brig" reset > /dev/null 2>&1
+"$WORK/brig" rm --all > /dev/null 2>&1
 : > "$STUB_LOG"
 "$WORK/brig" run claude --network isolated -d > "$WORK/iso.out" 2>&1
 grep -q -- '--net isolated' "$STUB_LOG" \
@@ -276,18 +276,18 @@ grep -q -- '--net isolated' "$STUB_LOG" \
 grep -q '^NETWORK .*isolated' "$WORK/iso.out" \
   && ok "the envelope names the isolated posture" \
   || bad "the envelope names the isolated posture -- got: $(cat "$WORK/iso.out")"
-"$WORK/brig" reset > /dev/null 2>&1
+"$WORK/brig" rm --all > /dev/null 2>&1
 
 # A posture brig does not know must stop the run rather than pick one.
-out="$(BRIG_NETWORK=airgapped "$WORK/brig" env claude 2>&1)"; rc=$?
+out="$(BRIG_NETWORK=airgapped "$WORK/brig" info claude 2>&1)"; rc=$?
 [ "$rc" != 0 ] && ok "an unknown BRIG_NETWORK refuses the run" \
   || bad "an unknown BRIG_NETWORK started anyway: $out"
-"$WORK/brig" reset > /dev/null 2>&1
+"$WORK/brig" rm --all > /dev/null 2>&1
 
 echo "== denylist =="
 : > "$STUB_LOG"
 out="$(ANTHROPIC_API_KEY=sk-metered BRIG_FORWARD_ENV='ANTHROPIC_API_KEY GH_TOKEN' \
-  GH_TOKEN=gh-secret "$WORK/brig" env claude 2>&1)"
+  GH_TOKEN=gh-secret "$WORK/brig" info claude 2>&1)"
 case "$out" in
   *ANTHROPIC_API_KEY*denylist*) ok "the metered key is refused, and says why" ;;
   *) bad "the metered key is refused -- got: $out" ;;
@@ -302,7 +302,7 @@ case "$out" in
 esac
 
 echo "== unresolved reference =="
-out="$(GH_TOKEN='op://vault/item/field' "$WORK/brig" env claude 2>&1)"
+out="$(GH_TOKEN='op://vault/item/field' "$WORK/brig" info claude 2>&1)"
 case "$out" in
   *"unresolved secret reference"*) ok "a secret-manager reference is not forwarded" ;;
   *) bad "a secret-manager reference is not forwarded -- got: $out" ;;
@@ -313,7 +313,7 @@ echo "== removed settings =="
 # credential. It is removed, and a run that still sets it fails here rather
 # than booting a sandbox without the login its user believes they configured --
 # a failure that would otherwise surface as the guest asking them to log in.
-out="$(BRIG_CREDENTIALS_CMD='printf {}' "$WORK/brig" env claude 2>&1)"; rc=$?
+out="$(BRIG_CREDENTIALS_CMD='printf {}' "$WORK/brig" info claude 2>&1)"; rc=$?
 [ "$rc" != 0 ] && ok "a run still setting BRIG_CREDENTIALS_CMD fails" \
   || bad "a run still setting BRIG_CREDENTIALS_CMD started anyway"
 case "$out" in
@@ -337,7 +337,7 @@ grep -q 'is now `brig info`' "$WORK/info.err" \
 # one grep each: a row that drifts between the preview and the run makes the
 # preview a claim about a boundary nobody is going to use.
 "$WORK/brig" run claude -d > "$WORK/runenv.out" 2>&1
-"$WORK/brig" reset > /dev/null 2>&1
+"$WORK/brig" rm --all > /dev/null 2>&1
 envelope_rows() { grep -E '^(SESSION|PROFILE|SANDBOX|ISOLATION|WORKSPACE|IMAGE|CREDENTIALS) ' "$1"; }
 envelope_rows "$WORK/info.out" > "$WORK/rows.info"
 envelope_rows "$WORK/runenv.out" > "$WORK/rows.run"
@@ -372,7 +372,7 @@ echo "== session collision =="
 # Two names whose slugs shorten to one sandbox must not share it: the tight slug
 # budget used to drop the second into the first's home with its own credentials,
 # and brig only warned. Now the second is refused. See issue #26.
-"$WORK/brig" reset > /dev/null 2>&1
+"$WORK/brig" rm --all > /dev/null 2>&1
 "$WORK/brig" run claude --name acme-corp-prod -d > /dev/null 2>&1
 out="$("$WORK/brig" run claude --name acme-corp-staging -d 2>&1)"; rc=$?
 [ "$rc" != 0 ] && ok "a colliding session name is refused" \
@@ -397,7 +397,7 @@ esac
 # there is nothing to guess, and dropping them would leave the refusal off
 # until every session had run again. Unlike the session index, whose keys
 # cannot be read back into a ref at all.
-"$WORK/brig" reset > /dev/null 2>&1
+"$WORK/brig" rm --all > /dev/null 2>&1
 rm -f "$BRIG_STATE_DIR/slug-claims.json" "$BRIG_STATE_DIR/sessions.json"
 printf '{"brig-claude-code-acme-corp": "acme-corp-prod"}' > "$BRIG_STATE_DIR/sessions.json"
 out="$("$WORK/brig" run claude --name acme-corp-staging -d 2>&1)"
@@ -414,7 +414,7 @@ grep -q 'acme-corp-prod' "$BRIG_STATE_DIR/slug-claims.json" \
 # that same boot would have replaced the file the claims were still sitting in,
 # which makes a plain `brig run claude` the one command that silently destroys
 # them.
-"$WORK/brig" reset > /dev/null 2>&1
+"$WORK/brig" rm --all > /dev/null 2>&1
 rm -f "$BRIG_STATE_DIR/slug-claims.json" "$BRIG_STATE_DIR/sessions.json"
 printf '{"brig-claude-code-acme-corp": "acme-corp-prod"}' > "$BRIG_STATE_DIR/sessions.json"
 "$WORK/brig" run claude -d > /dev/null 2>&1
@@ -425,7 +425,7 @@ grep -q 'acme-corp-prod' "$BRIG_STATE_DIR/slug-claims.json" \
 # And claims nothing of its own, which is the other half of that pair: every
 # unnamed run of a profile is meant to be the one session, so there is no name
 # for a later one to collide with and nothing to write down.
-"$WORK/brig" reset > /dev/null 2>&1
+"$WORK/brig" rm --all > /dev/null 2>&1
 rm -f "$BRIG_STATE_DIR/slug-claims.json" "$BRIG_STATE_DIR/sessions.json"
 "$WORK/brig" run claude -d > /dev/null 2>&1
 [ -e "$BRIG_STATE_DIR/slug-claims.json" ] \
@@ -436,7 +436,7 @@ rm -f "$BRIG_STATE_DIR/slug-claims.json" "$BRIG_STATE_DIR/sessions.json"
 # whose values are objects rather than the claims' strings, so it cannot be
 # read as claims. Mistaking one for the other deletes the file, and every
 # session in it loses its home.
-"$WORK/brig" reset > /dev/null 2>&1
+"$WORK/brig" rm --all > /dev/null 2>&1
 rm -f "$BRIG_STATE_DIR/slug-claims.json" "$BRIG_STATE_DIR/sessions.json"
 "$WORK/brig" run claude --name rc23guard -d > /dev/null 2>&1
 if [ -s "$BRIG_STATE_DIR/sessions.json" ]; then
@@ -458,7 +458,7 @@ if [ -s "$BRIG_STATE_DIR/sessions.json" ]; then
 else
   bad "no session index to guard: $(cat "$BRIG_STATE_DIR/sessions.json" 2>&1)"
 fi
-"$WORK/brig" reset > /dev/null 2>&1
+"$WORK/brig" rm --all > /dev/null 2>&1
 
 echo "== stop =="
 : > "$STUB_LOG"
@@ -472,21 +472,21 @@ grep -q 'CLAUDE_CODE_OAUTH_TOKEN' "$STUB_LOG" \
 
 echo "== lifecycle verbs =="
 : > "$STUB_LOG"
-out="$("$WORK/brig" create claude 2>"$WORK/create.err")"
-[ "$out" = brig-claude-code ] && ok "create prints the sandbox name" \
-  || bad "create prints the sandbox name -- got '$out'"
+out="$("$WORK/brig" run claude -d 2>"$WORK/detach.err")"
+[ "$out" = brig-claude-code ] && ok "run -d prints the sandbox name" \
+  || bad "run -d prints the sandbox name -- got '$out'"
 # The envelope is on stderr, so the scriptable name on stdout stays clean.
-grep -q '^SANDBOX .*brig-claude-code' "$WORK/create.err" \
-  && ok "create prints the execution envelope" \
-  || bad "create prints the execution envelope: $(cat "$WORK/create.err")"
+grep -q '^SANDBOX .*brig-claude-code' "$WORK/detach.err" \
+  && ok "run -d prints the execution envelope" \
+  || bad "run -d prints the execution envelope: $(cat "$WORK/detach.err")"
 grep -q -- '-- claude' "$STUB_LOG" \
-  && bad "create started the agent" || ok "create starts the sandbox, not the agent"
+  && bad "run -d started the agent" || ok "run -d starts the sandbox, not the agent"
 
-# exec and shell attach to a sandbox whose envelope the user already saw, so
-# they do not repeat it. The sandbox created just above is still running.
-"$WORK/brig" exec claude -- true > /dev/null 2>"$WORK/exec.err"
-grep -q '^SANDBOX ' "$WORK/exec.err" \
-  && bad "exec printed the envelope" || ok "exec does not print the envelope"
+# sh attaches to a sandbox whose envelope the user already saw, so it does not
+# repeat it. The sandbox started just above is still running.
+"$WORK/brig" sh claude -- true > /dev/null 2>"$WORK/sh.err"
+grep -q '^SANDBOX ' "$WORK/sh.err" \
+  && bad "sh printed the envelope" || ok "sh does not print the envelope"
 
 listing="$("$WORK/brig" ls 2>/dev/null)"
 case "$listing" in
@@ -512,14 +512,13 @@ grep -q '^argv: rm brig-claude-code' "$STUB_LOG" \
   && ok "rm removes the sandbox" || bad "rm removes the sandbox"
 [ -d "$WS" ] && ok "rm leaves the workspace alone" || bad "rm deleted the workspace"
 
-out="$("$WORK/brig" run claude -d 2>/dev/null)"
-[ "$out" = brig-claude-code ] && ok "run -d prints the name and exits" \
-  || bad "run -d prints the name -- got '$out'"
+# A sandbox for `rm --all` to remove.
+"$WORK/brig" run claude -d > /dev/null 2>&1
 
 : > "$STUB_LOG"
-"$WORK/brig" reset > /dev/null 2>&1
+"$WORK/brig" rm --all > /dev/null 2>&1
 grep -q '^argv: rm brig-claude-code' "$STUB_LOG" \
-  && ok "reset removes brig sandboxes" || bad "reset removes brig sandboxes"
+  && ok "rm --all removes brig sandboxes" || bad "rm --all removes brig sandboxes"
 
 echo "== remembered workspace =="
 # A session created with -w used to be restarted by the next verb that left the
@@ -532,9 +531,9 @@ echo "== remembered workspace =="
 # setting that names a directory and this is about the case where nothing does.
 RC="$WORK/ws-rc23"
 brig_bare() { env -u BRIG_WORKSPACE "$WORK/brig" "$@"; }
-brig_bare create claude --name rc23 -w "$RC" > /dev/null 2>&1
+brig_bare run claude --name rc23 -w "$RC" -d > /dev/null 2>&1
 : > "$STUB_LOG"
-brig_bare exec claude --name rc23 -- uname -a > /dev/null 2>&1
+brig_bare sh claude --name rc23 -- uname -a > /dev/null 2>&1
 grep -q '^argv: run ' "$STUB_LOG" \
   && bad "exec without -w restarted the session" \
   || ok "exec without -w finds the workspace the session was created with"
@@ -551,7 +550,7 @@ esac
 # An explicit directory is a request rather than a guess, so it still wins and
 # still restarts: a share cannot be moved on a live guest.
 : > "$STUB_LOG"
-brig_bare exec claude --name rc23 -w "$WORK/ws-other" -- uname -a > /dev/null 2>&1
+brig_bare sh claude --name rc23 -w "$WORK/ws-other" -- uname -a > /dev/null 2>&1
 grep -q '^argv: run ' "$STUB_LOG" \
   && ok "a -w naming a different directory still restarts the sandbox" \
   || bad "a -w naming a different directory still restarts the sandbox"
@@ -564,7 +563,7 @@ grep -q '"claude-code@rc23"' "$BRIG_STATE_DIR/sessions.json" \
   && ok "the session is filed under its ref" \
   || bad "the session is not filed under claude-code@rc23 -- got: $(cat "$BRIG_STATE_DIR/sessions.json" 2>&1)"
 : > "$STUB_LOG"
-brig_bare exec claude-code --name rc23 -- uname -a > /dev/null 2>&1
+brig_bare sh claude-code --name rc23 -- uname -a > /dev/null 2>&1
 grep -q '^argv: run ' "$STUB_LOG" \
   && bad "the alias did not find the session's workspace" \
   || ok "the alias finds the workspace the session was created with"
@@ -574,8 +573,8 @@ grep -q 'brig-claude-code-rc23' "$BRIG_STATE_DIR/sessions.json" \
   && bad "rm left the sandbox in the session index" \
   || ok "rm drops the remembered workspace"
 
-brig_bare create claude --name rc23 -w "$RC" > /dev/null 2>&1
-"$WORK/brig" reset > /dev/null 2>&1
+brig_bare run claude --name rc23 -w "$RC" -d > /dev/null 2>&1
+"$WORK/brig" rm --all > /dev/null 2>&1
 grep -q 'brig-claude-code-rc23' "$BRIG_STATE_DIR/sessions.json" \
   && bad "reset left a sandbox in the session index" \
   || ok "reset drops the remembered workspaces"
@@ -584,38 +583,38 @@ grep -q 'brig-claude-code-rc23' "$BRIG_STATE_DIR/sessions.json" \
 # spelling for a session that has no label, rather than a trailing '@' or an
 # invented default one, either of which would be a key no ref types.
 rm -f "$BRIG_STATE_DIR/sessions.json"
-brig_bare create claude -w "$WORK/ws-bare" > /dev/null 2>&1
+brig_bare run claude -w "$WORK/ws-bare" -d > /dev/null 2>&1
 grep -q '"claude-code":' "$BRIG_STATE_DIR/sessions.json" \
   && ok "an unlabelled session is filed under the bare agent name" \
   || bad "the unlabelled session is not keyed claude-code -- got: $(cat "$BRIG_STATE_DIR/sessions.json" 2>&1)"
 grep -q 'claude-code@' "$BRIG_STATE_DIR/sessions.json" \
   && bad "the unlabelled session was given a label -- got: $(cat "$BRIG_STATE_DIR/sessions.json")" \
   || ok "the unlabelled session is given no label"
-"$WORK/brig" reset > /dev/null 2>&1
+"$WORK/brig" rm --all > /dev/null 2>&1
 
 # And the '@' form on the command line reaches the file: a session created as
 # claude@label is filed exactly as --name label files it, key and value both,
 # so the two spellings address one entry rather than two.
 rm -f "$BRIG_STATE_DIR/sessions.json"
-brig_bare create claude@rc23ref -w "$WORK/ws-ref" > /dev/null 2>&1
+brig_bare run claude@rc23ref -w "$WORK/ws-ref" -d > /dev/null 2>&1
 grep -q '"claude-code@rc23ref":' "$BRIG_STATE_DIR/sessions.json" \
   && ok "a session created as a ref is filed under that ref" \
   || bad "the ref form is not keyed claude-code@rc23ref -- got: $(cat "$BRIG_STATE_DIR/sessions.json" 2>&1)"
 grep -q '"sandbox": "brig-claude-code-rc23ref"' "$BRIG_STATE_DIR/sessions.json" \
   && ok "the ref form records the sandbox --name would have named" \
   || bad "the ref form's sandbox is not brig-claude-code-rc23ref -- got: $(cat "$BRIG_STATE_DIR/sessions.json")"
-"$WORK/brig" reset > /dev/null 2>&1
+"$WORK/brig" rm --all > /dev/null 2>&1
 
 # The sandbox-keyed file the session index replaces is deleted rather than
 # migrated: its keys cannot be read back into a ref without guessing which dash
 # separated the agent from its label. One restart per session in it, which is
 # what an absent entry has always cost.
 printf '{"brig-claude-code-rc23": "%s"}' "$WORK/ws-legacy" > "$BRIG_STATE_DIR/workspaces.json"
-brig_bare create claude --name rc23 -w "$RC" > /dev/null 2>&1
+brig_bare run claude --name rc23 -w "$RC" -d > /dev/null 2>&1
 [ -e "$BRIG_STATE_DIR/workspaces.json" ] \
   && bad "the old sandbox-keyed index was left behind" \
   || ok "the old sandbox-keyed index is deleted on sight"
-"$WORK/brig" reset > /dev/null 2>&1
+"$WORK/brig" rm --all > /dev/null 2>&1
 
 # The index is bookkeeping, so an unusable one costs a restart and nothing
 # more: every command still works, and the workspace resolves as it did before
@@ -625,21 +624,29 @@ brig_bare run claude -d > "$WORK/corrupt.out" 2>&1
 rc=$?
 [ "$rc" = 0 ] && ok "a corrupt index is ignored rather than fatal" \
   || bad "a corrupt index failed the run -- got: $(cat "$WORK/corrupt.out")"
-"$WORK/brig" reset > /dev/null 2>&1
+"$WORK/brig" rm --all > /dev/null 2>&1
 
 echo "== argument hygiene =="
 # A flag typed to make a destructive command safe must not be read past and
-# ignored. reset has no flags today, so --dry-run is refused (exit 2) and
-# removes nothing rather than stopping every sandbox.
+# ignored. `rm --all` takes nothing beside --all, so --dry-run is refused
+# (exit 2) and removes nothing rather than stopping every sandbox.
 "$WORK/brig" run claude -d > /dev/null 2>&1
 : > "$STUB_LOG"
-"$WORK/brig" reset --dry-run > "$WORK/dry.out" 2>&1; rc=$?
-[ "$rc" = 2 ] && ok "reset --dry-run exits 2" || bad "reset --dry-run exits 2 -- got $rc"
+"$WORK/brig" rm --all --dry-run > "$WORK/dry.out" 2>&1; rc=$?
+[ "$rc" = 2 ] && ok "rm --all --dry-run exits 2" || bad "rm --all --dry-run exits 2 -- got $rc"
 grep -q -- '--dry-run' "$WORK/dry.out" \
-  && ok "reset --dry-run names the token" || bad "reset --dry-run names the token"
+  && ok "rm --all --dry-run names the token" || bad "rm --all --dry-run names the token"
 grep -q '^argv: rm ' "$STUB_LOG" \
-  && bad "reset --dry-run removed a sandbox" || ok "reset --dry-run removes nothing"
-"$WORK/brig" reset > /dev/null 2>&1
+  && bad "rm --all --dry-run removed a sandbox" || ok "rm --all --dry-run removes nothing"
+# A ref beside --all is two requests on one line, so it is refused rather than
+# resolved to either of them.
+out="$("$WORK/brig" rm claude --all 2>&1)"; rc=$?
+[ "$rc" = 2 ] && ok "rm claude --all exits 2" || bad "rm claude --all exits 2 -- got $rc: $out"
+case "$out" in
+  *claude*) ok "rm claude --all names the ref it will not take" ;;
+  *) bad "rm claude --all names the ref -- got: $out" ;;
+esac
+"$WORK/brig" rm --all > /dev/null 2>&1
 
 # An unknown flag to the left of the profile is refused and named, rather than
 # consuming the profile and blaming it for being absent.
@@ -657,9 +664,9 @@ out="$("$WORK/brig" stop claude extra 2>&1)"; rc=$?
 [ "$rc" = 2 ] && ok "stop refuses a stray argument" || bad "stop refuses a stray argument -- got $rc: $out"
 
 echo "== BRIG_NAME =="
-"$WORK/brig" reset > /dev/null 2>&1
+"$WORK/brig" rm --all > /dev/null 2>&1
 # A name set through BRIG_NAME still carries the prefix, so ls lists it and
-# reset removes it the way they do any brig sandbox.
+# `rm --all` removes it the way they do any brig sandbox.
 BRIG_NAME=brig-custom "$WORK/brig" run claude -d > /dev/null 2>&1
 listing="$("$WORK/brig" ls 2>/dev/null)"
 case "$listing" in
@@ -667,9 +674,9 @@ case "$listing" in
   *) bad "a BRIG_NAME sandbox appears in ls -- got: $listing" ;;
 esac
 : > "$STUB_LOG"
-"$WORK/brig" reset > /dev/null 2>&1
+"$WORK/brig" rm --all > /dev/null 2>&1
 grep -q '^argv: rm brig-custom' "$STUB_LOG" \
-  && ok "reset removes a BRIG_NAME sandbox" || bad "reset removes a BRIG_NAME sandbox"
+  && ok "rm --all removes a BRIG_NAME sandbox" || bad "rm --all removes a BRIG_NAME sandbox"
 # A BRIG_NAME without the prefix would be invisible to both, so it is refused at
 # creation with a message naming the constraint.
 out="$(BRIG_NAME=custom "$WORK/brig" run claude -d 2>&1)"; rc=$?
@@ -679,7 +686,8 @@ case "$out" in
   *brig-*) ok "the refusal names the required prefix" ;;
   *) bad "the refusal names the required prefix -- got: $out" ;;
 esac
-"$WORK/brig" reset > /dev/null 2>&1
+
+"$WORK/brig" rm --all > /dev/null 2>&1
 
 echo "== no runtime =="
 # With no runtime on PATH, env still reports what is knowable and marks only the
@@ -770,7 +778,7 @@ grep -q -- "--shared-dir $WORK/other:/home/claude" "$STUB_LOG" \
   && ok "-w overrides the workspace" || bad "-w overrides the workspace"
 grep -q 'ghcr.io/me/img:latest' "$STUB_LOG" \
   && ok "-t overrides the image" || bad "-t overrides the image"
-"$WORK/brig" reset > /dev/null 2>&1
+"$WORK/brig" rm --all > /dev/null 2>&1
 
 echo "== ubuntu =="
 : > "$STUB_LOG"
@@ -1005,7 +1013,7 @@ grep -q -- '-- claude -p hi' "$STUB_LOG" \
 [ -f "$BRIG_PROFILE_DIR/mytool.yaml" ] \
   && bad "rm did not remove the copy under the name it was given" \
   || ok "rm removes the copy under the name it was given, asking nothing"
-"$WORK/brig" reset > /dev/null 2>&1
+"$WORK/brig" rm --all > /dev/null 2>&1
 
 # Every spelling this release retires keeps working, and says the one that
 # replaces it. Both halves matter: a spelling that fails breaks every script
@@ -1164,14 +1172,54 @@ export BRIG_BOOT_ASSETS="$WORK/assets"
 # to the one that needs no gateway rather than teach the stub to fake one.
 export BRIG_HYPERVISOR=vz
 
-echo "== shell =="
+echo "== sh =="
 : > "$STUB_LOG"
-"$WORK/brig" shell claude echo hi there > /dev/null 2>"$WORK/shell.err"
+"$WORK/brig" sh claude echo hi there > /dev/null 2>"$WORK/shell.err"
 grep -q -- '-- bash -lc echo hi there' "$STUB_LOG" \
   && ok "a trailing command reaches bash as one argument" \
   || bad "a trailing command reaches bash as one argument"
 grep -q '^SANDBOX ' "$WORK/shell.err" \
-  && bad "shell printed the envelope" || ok "shell does not print the envelope"
+  && bad "sh printed the envelope" || ok "sh does not print the envelope"
+
+# And with no command it is a login shell. One verb, and which of the two you
+# get is said by whether you typed a command -- not by which word you reached
+# for, which is what exec and shell made you choose.
+: > "$STUB_LOG"
+"$WORK/brig" sh claude > /dev/null 2>&1
+grep -q -- '-- bash -l$' "$STUB_LOG" \
+  && ok "sh with no command opens a login shell" \
+  || bad "sh with no command opens a login shell -- got: $(grep '^argv: exec' "$STUB_LOG" | tail -1)"
+
+echo "== retired spellings =="
+# Every spelling this release retires still works and says what replaces it. An
+# old spelling has to survive the commit that renames it, or that commit breaks
+# every script anyone has written.
+#
+# Both halves are asserted, and neither is enough alone: a spelling that fails
+# breaks those scripts, and one that works silently never teaches anyone the new
+# word, so the old one is still in them at the release that removes it.
+retired() {
+  local want="$1"; shift
+  local line="brig $*"
+  "$WORK/brig" "$@" > "$WORK/retired.out" 2>&1
+  local rc=$?
+  case "$rc" in
+    2|3) bad "$line was refused -- rc $rc: $(cat "$WORK/retired.out")" ;;
+    *)   ok "$line still works" ;;
+  esac
+  grep -q "is now \`$want\`" "$WORK/retired.out" \
+    && ok "$line names $want as its replacement" \
+    || bad "$line names $want -- got: $(cat "$WORK/retired.out")"
+}
+"$WORK/brig" run claude -d > /dev/null 2>&1
+retired 'brig sh' exec claude -- true
+retired 'brig sh' shell claude echo hi
+retired 'brig info' env claude
+retired 'brig run -d' create claude
+retired '<agent>@<label>' run claude --name retn -d
+retired '<agent>@<label>' run claude -n retn -d
+# Last of the group: it removes what the others were acting on.
+retired 'brig rm --all' reset
 
 [ "$fail" = 0 ] && echo PASS || echo FAILURES
 exit "$fail"


### PR DESCRIPTION
## Summary

`brig ls` printed `brig-claude-code-refactor`, which no verb accepted. Copying what the list showed
produced `unknown profile`. This makes the printed identifier the operand.

The operand half was already done by #108 (`split` returns a `session.Ref`, the label maps onto the
session path), so `brig stop claude@refactor` worked before this PR. What was missing: the verb
tree, and `ls` printing a ref at all.

## Related issues

Fixes #5. Part of #47. **Stacked on #118** — base `feat/13-agent-noun-groups`.
Merge order: #113, #115, #117, #118, this.

## Changes

Verb collapse, each retired spelling kept working with a one-line notice:

| retired | replacement |
| --- | --- |
| `brig exec <ref> -- cmd` | `brig sh <ref> cmd` |
| `brig shell <ref>` | `brig sh <ref>` |
| `brig create <ref>` | `brig run -d <ref>` |
| `brig reset` | `brig rm --all` |
| `brig env <ref>` | `brig info <ref>` |
| `-n`, `--name NAME` | `<agent>@<label>` |

- `brig sh <ref> [command...]`: with a command runs it, without one opens a login shell.
- Verbless `brig <ref>` resolves **last in the dispatch chain**, so a token is tried as a ref only
  after every verb has been checked. Accepted, in no help text or example.
- `brig ls` gains a `REF` column. `brig ls -q` prints refs only.
- `-n`/`--name` is mapped to a label and warned about rather than aliased: it is also Claude Code's
  own flag.

**No-index-entry case in `ls`.** A sandbox with no entry in `~/.brig/sessions.json` (created before
the index, or pruned) has no recorded ref. Order: recorded ref, else derive from the sandbox name,
else `-`.

Deriving is safe because it cannot address a different sandbox. A sandbox is named
`brig-<agent>-<slug>`, so re-resolving a decomposed ref rebuilds the same name. The
`claude-code` + `refactor` vs `claude-code-refactor` ambiguity picks between two readings that
compose to one string, so either is a valid address for that sandbox. The two copies of the
decomposition loop (`ls`'s workspace column already had one) are now one `splitSandboxName`.

Out of scope: `sh --cwd/-u/-t/-T`, multi-ref `rm`/`stop`, `brig diff`/`apply`, `brig start`. None
exist today; all are new capability.

## Testing

`script/smoke.sh`: 193 → 219 passing assertions.

Unit: `lifecycle_test.go` (142), `listing_test.go` (157), `deprecated_test.go` +111. The round-trip
test feeds `brig ls -q` into every verb and asserts each accepts it — that is the acceptance
criterion for this issue.

### Smoke failure set: 3 lines differ from the parent, not 0

Local run: 11 FAIL on both this branch and `845f89a`. The sets are **not** textually identical:

- parent `create prints the sandbox name` + `run -d prints the name` → this branch
  `run -d prints the sandbox name`. Two assertions became one: the `create` case was rewritten in
  the taught spelling, and the duplicate `run -d` case became setup for `rm --all`.
- this branch adds `sh with no command opens a login shell`, which fails locally.

All 11 local failures are downstream of the first: `brig run` exits 1 with `.claude/.credentials.json
sits on virtiofs rather than an ephemeral mount`, so no agent or shell exec runs against the stub on
that host. The equivalent assertion written against the parent's own `shell` verb fails there
identically. Re-run with `env -u GH_TOKEN`: same 11.

`script/smoke.sh` runs in CI (`ci.yml:62`) and passes there, so CI is the arbiter for whether the new
assertion holds.

## Manual testing

```bash
make build

export BRIG_RUNTIME=nosuchruntime BRIG_PROFILE_DIR=$(mktemp -d)
./brig create claude      # brig: `brig create` is now `brig run -d`
./brig exec claude -- ls   # brig: `brig exec` is now `brig sh`
./brig shell claude        # brig: `brig shell` is now `brig sh`
./brig reset               # brig: `brig reset` is now `brig rm --all`
./brig env claude          # brig: `brig env` is now `brig info`
```

Each prints the notice and then does the job. `runtime unavailable` after the notice means the line
parsed.

For `ls`, the ref column and the round trip need a runtime. The stub from `script/smoke.sh` works by
hand — extract the `hull` heredoc and export `BRIG_RUNTIME_BIN`, `BRIG_STATE_DIR`,
`BRIG_BOOT_ASSETS`, `BRIG_HYPERVISOR=vz`, `BRIG_VERIFY=off`:

```bash
./brig run -d claude@refactor
./brig ls          # REF column reads claude-code@refactor
./brig ls -q       # claude-code@refactor
for r in $(./brig ls -q); do ./brig info "$r"; done     # every ref must be accepted

rm "$BRIG_STATE_DIR/sessions.json"
./brig ls          # REF still claude-code@refactor, derived from the sandbox name
```

## Checklist

- [x] `make all` passes (vet, test, build)
- [x] `script/smoke.sh` passes
- [x] I have added or updated tests covering the change
- [x] I have run `go test ./... -race`, if the change touches concurrency, subprocesses or the daemon
- [ ] I have exercised the change against a real runtime (`brig run <agent>`), if it touches the run, exec or credential path
- [x] I have updated the affected docs (README, `docs/security.md`, `docs/profiles.md`, `docs/brigd.md`)

`script/smoke.sh` is ticked on the basis of CI, which is where it runs clean; see the section above
for the local host failures and why they are not this change.

Real runtime: not booted by the author of this branch. Every verb was exercised against the stub,
which covers the whole path except the VM.

Docs: README updated for the verbs this changes. The structural rewrite is #111.

## Credentials and the sandbox boundary

No new mount, no new forwarded variable, no new host path reachable from the guest. `brig sh` uses
the same exec path `exec` and `shell` used. `ls` prints sandbox names, refs and workspace paths, as
before.

## LLM usage

Authored with assistance from Claude Code (Opus 5). Verification re-run independently of the agent
that wrote the change: `gofmt`, `make all`, verb probes against the built binary, and the `ls`
round-trip plus the derive fallback exercised against the stub runtime with `sessions.json` removed.

Commits on this branch are **unsigned**: SSH signing via 1Password cannot be approved
non-interactively. `4f2ed2f`, `930e948`, `822596e` and `85dee40` lower in the stack are unsigned for
the same reason. The `main` ruleset does not require signatures.
