### PR TITLE
feat(session): drop the slug length cap and stop truncating

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,18 +221,18 @@ brig run claude --name refactor    # the same session, the older spelling
 A session of its own: its own workspace (`~/brig/claude-code-refactor`), its
 own sandbox, and the name you typed reaches the agent as its display name.
 
-Paths use a short lowercase form of the name -- letters, digits, dot, dash and
-underscore, ten characters -- so `my_project` and `my-project` stay separate,
-while `Foo` and `foo` do not (macOS filesystems ignore case, and two names
-sharing one directory but not one VM is a bug waiting to happen). If the slug
-differs from what you typed, brig says which directory it used.
-`brig info claude@refactor` prints the one in use.
+Paths use a lowercase form of the name -- letters, digits, dot, dash and
+underscore -- so `my_project` and `my-project` stay separate, while `Foo` and
+`foo` do not (macOS filesystems ignore case, and two names sharing one directory
+but not one VM is a bug waiting to happen). Nothing is shortened, so the name you
+pick is the directory you get. If the slug differs from what you typed, brig says
+which directory it used. `brig info claude@refactor` prints the one in use.
 
 The `@` form is the stricter of the two: a label brig would have to rewrite --
-uppercase, a space, more than ten characters -- is refused rather than quietly
-shortened, and the message names what it would have become. That is what makes
-the label safe to use as an address: nothing is silently mapped onto a directory
-you did not ask for. `--name` keeps its older, lenient behaviour.
+uppercase, a space, a slash -- is refused rather than quietly rewritten, and the
+message names what it would have become. That is what makes the label safe to use
+as an address: nothing is silently mapped onto a directory you did not ask for.
+`--name` keeps its older, lenient behaviour.
 
 **Every verb takes the ref.** A named session is addressed as
 `<agent>@<label>`, and the older agent-plus-`--name` spelling still works

--- a/cmd/brig/hygiene_test.go
+++ b/cmd/brig/hygiene_test.go
@@ -306,7 +306,9 @@ func TestParseRefusesABadRef(t *testing.T) {
 		{"claude@"},
 		{"claude@a@b"},
 		{"claude@Refactor"},
-		{"claude@my-very-long-label"},
+		// Long is not what refuses this -- a label is not shortened, so there
+		// is no length to refuse -- the spaces are.
+		{"claude@my very long label"},
 		{"@refactor"},
 	} {
 		_, _, _, err := parse(args)

--- a/cmd/brig/main.go
+++ b/cmd/brig/main.go
@@ -61,7 +61,7 @@ usage:
 A <ref> is the session. claude is that agent's default session, and
 claude@refactor is a session of its own -- its own workspace, its own sandbox,
 and the label reaching the agent as its display name. A label brig would have
-to shorten is refused rather than shortened. brig ls prints the ref of every
+to rewrite is refused rather than rewritten. brig ls prints the ref of every
 sandbox, and every verb above takes one.
 
 flags (before the agent's own arguments; -- ends brig's parsing):
@@ -354,9 +354,9 @@ func run(args []string) error {
 	if err != nil {
 		return err
 	}
-	// The slug is shortened and sanitised, so the directory a named session
-	// gets rarely reads back as the name typed. Say which directory it actually
-	// is whenever the two differ. A name that shortens onto another session's
+	// The slug is sanitised, so the directory a named session gets does not
+	// always read back as the name typed. Say which directory it actually is
+	// whenever the two differ. A name that sanitises onto another session's
 	// sandbox is refused later, at EnsureRunning; this only names the directory.
 	if cfg.RawName != "" && cfg.RawName != cfg.Slug {
 		fmt.Fprintf(os.Stderr, "brig: session %q uses %s (sandbox %s)\n",

--- a/internal/session/ref.go
+++ b/internal/session/ref.go
@@ -23,21 +23,19 @@ const refSep = "@"
 // places that have to agree: the sandbox name, which is the profile's name
 // plus "-" plus the slug (see internal/wrap/config.go), and the workspace
 // directory the guest gets as its home. Slug is what turns a name into both,
-// and Slug truncates at maxSlug -- so a cap any longer than that would let two
-// labels differing only past character maxSlug slug the same, land on one
-// sandbox and share one home directory. Refusing the label rather than
-// truncating it is what removes that collision, instead of detecting it later
-// and asking the user to pick again.
+// so a label Slug would rewrite is a label that addresses a directory nobody
+// typed. Refusing it is what keeps a ref an address, instead of quietly
+// mapping one spelling onto a session started under another.
 //
-// So the rule is: a label must already be what Slug would make of it. Below
-// the cap Slug cannot truncate, which is why the length check comes first and
-// why a single `label != Slug(label)` is then an exact test for "not
-// slug-clean" -- the character rules stay in Slug and are not restated here,
-// so the two cannot drift.
+// So the rule is: a label must already be what Slug would make of it. Slug
+// changes characters and nothing else -- it does not shorten -- so the single
+// `label != Slug(label)` is an exact test for "not slug-clean" at any length,
+// and there is no length for a label to be refused for. The character rules
+// stay in Slug and are not restated here, so the two cannot drift.
 //
 // --name is deliberately not held to this. It keeps its older, lenient
-// behaviour, truncation and the warning that names the directory it actually
-// got; the '@' form is the strict one.
+// behaviour, sanitising the name and reporting the directory it actually got;
+// the '@' form is the strict one.
 func ParseRef(s string) (Ref, error) {
 	agent, label, hasLabel := strings.Cut(s, refSep)
 	if strings.Contains(label, refSep) {
@@ -61,14 +59,6 @@ func ParseRef(s string) (Ref, error) {
 		return Ref{}, fmt.Errorf("session ref %q ends with %q and names no session. "+
 			"Drop the %q for the default session, or name one: `%s%srefactor`",
 			s, refSep, refSep, agent, refSep)
-	}
-	// Length before characters: see the doc comment. Counted in bytes because
-	// that is the budget Slug spends.
-	if len(label) > maxSlug {
-		return Ref{}, fmt.Errorf("session label %q is %d characters, and a label caps at %d. "+
-			"The label names a directory and a sandbox, so a longer one would have to be "+
-			"shortened -- and two labels shortened the same way would share one of each. "+
-			"Pick a shorter label", label, len(label), maxSlug)
 	}
 	if slug := Slug(label); slug != label {
 		if slug == "" {

--- a/internal/session/ref_test.go
+++ b/internal/session/ref_test.go
@@ -22,9 +22,11 @@ func TestParseRef(t *testing.T) {
 		{"claude@v1.2", Ref{Agent: "claude", Label: "v1.2"}},
 		{"claude@a-b", Ref{Agent: "claude", Label: "a-b"}},
 		{"claude@2", Ref{Agent: "claude", Label: "2"}},
-		// Exactly at the budget, which is the boundary the refusal below sits
-		// one character past.
-		{"claude@" + strings.Repeat("a", maxSlug), Ref{Agent: "claude", Label: strings.Repeat("a", maxSlug)}},
+		// Long, and slug-clean at that length. Nothing is cut any more, so a
+		// label is refused for what is in it and never for how much of it
+		// there is.
+		{"claude@a-really-rather-long-refactor-label",
+			Ref{Agent: "claude", Label: "a-really-rather-long-refactor-label"}},
 	}
 	for _, c := range cases {
 		got, err := ParseRef(c.in)
@@ -65,11 +67,11 @@ func TestParseRefRefusals(t *testing.T) {
 		// One '@' and no more: a second one is a typo, and picking a side
 		// would make `a@b@c` mean whichever side the parser happened to read.
 		{"claude@a@b", "claude@a@b"},
-		// One character past the budget.
-		{"claude@" + strings.Repeat("a", maxSlug+1), strings.Repeat("a", maxSlug+1)},
-		// Below the budget and not slug-clean: uppercase, a space, a path
-		// separator, a leading dash, a label with nothing usable in it, and a
-		// non-ASCII label.
+		// Long and not slug-clean. It is the uppercase that refuses this, not
+		// the length: the same label in lower case parses above.
+		{"claude@A-Really-Rather-Long-Refactor-Label", "A-Really-Rather-Long-Refactor-Label"},
+		// Not slug-clean: uppercase, a space, a path separator, a leading
+		// dash, a label with nothing usable in it, and a non-ASCII label.
 		{"claude@Refactor", "Refactor"},
 		{"claude@my ref", "my ref"},
 		{"claude@a/b", "a/b"},
@@ -107,15 +109,23 @@ func TestRefString(t *testing.T) {
 	}
 }
 
-// The cap is Slug's own budget, not a number of its own. A longer cap would
-// let two labels that differ only past the budget slug the same, which is the
-// collision the refusal exists to remove.
-func TestRefLabelCapIsTheSlugBudget(t *testing.T) {
-	long := strings.Repeat("a", maxSlug+1)
-	if Slug(long) == long {
-		t.Fatalf("Slug no longer truncates %q, so the cap needs rereading", long)
+// A label is refused for what is in it, not for how long it is. Both halves
+// are asserted together because they are one fact: Slug does not cut, so there
+// is no length at which ParseRef starts refusing -- and a budget put back into
+// Slug would make ParseRef refuse long labels again without a word being
+// changed here.
+func TestALongLabelIsRefusedOnlyForItsCharacters(t *testing.T) {
+	long := strings.Repeat("a", 200)
+	if got := Slug(long); got != long {
+		t.Fatalf("Slug cut a %d-character label to %d, which is what ParseRef would refuse it for",
+			len(long), len(got))
 	}
-	if _, err := ParseRef("claude@" + long); err == nil {
-		t.Errorf("a label Slug would truncate was accepted")
+	if _, err := ParseRef("claude@" + long); err != nil {
+		t.Errorf("a long slug-clean label was refused: %v", err)
+	}
+	// And length excuses nothing: the character test is the whole of the rule,
+	// at any length.
+	if _, err := ParseRef("claude@" + strings.ToUpper(long)); err == nil {
+		t.Errorf("a long label Slug would rewrite was accepted")
 	}
 }

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -13,14 +13,20 @@ import (
 	"github.com/brig-sh/brig/internal/profile"
 )
 
-// maxSlug keeps directory names short. It is a tight budget, so two long
-// names can slug the same and share one sandbox; callers report the
-// directory in use whenever the slug differs from the name.
-const maxSlug = 10
-
 // Slug turns a session name into something safe to put in a path. It returns
 // the empty string when the name holds no usable characters; the caller
 // decides what to do about that.
+//
+// Nothing is shortened. A slug used to be cut to ten characters to keep a
+// directory name short, and that cut is what made two long names one
+// directory: the same guest home and the same sandbox for two sessions, with
+// whichever credentials arrived last. A slug is now as long as the name makes
+// it, and the only ceiling left is the filesystem's own limit on a path
+// component.
+//
+// Sanitising still collapses names, which is a smaller class and not one a
+// budget was ever protecting against: Foo, foo! and foo are all foo. That is
+// what claimSlug refuses in internal/wrap -- see slugclaim.go.
 //
 // Replacing everything outside [A-Za-z0-9._-] is what makes this safe: it
 // takes out every '/', so a slug holds no path separator and cannot escape
@@ -39,19 +45,14 @@ func Slug(name string) string {
 		case r >= 'a' && r <= 'z', r >= '0' && r <= '9', r == '.', r == '_', r == '-':
 			b.WriteRune(r)
 		default:
-			// One dash per rune, collapsed below. A multi-byte rune is one
-			// character here, not one per byte, so a non-ASCII name does not
-			// blow the length budget on dashes.
+			// One dash per rune, collapsed below: a multi-byte rune becomes
+			// one dash rather than one per byte, so ünï reads as a name and
+			// not as a row of dashes.
 			b.WriteByte('-')
 		}
 	}
 	s := collapseDashes(b.String())
 	s = strings.TrimLeft(s, "-.")
-	s = strings.TrimRight(s, "-.")
-	if len(s) > maxSlug {
-		s = s[:maxSlug]
-	}
-	// Truncation can leave a trailing separator behind.
 	return strings.TrimRight(s, "-.")
 }
 
@@ -70,6 +71,29 @@ func collapseDashes(s string) string {
 		b.WriteRune(r)
 	}
 	return b.String()
+}
+
+// legacyBudget is the ten characters a slug used to be cut to. It is not a
+// limit any more -- see Slug -- and it survives only so that a session named
+// under it can be recognised. See LegacySlug.
+const legacyBudget = 10
+
+// LegacySlug is the slug an older release would have derived from this name:
+// today's slug cut to the old budget, with the trailing-separator trim that
+// release reapplied after the cut. It equals Slug for every name short enough
+// never to have been cut, which is how a caller tells a session whose
+// directory has moved from one whose has not.
+//
+// It exists for the migration notice and for nothing else. Nothing in a run
+// derives a path from it: the point is to name the directory the old release
+// left behind, so the reader can move or delete it.
+func LegacySlug(name string) string {
+	s := Slug(name)
+	if len(s) <= legacyBudget {
+		return s
+	}
+	// Counted in bytes, because bytes are the budget that release spent.
+	return strings.TrimRight(s[:legacyBudget], "-.")
 }
 
 // Resolve validates a session name and returns its slug.

--- a/internal/session/session_test.go
+++ b/internal/session/session_test.go
@@ -2,6 +2,7 @@ package session
 
 import (
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/brig-sh/brig/internal/profile"
@@ -23,19 +24,18 @@ func TestMain(m *testing.M) {
 func TestSlug(t *testing.T) {
 	cases := []struct{ in, want string }{
 		{"foo", "foo"},
-		{"Foo", "foo"},                     // lowercased
-		{"My Big Refactor", "my-big-ref"},  // spaces, truncated to 10
-		{"feature/JIRA-123", "feature-ji"}, // slash is not a path separator here
-		{"-foo", "foo"},                    // leading dash would read as a flag
-		{"../../etc", "etc"},               // no traversal survives
-		{"...", ""},                        // nothing usable
-		{"", ""},                           //
-		{"ünïcode", "n-code"},              // non-ASCII becomes dashes
-		{"exactlyten", "exactlyten"},       // exactly at the budget
-		{"abcdefghi-jkl", "abcdefghi"},     // truncation leaves no trailing dash
-		{"a---b", "a-b"},                   // dashes collapse
-		{"a___b", "a___b"},                 // underscore survives, so my_project
-		{"Desktop!", "desktop"},            // and my-project stay separate
+		{"Foo", "foo"},                           // lowercased
+		{"My Big Refactor", "my-big-refactor"},   // spaces become dashes
+		{"feature/JIRA-123", "feature-jira-123"}, // slash is not a path separator here
+		{"-foo", "foo"},                          // leading dash would read as a flag
+		{"../../etc", "etc"},                     // no traversal survives
+		{"...", ""},                              // nothing usable
+		{"", ""},                                 //
+		{"ünïcode", "n-code"},                    // non-ASCII becomes dashes
+		{"abcdefghi-jkl", "abcdefghi-jkl"},       // nothing is cut, so nothing to re-trim
+		{"a---b", "a-b"},                         // dashes collapse
+		{"a___b", "a___b"},                       // underscore survives, so my_project
+		{"Desktop!", "desktop"},                  // and my-project stay separate
 	}
 	for _, c := range cases {
 		if got := Slug(c.in); got != c.want {
@@ -48,11 +48,56 @@ func TestResolve(t *testing.T) {
 	if slug, err := Resolve("foo"); err != nil || slug != "foo" {
 		t.Errorf(`Resolve("foo") = %q, %v; want "foo", nil`, slug, err)
 	}
-	// "claude-desktop" is not in this list: it slugs to "claude-des", which
-	// lands on a workspace of its own rather than on the Desktop profile's.
-	for _, bad := range []string{"...", "", "desktop", "Desktop!"} {
+	// "claude-desktop" is in this list now. It used to be cut to "claude-des",
+	// a workspace of its own; with nothing cut it slugs to the Desktop
+	// profile's own workspace, so it is refused like every other spelling of
+	// it.
+	for _, bad := range []string{"...", "", "desktop", "Desktop!", "claude-desktop"} {
 		if _, err := Resolve(bad); err == nil {
 			t.Errorf("Resolve(%q) succeeded; want an error", bad)
+		}
+	}
+}
+
+// Slug does not truncate. The ten-character budget it used to spend bought a
+// short directory name and paid for it by mapping two long names onto one
+// directory -- which is the collision the budget was then blamed for. The only
+// ceiling left is the filesystem's own limit on a path component.
+func TestSlugDoesNotTruncate(t *testing.T) {
+	for _, long := range []string{
+		"a-really-rather-long-session-name-for-one-refactor",
+		// Length alone, with nothing in it to sanitise: what is asserted is
+		// that no budget is spent, not that some character survived.
+		strings.Repeat("a", 200),
+	} {
+		if got := Slug(long); got != long {
+			t.Errorf("Slug of %d characters came back as %q (%d)", len(long), got, len(got))
+		}
+	}
+}
+
+// LegacySlug is what an older release derived, and it has exactly one caller:
+// the migration notice, which has to name the directory that release left
+// behind. So it cuts where Slug no longer does, and agrees with Slug on every
+// name short enough never to have been cut -- which is how a caller tells a
+// session whose home has moved from one whose has not.
+func TestLegacySlug(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"foo", "foo"},
+		{"exactlyten", "exactlyten"},      // at the old budget, so never cut
+		{"refactoring", "refactorin"},     // one character past it
+		{"My Big Refactor", "my-big-ref"}, //
+		{"abcdefghi-jkl", "abcdefghi"},    // the cut left a trailing dash, trimmed
+		{"...", ""},                       // nothing usable, cut or not
+	}
+	for _, c := range cases {
+		if got := LegacySlug(c.in); got != c.want {
+			t.Errorf("LegacySlug(%q) = %q, want %q", c.in, got, c.want)
+		}
+		// The pair the notice is decided on: a name the old budget left alone
+		// slugs the same under both, and nothing is said about it.
+		if len(Slug(c.in)) <= 10 && LegacySlug(c.in) != Slug(c.in) {
+			t.Errorf("LegacySlug(%q) disagrees with Slug on a name that was never cut", c.in)
 		}
 	}
 }

--- a/internal/wrap/config.go
+++ b/internal/wrap/config.go
@@ -72,6 +72,10 @@ type Config struct {
 	// envWarnings are what building Env decided to drop, held until BuildEnv
 	// has somewhere to print them: Load has no writer yet.
 	envWarnings []string
+	// slugMigration is the notice for a session whose home has moved since it
+	// was created, held until BuildEnv for the same reason. See
+	// slugMigrationNotice.
+	slugMigration []string
 	// secrets is what the store gave this run, kept so file delivery does not
 	// read it twice -- and cleared the moment delivery is done, because a
 	// plaintext refresh token has no business outliving its use.
@@ -213,6 +217,9 @@ func Load(t profile.Profile, o Options, rt runtime.Runtime) (*Config, error) {
 		return nil, fmt.Errorf("BRIG_NAME is %q, but a brig sandbox name must begin with %q so that "+
 			"`brig ls` and `brig reset` can find it; use %q instead", vmName, NamePrefix, NamePrefix+vmName)
 	}
+	// Kept before the suffix goes on, for the migration notice below: it has
+	// to name the sandbox an older release derived from this same profile.
+	vmBase := vmName
 	if slug != "" {
 		vmName += "-" + slug
 	}
@@ -336,10 +343,64 @@ func Load(t profile.Profile, o Options, rt runtime.Runtime) (*Config, error) {
 		return nil, strictErr
 	}
 	c.GuestCwd = GuestCwd(cwd, c.Workspace, t.GuestHome)
+	// After the Config is built, because the notice reads the pair this run
+	// resolved to and reports it against the pair the old one had.
+	c.slugMigration = c.slugMigrationNotice(base, vmBase)
 	if err := c.resolveGitIdentity(); err != nil {
 		return nil, err
 	}
 	return c, nil
+}
+
+// slugMigrationNotice is what this run has to be told about a session created
+// before a slug stopped being cut to ten characters, or nothing when this run
+// is not one.
+//
+// A longer --name now keeps its name in full, so it derives a different slug
+// than it used to -- and both the sandbox name and the guest home come off the
+// slug on every run. The same command that worked yesterday therefore boots a
+// new sandbox on a new home directory, and the old pair is orphaned: the work
+// in the old workspace is on the host and is still there, but state inside the
+// guest is not, and a login made in the sandbox is the half of that people
+// notice.
+//
+// Both conditions have to hold before this says anything, because a notice
+// that reaches people it does not apply to is one they learn to skip. The slug
+// has to have actually moved -- a name of ten characters or fewer slugs today
+// exactly as it always did -- and the directory it moved from has to be on
+// disk, since a long name that never ran has nothing orphaned to name.
+//
+// The old home is read back from the session index first and derived only as a
+// fallback, so a session started under --workspace or BRIG_WORKSPACE is named
+// where it actually is rather than where this invocation's base would have put
+// it.
+func (c *Config) slugMigrationNotice(base, vmBase string) []string {
+	if c.RawName == "" {
+		return nil
+	}
+	old := session.LegacySlug(c.RawName)
+	if old == "" || old == c.Slug {
+		return nil
+	}
+	oldVM := vmBase + "-" + old
+	oldWorkspace := rememberedWorkspace(sessionKey(c.Profile.Name, old), oldVM)
+	if oldWorkspace == "" {
+		oldWorkspace = base + "-" + old
+	}
+	// Only a stat that says the directory is there. One that fails any other
+	// way has not established that there is anything to move, and guessing
+	// from it would put the notice in front of the run that cannot act on it.
+	if _, err := os.Stat(oldWorkspace); err != nil {
+		return nil
+	}
+	return []string{
+		fmt.Sprintf("session %q used to be shortened to %q and now keeps its name in full, "+
+			"so it has a new home and a new sandbox: %s (%s) instead of %s (%s).",
+			c.RawName, old, c.Workspace, c.VMName, oldWorkspace, oldVM),
+		fmt.Sprintf("Nothing reads %s now. The work in it is on the host, so move or delete "+
+			"it at your leisure -- but state inside the old sandbox does not come across, "+
+			"so this session may ask you to log in again.", oldWorkspace),
+	}
 }
 
 // envOverride applies BRIG_FORWARD_ENV, which replaces the env-sourced set,

--- a/internal/wrap/run.go
+++ b/internal/wrap/run.go
@@ -26,6 +26,12 @@ func (c *Config) BuildEnv() (creds.Set, error) {
 	for _, w := range c.envWarnings {
 		c.warnf("%s", w)
 	}
+	// Beside them, and for the same reason: this too was decided in Load, it
+	// is nobody's fault and no reason to fail, and the run it applies to is
+	// the one about to create the new directory. See slugMigrationNotice.
+	for _, w := range c.slugMigration {
+		c.warnf("%s", w)
+	}
 
 	// Resolved before anything else touches the sandbox, and returned as an
 	// error rather than a warning: a run whose secret cannot be resolved must
@@ -173,9 +179,9 @@ func (c *Config) resolveSecrets() (creds.Resolution, error) {
 // EnsureRunning brings the sandbox up if it is not already, and makes sure
 // the one that is up is mounting this workspace.
 func (c *Config) EnsureRunning(set creds.Set) error {
-	// Before anything is prepared or booted: a name that shortens to a sandbox
-	// another name already owns is refused here rather than dropped into that
-	// sandbox's home directory. See slugclaim.go.
+	// Before anything is prepared or booted: a name that sanitises onto a
+	// sandbox another name already owns is refused here rather than dropped
+	// into that sandbox's home directory. See slugclaim.go.
 	if err := c.claimSlug(); err != nil {
 		return err
 	}

--- a/internal/wrap/slugclaim.go
+++ b/internal/wrap/slugclaim.go
@@ -7,20 +7,25 @@ import (
 
 // The session-claim index: which session name owns each sandbox.
 //
-// A session name is turned into a short slug for its paths, and the sandbox is
-// brig-<profile>-<slug>. The slug budget is tight, so two different names that
-// share their leading characters can shorten to one slug and land on one
-// sandbox and one workspace -- with whatever credentials each was handed. brig
-// used to warn about that and carry on, which left two agents in one guest home
-// with different logins. Refuse the second name instead.
+// A session name is turned into a slug for its paths, and the sandbox is
+// brig-<profile>-<slug>. Sanitising is not one-to-one: Foo, foo! and foo are
+// all foo, so two different names can land on one sandbox and one workspace --
+// with whatever credentials each was handed. brig used to warn about that and
+// carry on, which left two agents in one guest home with different logins.
+// Refuse the second name instead.
+//
+// A slug used to be cut to ten characters as well, which collided two long
+// names that shared their leading characters the same way. That cut is gone
+// (see session.Slug) and this refusal is not: what remains is the collapse,
+// which no length budget was ever protecting against.
 //
 // The first name to take a sandbox writes down that it owns it; a later run
-// whose name shortens to the same sandbox but is not that name is refused and
+// whose name lands on the same sandbox but is not that name is refused and
 // told to pick another --name. The same name returning is the ordinary repeat
 // run and is let through.
 //
 // Keyed by sandbox name, not by the bare slug: the sandbox name carries the
-// profile, and two profiles that shorten to one slug share nothing, since the
+// profile, and two profiles that sanitise to one slug share nothing, since the
 // sandbox and the workspace both include the profile. It is also the key rm and
 // reset already have in hand, so releasing a claim sits beside ForgetSandbox
 // on both paths. Same file conventions as the session index (see index.go):
@@ -123,7 +128,7 @@ func (c *Config) claimSlug() error {
 	}
 	owner, taken := index[c.VMName]
 	if taken && owner != c.RawName {
-		return fmt.Errorf("session %q shortens to %q, the sandbox session %q already "+
+		return fmt.Errorf("session %q becomes %q, the sandbox session %q already "+
 			"uses (%s). Sharing it would put both agents in one home directory with "+
 			"whichever credentials arrived last, so run one under a different --name",
 			c.RawName, c.Slug, owner, c.VMName)
@@ -134,13 +139,13 @@ func (c *Config) claimSlug() error {
 	index[c.VMName] = c.RawName
 	if err := writeIndex(slugClaimIndexName, index); err != nil {
 		c.warnf("could not record %s as the owner of %s (%v). A later run whose name "+
-			"shortens to the same sandbox will not be refused.", c.RawName, c.VMName, err)
+			"lands on the same sandbox will not be refused.", c.RawName, c.VMName, err)
 	}
 	return nil
 }
 
 // ForgetSlugClaim drops a removed sandbox's claim, so the next session name
-// that shortens to it can take it. Errors are dropped the way ForgetSandbox
+// that lands on it can take it. Errors are dropped the way ForgetSandbox
 // drops its own: a removal that worked must not report a failure because a
 // bookkeeping file could not be rewritten.
 func ForgetSlugClaim(vmName string) {

--- a/internal/wrap/slugclaim_test.go
+++ b/internal/wrap/slugclaim_test.go
@@ -7,9 +7,13 @@ import (
 	"testing"
 )
 
-// The transcript in issue #26: two different session names whose slugs shorten
-// to the same sandbox. The first claims it; the second must be refused rather
-// than dropped into the same guest home with different credentials.
+// The transcript in issue #26: two different session names whose slugs land on
+// the same sandbox. The first claims it; the second must be refused rather than
+// dropped into the same guest home with different credentials.
+//
+// The collision is sanitisation, which is the class that survives a slug no
+// longer being cut to a budget: the space and the case both go, so these two
+// names are one slug however long they are.
 func TestACollidingSessionNameIsRefused(t *testing.T) {
 	isolateState(t)
 
@@ -18,20 +22,20 @@ func TestACollidingSessionNameIsRefused(t *testing.T) {
 		t.Fatalf("the first name could not claim its own sandbox: %v", err)
 	}
 
-	staging := mustLoad(t, Options{Name: "acme-corp-staging"})
-	if staging.VMName != prod.VMName {
+	retyped := mustLoad(t, Options{Name: "Acme Corp Prod"})
+	if retyped.VMName != prod.VMName {
 		t.Fatalf("the two names did not collide: %q and %q -- pick names that do",
-			prod.VMName, staging.VMName)
+			prod.VMName, retyped.VMName)
 	}
 
-	err := staging.claimSlug()
+	err := retyped.claimSlug()
 	if err == nil {
 		t.Fatal("a name colliding with another was allowed to share the sandbox")
 	}
 	// The refusal has to name both sessions, so the reader knows what they are
 	// up against and which other name to look for.
 	if !strings.Contains(err.Error(), "acme-corp-prod") ||
-		!strings.Contains(err.Error(), "acme-corp-staging") {
+		!strings.Contains(err.Error(), "Acme Corp Prod") {
 		t.Errorf("the refusal does not name both sessions: %v", err)
 	}
 }
@@ -67,8 +71,8 @@ func TestRemoveReleasesTheClaim(t *testing.T) {
 		t.Fatalf("remove failed: %v", err)
 	}
 
-	staging := mustLoad(t, Options{Name: "acme-corp-staging"})
-	if err := staging.claimSlug(); err != nil {
+	retyped := mustLoad(t, Options{Name: "Acme Corp Prod"})
+	if err := retyped.claimSlug(); err != nil {
 		t.Errorf("the sandbox was not released by rm: %v", err)
 	}
 }
@@ -88,8 +92,8 @@ func TestForgetSlugClaimPrunesByName(t *testing.T) {
 	ForgetSlugClaim("brig-claude-code-neverseen")
 	ForgetSlugClaim(prod.VMName)
 
-	staging := mustLoad(t, Options{Name: "acme-corp-staging"})
-	if err := staging.claimSlug(); err != nil {
+	retyped := mustLoad(t, Options{Name: "Acme Corp Prod"})
+	if err := retyped.claimSlug(); err != nil {
 		t.Errorf("reset did not release the claim: %v", err)
 	}
 }
@@ -103,19 +107,19 @@ func TestTheOldClaimsAreCarriedAcrossTheRename(t *testing.T) {
 
 	// sessions.json as the claim index had it: keyed by the sandbox name, with
 	// the owning session name as the value.
-	body := `{"brig-claude-code-acme-corp": "acme-corp-prod"}`
+	body := `{"brig-claude-code-acme-corp-prod": "acme-corp-prod"}`
 	if err := os.WriteFile(filepath.Join(dir, sessionIndexName), []byte(body), 0o600); err != nil {
 		t.Fatal(err)
 	}
 
 	// The claim is still in force, which is the whole point of carrying it:
-	// this name shortens to the sandbox acme-corp-prod owns.
-	staging := mustLoad(t, Options{Name: "acme-corp-staging"})
-	if staging.VMName != "brig-claude-code-acme-corp" {
-		t.Fatalf("this case is written around brig-claude-code-acme-corp, and the "+
-			"sandbox is %q", staging.VMName)
+	// this name sanitises to the sandbox acme-corp-prod owns.
+	retyped := mustLoad(t, Options{Name: "Acme Corp Prod"})
+	if retyped.VMName != "brig-claude-code-acme-corp-prod" {
+		t.Fatalf("this case is written around brig-claude-code-acme-corp-prod, and the "+
+			"sandbox is %q", retyped.VMName)
 	}
-	err := staging.claimSlug()
+	err := retyped.claimSlug()
 	if err == nil {
 		t.Fatal("the carried claim did not refuse a colliding name")
 	}
@@ -125,7 +129,7 @@ func TestTheOldClaimsAreCarriedAcrossTheRename(t *testing.T) {
 
 	// Moved rather than copied: what is left under the old name is a file the
 	// session index is about to write for itself.
-	if got := readIndex[string](slugClaimIndexName)["brig-claude-code-acme-corp"]; got != "acme-corp-prod" {
+	if got := readIndex[string](slugClaimIndexName)["brig-claude-code-acme-corp-prod"]; got != "acme-corp-prod" {
 		t.Errorf("the claim was carried over as %q", got)
 	}
 	if _, err := os.Stat(filepath.Join(dir, sessionIndexName)); !os.IsNotExist(err) {

--- a/internal/wrap/slugmigration_test.go
+++ b/internal/wrap/slugmigration_test.go
@@ -1,0 +1,80 @@
+package wrap
+
+import (
+	"bytes"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// The session the migration notice exists for: a name longer than the ten
+// characters an older release cut it to, whose old home is still on disk. Its
+// sandbox and its home both move, so the notice has to name both directories
+// -- the old one so it can be moved or deleted, the new one so the reader can
+// see where the session went.
+func TestALongNameIsToldItsHomeHasMoved(t *testing.T) {
+	isolateState(t)
+	base := filepath.Join(t.TempDir(), "ws")
+	// The directory the old budget gave "refactoring". Its being here is half
+	// of what the notice is decided on.
+	mustMkdir(t, base+"-refactorin")
+
+	c := mustLoad(t, Options{Name: "refactoring", Workspace: base})
+	if len(c.slugMigration) == 0 {
+		t.Fatal("a session whose home has moved was told nothing")
+	}
+	notice := strings.Join(c.slugMigration, " ")
+	for _, want := range []string{base + "-refactorin", base + "-refactoring"} {
+		if !strings.Contains(notice, want) {
+			t.Errorf("the notice does not name %s: %s", want, notice)
+		}
+	}
+}
+
+// Nothing orphaned, nothing to say. The name slugs differently than it used
+// to, but no directory was ever created under the old slug, so there is
+// nothing for the reader to move and the notice would be noise -- which is how
+// people learn to skip the ones that do apply to them.
+func TestNoMigrationNoticeWhenTheOldHomeIsNotThere(t *testing.T) {
+	isolateState(t)
+	base := filepath.Join(t.TempDir(), "ws")
+
+	c := mustLoad(t, Options{Name: "refactoring", Workspace: base})
+	if len(c.slugMigration) != 0 {
+		t.Errorf("a session with nothing orphaned was warned: %v", c.slugMigration)
+	}
+}
+
+// A name the old budget left alone slugs exactly as it always did, so its home
+// has not moved and its directory being there means nothing. Ten characters is
+// the boundary, and it is on the silent side of it.
+func TestNoMigrationNoticeForANameTheOldBudgetLeftAlone(t *testing.T) {
+	isolateState(t)
+	base := filepath.Join(t.TempDir(), "ws")
+	mustMkdir(t, base+"-exactlyten")
+
+	c := mustLoad(t, Options{Name: "exactlyten", Workspace: base})
+	if len(c.slugMigration) != 0 {
+		t.Errorf("a name that was never cut was warned: %v", c.slugMigration)
+	}
+}
+
+// The notice reaches the user, and it reaches them from BuildEnv with the env
+// warnings rather than from Load: both are decisions Load made and neither is
+// a reason to fail, so they are said together, once, on the way to the run
+// that is about to create the new directory.
+func TestBuildEnvSaysTheMigrationNotice(t *testing.T) {
+	c := bindingConfig(t, "env:\n  - name: NOPE\n    ref: env.NOPE\n")
+	c.slugMigration = []string{"the home has moved", "the guest state has not"}
+	warned := &bytes.Buffer{}
+	c.Err = warned
+
+	if _, err := c.BuildEnv(); err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range c.slugMigration {
+		if !strings.Contains(warned.String(), want) {
+			t.Errorf("the notice did not reach stderr: %q", warned.String())
+		}
+	}
+}

--- a/script/smoke.sh
+++ b/script/smoke.sh
@@ -361,20 +361,24 @@ grep -q '^SANDBOX .*brig-claude-code' "$WORK/env.out" \
 echo "== named session =="
 : > "$STUB_LOG"
 "$WORK/brig" run claude --name 'My Big Refactor' -p hi > /dev/null 2>&1
-grep -q -- "--shared-dir $WS-my-big-ref:/home/claude" "$STUB_LOG" \
+grep -q -- "--shared-dir $WS-my-big-refactor:/home/claude" "$STUB_LOG" \
   && ok "a named session gets its own workspace" || bad "named session gets its own workspace"
-grep -q -- '--name brig-claude-code-my-big-ref' "$STUB_LOG" \
+grep -q -- '--name brig-claude-code-my-big-refactor' "$STUB_LOG" \
   && ok "a named session gets its own sandbox" || bad "named session gets its own sandbox"
 grep -q -- "-- claude --name My Big Refactor -p hi" "$STUB_LOG" \
   && ok "the raw name reaches the agent" || bad "the raw name reaches the agent"
 
 echo "== session collision =="
-# Two names whose slugs shorten to one sandbox must not share it: the tight slug
-# budget used to drop the second into the first's home with its own credentials,
-# and brig only warned. Now the second is refused. See issue #26.
+# Two names whose slugs land on one sandbox must not share it: brig used to drop
+# the second into the first's home with its own credentials and only warn. Now
+# the second is refused. See issue #26.
+#
+# The collision is sanitisation, which is the class that survives a slug no
+# longer being cut to ten characters: the space and the case both go, so these
+# two names are one slug however long they are.
 "$WORK/brig" rm --all > /dev/null 2>&1
 "$WORK/brig" run claude --name acme-corp-prod -d > /dev/null 2>&1
-out="$("$WORK/brig" run claude --name acme-corp-staging -d 2>&1)"; rc=$?
+out="$("$WORK/brig" run claude --name 'Acme Corp Prod' -d 2>&1)"; rc=$?
 [ "$rc" != 0 ] && ok "a colliding session name is refused" \
   || bad "a colliding session name started anyway -- got rc $rc"
 case "$out" in
@@ -388,7 +392,7 @@ esac
 # rm releases the claim, so the name that was refused can take the sandbox once
 # the first is gone.
 "$WORK/brig" rm claude --name acme-corp-prod > /dev/null 2>&1
-"$WORK/brig" run claude --name acme-corp-staging -d > /dev/null 2>&1 \
+"$WORK/brig" run claude --name 'Acme Corp Prod' -d > /dev/null 2>&1 \
   && ok "rm frees the sandbox for the other name" \
   || bad "the sandbox stayed claimed after rm"
 
@@ -399,8 +403,8 @@ esac
 # cannot be read back into a ref at all.
 "$WORK/brig" rm --all > /dev/null 2>&1
 rm -f "$BRIG_STATE_DIR/slug-claims.json" "$BRIG_STATE_DIR/sessions.json"
-printf '{"brig-claude-code-acme-corp": "acme-corp-prod"}' > "$BRIG_STATE_DIR/sessions.json"
-out="$("$WORK/brig" run claude --name acme-corp-staging -d 2>&1)"
+printf '{"brig-claude-code-acme-corp-prod": "acme-corp-prod"}' > "$BRIG_STATE_DIR/sessions.json"
+out="$("$WORK/brig" run claude --name 'Acme Corp Prod' -d 2>&1)"
 case "$out" in
   *acme-corp-prod*) ok "a claim written under the old file name still refuses" ;;
   *) bad "the old claim was dropped -- got: $out" ;;
@@ -416,7 +420,7 @@ grep -q 'acme-corp-prod' "$BRIG_STATE_DIR/slug-claims.json" \
 # them.
 "$WORK/brig" rm --all > /dev/null 2>&1
 rm -f "$BRIG_STATE_DIR/slug-claims.json" "$BRIG_STATE_DIR/sessions.json"
-printf '{"brig-claude-code-acme-corp": "acme-corp-prod"}' > "$BRIG_STATE_DIR/sessions.json"
+printf '{"brig-claude-code-acme-corp-prod": "acme-corp-prod"}' > "$BRIG_STATE_DIR/sessions.json"
 "$WORK/brig" run claude -d > /dev/null 2>&1
 grep -q 'acme-corp-prod' "$BRIG_STATE_DIR/slug-claims.json" \
   && ok "an unnamed run carries the old claims across" \
@@ -458,6 +462,59 @@ if [ -s "$BRIG_STATE_DIR/sessions.json" ]; then
 else
   bad "no session index to guard: $(cat "$BRIG_STATE_DIR/sessions.json" 2>&1)"
 fi
+"$WORK/brig" rm --all > /dev/null 2>&1
+
+echo "== the slug migration =="
+# A --name longer than ten characters used to be cut to that, so it had a
+# shorter sandbox and a shorter home than it gets now. Both come off the slug on
+# every run, so such a session boots a new pair and the old one is orphaned: the
+# work in the old workspace is on the host and is still there, state inside the
+# old guest is not. Say so, and name both directories so the old one can be
+# moved or deleted.
+"$WORK/brig" rm --all > /dev/null 2>&1
+mkdir -p "$WS-refactorin"
+"$WORK/brig" run claude --name refactoring -d > /dev/null 2> "$WORK/moved.err"
+grep -q -- "instead of $WS-refactorin (brig-claude-code-refactorin)" "$WORK/moved.err" \
+  && ok "the migration notice names the home that was left behind" \
+  || bad "the notice does not name the old home -- got: $(cat "$WORK/moved.err")"
+grep -q -- "new sandbox: $WS-refactoring (brig-claude-code-refactoring)" "$WORK/moved.err" \
+  && ok "the migration notice names the home in use now" \
+  || bad "the notice does not name the new home -- got: $(cat "$WORK/moved.err")"
+
+# Nothing orphaned, nothing said. This name slugs differently than it used to,
+# but no directory was ever created under the old slug, so there is nothing for
+# the reader to move -- and a notice that reaches people it does not apply to is
+# one they learn to skip.
+"$WORK/brig" rm --all > /dev/null 2>&1
+rm -rf "$WS-benchmarkin"
+"$WORK/brig" run claude --name benchmarking -d > /dev/null 2> "$WORK/fresh.err"
+grep -q 'used to be shortened' "$WORK/fresh.err" \
+  && bad "a session with nothing orphaned was warned -- got: $(cat "$WORK/fresh.err")" \
+  || ok "a session with nothing orphaned is not warned"
+
+# And a name the old budget left alone slugs exactly as it always did, so its
+# directory being there means nothing. Ten characters is the boundary, and this
+# is on the silent side of it.
+"$WORK/brig" rm --all > /dev/null 2>&1
+mkdir -p "$WS-exactlyten"
+"$WORK/brig" run claude --name exactlyten -d > /dev/null 2> "$WORK/short.err"
+grep -q 'used to be shortened' "$WORK/short.err" \
+  && bad "a name that was never cut was warned -- got: $(cat "$WORK/short.err")" \
+  || ok "a name the old budget left alone is not warned"
+
+# The ref form refused any label over ten characters. A long one is a sandbox
+# and a directory of its own now, and is refused only for what is in it.
+"$WORK/brig" rm --all > /dev/null 2>&1
+: > "$STUB_LOG"
+"$WORK/brig" run 'claude@a-long-refactor-label' -d > /dev/null 2>&1
+grep -q -- '--name brig-claude-code-a-long-refactor-label' "$STUB_LOG" \
+  && ok "a long label gets a sandbox of its own" \
+  || bad "a long label did not reach the sandbox name"
+out="$("$WORK/brig" run 'claude@A-Long-Refactor-Label' -d 2>&1)"
+case "$out" in
+  *a-long-refactor-label*) ok "a long label brig would rewrite is still refused" ;;
+  *) bad "a long label brig would rewrite was not refused -- got: $out" ;;
+esac
 "$WORK/brig" rm --all > /dev/null 2>&1
 
 echo "== stop =="


### PR DESCRIPTION
## Summary

A session label was capped at ten characters. `experiment` fit exactly; `refactoring` did not.

The cap existed only to bound `Slug`'s truncation, and truncation is what made two different labels
land on one sandbox and one guest home. So the truncation goes and the cap goes with it — there is
nothing left for a length limit to protect against.

The issue as filed said raise it to 20. The decision was to remove it. If an unbounded label turns
out to be a problem, that gets addressed then.

## Related issues

Fixes #114. Part of #47. **Stacked on #119** — base `feat/5-lifecycle-verbs-refs`.
Merge order: #113, #115, #117, #118, #119, this.

## Changes

- `Slug` no longer truncates. `maxSlug` is deleted, not renumbered.
- `ParseRef`'s length check is gone. Its remaining rule — a label must already be what `Slug` would
  make of it — is now purely the character test, at any length.
- `session.LegacySlug` and `legacyBudget = 10` are new, and exist only so the notice below can
  recognise a name the old budget would have cut. `LegacySlug` has one caller
  (`internal/wrap/config.go`) and derives no path.
- The three `ref_test.go` cases built on `maxSlug` were rewritten rather than retargeted: a long
  label is now valid, so the property under test changed.

### `claimSlug` stays, and this is the reason

Removing truncation removes one source of collision, not all of them. Sanitising is not one-to-one:
`Foo`, `foo!` and `foo` are all `foo`, so two `--name` values can still land on one sandbox. That
refusal is what stops two agents sharing a guest home with whichever credentials arrived last, and no
length budget was ever protecting against it.

Its logic is unchanged. Its comments and two user-facing messages are not: they said a name
"shortens to" a sandbox, which is no longer how a collision happens.

Two test fixtures had to move for the same reason, and neither is a weakened assertion:

- `internal/wrap/slugclaim_test.go` collided `acme-corp-prod` with `acme-corp-staging`, which
  collide *only* by truncation. After this change they are distinct slugs, so the test would have
  failed at its own "the two names did not collide" guard. Repointed at `acme-corp-prod` versus
  `Acme Corp Prod` — a sanitisation collision, which is the class that survives. Same substitution in
  `script/smoke.sh`'s `== session collision ==` block.
- `cmd/brig/hygiene_test.go:309` asserted `claude@my-very-long-label` is refused, which was a pure
  length refusal. That label is now valid, so the case became a sanitisation refusal.

### The migration notice

Any existing session whose `--name` is longer than ten characters now slugs differently, so it gets a
new sandbox and a new guest home and the old pair is orphaned. The work in the workspace survives,
being on the host; the guest's in-memory state and an in-sandbox login do not.

It fires only when the slug the old budget would have produced differs from the new one **and** the
old workspace directory is on disk, and it names both homes and both sandboxes:

```
brig: session "refactoring-api" used to be shortened to "refactorin" and now keeps its
name in full, so it has a new home and a new sandbox:
<workspace>/ws-refactoring-api (brig-claude-code-refactoring-api) instead of
<workspace>/ws-refactorin (brig-claude-code-refactorin).
```

Computed in `Load` and held on the `Config` until `BuildEnv` prints it, beside `envWarnings`, which
is the existing precedent for a decision `Load` makes with no writer available. Printing it from
`cmd/brig` beside `LegacyHint()` would have matched the issue's tone reference but missed
`cmd/brigd`, which also calls `BuildEnv`.

The old home is read from the session index first and derived as `<base>-<oldSlug>` only as a
fallback, so a session started under `--workspace` or `BRIG_WORKSPACE` is named where it actually is.

### Accepted, and deliberately unguarded

- The bound is now the filesystem's: 255 bytes per path component. A label near that fails at
  directory creation with a filesystem error rather than a brig message.
- The sandbox is `brig-<agent>-<slug>`, so a long label is also subject to the runtime's own name
  limits.

No length guard, no warning and no truncation fallback was added for either.

## Testing

`script/smoke.sh`: 219 → 225 passing assertions, `FAIL` set byte-identical to the parent
(`fc476e4`), verified by diff. Six new assertions:

```
== the slug migration ==
  the migration notice names the home that was left behind
  the migration notice names the home in use now
  a session with nothing orphaned is not warned
  a name the old budget left alone is not warned
  a long label gets a sandbox of its own
  a long label brig would rewrite is still refused
```

Unit: `internal/wrap/slugmigration_test.go` (new), plus the rewritten `ref_test.go`,
`session_test.go` and `slugclaim_test.go` cases.

The 11 pre-existing `FAIL` lines are host-specific: `brig run` aborts at
`.claude/.credentials.json sits on virtiofs rather than an ephemeral mount`, so nothing needing an
in-guest exec runs against the stub. The same suite passes in CI (`ci.yml:62`).

## Manual testing

No runtime needed for the label rules:

```bash
make build
export BRIG_RUNTIME=nosuchruntime BRIG_PROFILE_DIR=$(mktemp -d)

./brig run 'claude@my-really-long-label-that-is-way-over-ten'   # accepted (parses)
./brig run 'claude@Refactor'                                    # refused: would become "refactor"
./brig run 'claude@my really long label'                        # refused: would become "my-really-long-label"
```

`runtime unavailable` means the line parsed, i.e. the label was accepted.

The migration notice needs a sandbox. Using the stub from `script/smoke.sh` (extract the `hull`
heredoc, export `BRIG_RUNTIME_BIN`, `BRIG_STATE_DIR`, `BRIG_WORKSPACE`, `BRIG_BOOT_ASSETS`,
`BRIG_HYPERVISOR=vz`, `BRIG_VERIFY=off`):

```bash
mkdir -p "$BRIG_WORKSPACE-refactorin"          # the home the old budget would have made
./brig run -d claude --name refactoring-api    # notice names both homes and both sandboxes

# and the two quiet cases
rm -rf "$BRIG_WORKSPACE-refactorin"
./brig run -d claude --name refactoring-api    # silent: nothing orphaned
./brig run -d claude --name short              # silent: the old budget left it alone
```

## Checklist

- [x] `make all` passes (vet, test, build)
- [x] `script/smoke.sh` passes
- [x] I have added or updated tests covering the change
- [x] I have run `go test ./... -race`, if the change touches concurrency, subprocesses or the daemon
- [ ] I have exercised the change against a real runtime (`brig run <agent>`), if it touches the run, exec or credential path
- [x] I have updated the affected docs (README, `docs/security.md`, `docs/profiles.md`, `docs/brigd.md`)

`script/smoke.sh` is ticked on CI, where it runs clean; the local host failures are described above.

Real runtime: not booted. Exercised against the stub, which covers the whole path except the VM.

Docs: the README sentence stating a ten-character limit is corrected. The structural rewrite is #111.

## Credentials and the sandbox boundary

The failure this area guards against is two sessions on one guest home, each handed different
credentials, with whichever booted last leaving its own behind. `claimSlug` is what refuses it and it
is unchanged — see the section above for why removing truncation does not remove the need for it, and
why the surviving collision class is now the primary test case rather than an additional one.

The migration notice exists so that a changed slug is not a silent relocation: without it, a session
would come back on a new empty home with no indication that the old one still holds its state.

No new mount, no new forwarded variable, no new host path reachable from the guest.

## LLM usage

Authored with assistance from Claude Code (Opus 5). Verification re-run independently of the agent
that wrote the change: `gofmt`, `make all`, label-rule probes against the built binary, and all three
migration-notice cases (fires, and both quiet cases) exercised against the stub runtime. The claim
that `claimSlug` was untouched was checked against the diff and corrected — its logic is unchanged,
its comments and messages are not.

Commit is unsigned: SSH signing does not work non-interactively in the environment it was produced
in. The `main` ruleset does not require signatures.
