### PR TITLE
feat(wrap): mount a named project beside the guest home

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ separate Linux re-implementation of it.
 
 | command | what it does |
 | --- | --- |
-| `brig run <ref> [args…]` | start the sandbox if needed, then run the agent. Arguments pass through untouched. `-d` starts it and exits, printing its name |
+| `brig run <ref> [project] [args…]` | start the sandbox if needed, then run the agent. A directory named after the ref is mounted as this run's project and the agent starts in it. Remaining arguments pass through untouched. `-d` starts it and exits, printing its name |
 | `brig sh <ref> [cmd…]` | a login shell inside the sandbox, or one command in it |
 | `brig stop <ref>` | stop the sandbox, keep it. Starting it again is a boot, not a fresh creation |
 | `brig rm <ref>` | stop and remove the sandbox. The workspace is untouched |
@@ -152,6 +152,11 @@ the label: `brig run claude@refactor` is what `brig run claude --name refactor`
 was. That one is mapped and warned about rather than quietly reinterpreted,
 because `--name` is also Claude Code's own flag.
 
+`-w`/`--workspace` is `--home`, on the same terms: both spellings keep working
+and each says so. The word went because there are two host directories on a run
+line now -- the guest's own home and the project you name -- and "workspace"
+could not say which of them it meant.
+
 `brig secret` keeps `create|read|update|delete`, and that is deliberate rather
 than an oversight. The tidier `set`/`get` pair would make one typo turn a read
 into a write, silently replacing a stored credential with no way back to the
@@ -162,7 +167,9 @@ of place. Left of the verb are brig's global flags, a closed set -- an unknown
 flag there is a usage error naming the token, rather than an operand quietly
 swallowed. Between the verb and the agent are the run-line flags below. Right of
 the agent the vocabulary is the agent's, and `--` ends brig's parsing outright,
-so an agent flag spelled like one of brig's still reaches it.
+so an agent flag spelled like one of brig's still reaches it. The one exception
+is `run`'s project directory, which is the second bare word on the line -- see
+[The project you name](#the-project-you-name).
 
 brig does still read its own flags after the agent, because `brig run claude -q`
 is a line that works. But once an unknown token has ended brig's reading, a brig
@@ -173,7 +180,7 @@ the token, so a line that works today keeps working.
 | --- | --- |
 | `-n, --name NAME` | a session of its own: own workspace, own sandbox. Also written `<agent>@<label>` |
 | `--image IMAGE` | guest image to boot (`-t` still works, with a note) |
-| `-w, --workspace PATH` | host directory to mount as the guest home |
+| `--home PATH` | host directory to mount as the guest home (`-w`/`--workspace` still work, each with a note) |
 | `--mem MB` | guest memory (`--memory` also works; `-m` works with a note) |
 | `--cpus N` | guest vCPUs |
 | `-d, --detach` | with `run`: start the sandbox, print its name, exit |
@@ -210,6 +217,47 @@ brig run claude -- --name not-a-session    # --name reaches claude, not brig
 brig sh codex 'ls -la ~'                   # one command, in a login shell
 brig sh codex                              # a login shell, no command
 ```
+
+### The project you name
+
+```bash
+cd ~/src/myproject
+brig run claude .
+```
+
+That line does what it looks like. The directory is mounted at
+`/work/myproject` in the guest and the agent starts there.
+
+`/work`, not the guest home. The home is the agent's own -- its dotfiles, its
+onboarding state, its caches -- so a project mounted there could be mistaken for
+home state or collide with the agent's files. Under `/work` it cannot, by the
+mount layout rather than by a convention anyone has to remember. Both mounts are
+read-write, and `brig info` and the pre-run envelope name each of them.
+
+The project is per run, not part of the session. The session is its ref, and the
+ref is the home: `brig run claude ~/src/a` and `brig run claude ~/src/b` are the
+same session with the same home, one after the other. The one consequence worth
+knowing is that the second one restarts the sandbox -- a share is bound at boot
+and cannot be attached to a live guest -- and brig says so when it does. Nothing
+persistent is lost: the home is a host directory that survives the restart, and
+so is each project.
+
+Only `run` takes one. On `sh` the second bare word is already the guest command,
+and brig's own parsing still stops at the project, so a flag after it is the
+agent's exactly as it was before.
+
+```bash
+brig run claude ~/src/myproject -p "what does this do?"  # project, then args
+brig run claude -- ~/src/myproject                      # a path FOR the agent
+brig run claude --home ~/homes/claude ~/src/myproject    # both, each named
+```
+
+**This is a breaking change, for one release.** That word used to end brig's
+parsing and reach the agent, so `brig run claude .` passed `.` to the agent.
+Anything brig now reads as a project it says so about, naming the reading it
+lost beside the one it gained, and `--` is how to keep the old one. The notice
+goes in the next release. A word that names no directory is refused rather than
+mounted, so a line that meant the agent gets an error and not a surprise.
 
 ### Named sessions
 
@@ -272,13 +320,14 @@ To drop the workspace too, remove the directory `brig info` prints. And
 `brig rm --all` stops and removes every brig sandbox at once, named ones
 included, leaving all workspaces alone.
 
-**`-w` is remembered.** A session created with `--workspace` keeps that
+**The home is remembered.** A session created with `--home` keeps that
 directory for every later verb, so `brig sh claude@refactor ls` finds it
 without repeating the flag. brig records it in `~/.brig/sessions.json`, filed
-under the session's ref, and reads it back when neither `--workspace` nor
+under the session's ref, and reads it back when neither `--home` nor
 `BRIG_WORKSPACE` names one; `brig rm` drops the entry with the sandbox, and
 `brig ls` drops any whose sandbox has gone. That file is also where `brig ls`
-reads the ref it prints.
+reads the ref it prints, and where the project a session last ran with is
+recorded -- which is how the next run knows whether it has to restart.
 
 That file is an index and not a record of the truth: the runtime stays the
 authority on what is actually mounted, and an unreadable index costs one restart
@@ -294,7 +343,7 @@ The verbs line up deliberately, so muscle memory carries over:
 
 | `sbx` | `brig` | note |
 | --- | --- | --- |
-| `sbx run <agent> [path]` | `brig run <agent> [-w path]` | brig takes the workspace as a flag rather than a positional, so it never has to guess where agent arguments begin |
+| `sbx run <agent> [path]` | same | the positional is the project brig mounts and starts the agent in; `--home` is the separate directory that is the guest's own |
 | `sbx create` | `brig run -d` | starts the sandbox and exits, printing its name |
 | `sbx ls` / `sbx stop` / `sbx rm` | same | |
 | `sbx exec` | `brig sh` | one verb for a command and for a login shell |

--- a/README.md
+++ b/README.md
@@ -181,6 +181,7 @@ the token, so a line that works today keeps working.
 | `-n, --name NAME` | a session of its own: own workspace, own sandbox. Also written `<agent>@<label>` |
 | `--image IMAGE` | guest image to boot (`-t` still works, with a note) |
 | `--home PATH` | host directory to mount as the guest home (`-w`/`--workspace` still work, each with a note) |
+| `--no-project` | with `run`: mount no project, whatever this session ran with last |
 | `--mem MB` | guest memory (`--memory` also works; `-m` works with a note) |
 | `--cpus N` | guest vCPUs |
 | `-d, --detach` | with `run`: start the sandbox, print its name, exit |

--- a/README.md
+++ b/README.md
@@ -167,14 +167,15 @@ of place. Left of the verb are brig's global flags, a closed set -- an unknown
 flag there is a usage error naming the token, rather than an operand quietly
 swallowed. Between the verb and the agent are the run-line flags below. Right of
 the agent the vocabulary is the agent's, and `--` ends brig's parsing outright,
-so an agent flag spelled like one of brig's still reaches it. The one exception
-is `run`'s project directory, which is the second bare word on the line -- see
-[The project you name](#the-project-you-name).
+so an agent flag spelled like one of brig's still reaches it.
 
 brig does still read its own flags after the agent, because `brig run claude -q`
-is a line that works. But once an unknown token has ended brig's reading, a brig
-flag further along belongs to the agent -- and brig now says so, without taking
-the token, so a line that works today keeps working.
+is a line that works. What ends brig's reading is the first token it does not
+own. On `run` that is not the project directory -- the second bare word is
+brig's own operand, so brig reads past it and on to the next token; see
+[The project you name](#the-project-you-name). Once an unknown token has ended
+brig's reading, a brig flag further along belongs to the agent -- and brig says
+so, without taking the token, so a line that works today keeps working.
 
 | flag | what it does |
 | --- | --- |
@@ -243,14 +244,17 @@ and cannot be attached to a live guest -- and brig says so when it does. Nothing
 persistent is lost: the home is a host directory that survives the restart, and
 so is each project.
 
-Only `run` takes one. On `sh` the second bare word is already the guest command,
-and brig's own parsing still stops at the project, so a flag after it is the
-agent's exactly as it was before.
+Only `run` takes one. On `sh` the second bare word is already the guest command.
+
+The project is brig's own operand, like the ref, so brig keeps reading its own
+flags after it. Parsing ends at the next bare word or the first flag brig does
+not own -- everything from there is the agent's.
 
 ```bash
-brig run claude ~/src/myproject -p "what does this do?"  # project, then args
-brig run claude -- ~/src/myproject                      # a path FOR the agent
-brig run claude --home ~/homes/claude ~/src/myproject    # both, each named
+brig run claude ~/src/myproject -p "what does this do?"  # project, then agent args
+brig run claude ~/src/myproject --mem 4096 -d            # project, then brig flags
+brig run claude -- ~/src/myproject                       # a path FOR the agent
+brig run claude --home ~/homes/claude ~/src/myproject     # both, each named
 ```
 
 **This is a breaking change, for one release.** That word used to end brig's

--- a/cmd/brig/deprecated_test.go
+++ b/cmd/brig/deprecated_test.go
@@ -244,7 +244,7 @@ func TestDeprecatedShortFlagsStillWork(t *testing.T) {
 			o   options
 			err error
 		)
-		warning := captureStderr(t, func() { o, _, _, err = parse(c.args) })
+		warning := captureStderr(t, func() { o, _, _, err = parse("run", c.args) })
 		if err != nil {
 			t.Errorf("parse(%q): %v", c.args, err)
 			continue
@@ -262,7 +262,7 @@ func TestDeprecatedShortFlagsStillWork(t *testing.T) {
 	}
 	// The long spellings are current, so they say nothing.
 	warning := captureStderr(t, func() {
-		if _, _, _, err := parse([]string{"claude", "--image", "img:1", "--mem", "8"}); err != nil {
+		if _, _, _, err := parse("run", []string{"claude", "--image", "img:1", "--mem", "8"}); err != nil {
 			t.Errorf("parse: %v", err)
 		}
 	})
@@ -272,7 +272,7 @@ func TestDeprecatedShortFlagsStillWork(t *testing.T) {
 	// A value that happens to be spelled like a deprecated flag is a value.
 	// Warning on it would send the reader looking for a flag they did not type.
 	warning = captureStderr(t, func() {
-		if _, _, _, err := parse([]string{"claude", "--name", "-t"}); err != nil {
+		if _, _, _, err := parse("run", []string{"claude", "--name", "-t"}); err != nil {
 			t.Errorf("parse: %v", err)
 		}
 	})
@@ -362,7 +362,7 @@ func TestNameFlagRetiresOntoTheLabel(t *testing.T) {
 			o   options
 			err error
 		)
-		notice := captureStderr(t, func() { o, _, _, err = parse(c.args) })
+		notice := captureStderr(t, func() { o, _, _, err = parse("run", c.args) })
 		if err != nil {
 			t.Errorf("parse(%q): %v", c.args, err)
 			continue
@@ -379,7 +379,7 @@ func TestNameFlagRetiresOntoTheLabel(t *testing.T) {
 	}
 	// The label form is the current spelling, so it says nothing.
 	notice := captureStderr(t, func() {
-		o, _, _, err := parse([]string{"claude@refactor"})
+		o, _, _, err := parse("run", []string{"claude@refactor"})
 		if err != nil {
 			t.Errorf("parse: %v", err)
 		}

--- a/cmd/brig/hygiene_test.go
+++ b/cmd/brig/hygiene_test.go
@@ -16,7 +16,7 @@ func TestParseRefusesUnknownFlagBeforeProfile(t *testing.T) {
 		{"--dry-run", "claude"},
 		{"-x", "claude"},
 	} {
-		_, _, _, err := parse(args)
+		_, _, _, err := parse("run", args)
 		if err == nil {
 			t.Errorf("parse(%q) was accepted", args)
 			continue
@@ -34,7 +34,7 @@ func TestParseRefusesUnknownFlagBeforeProfile(t *testing.T) {
 // The same flag once the profile is named is the agent's, and still passes
 // through. This is the line the refusal above must not break.
 func TestParseKeepsUnknownFlagAfterProfileForTheAgent(t *testing.T) {
-	_, name, tail, err := parse([]string{"claude", "--nope"})
+	_, name, tail, err := parse("run", []string{"claude", "--nope"})
 	if err != nil {
 		t.Fatalf("parse: %v", err)
 	}
@@ -109,7 +109,7 @@ func TestLsAndRemoveAllRefuseArguments(t *testing.T) {
 // pair exists because "offline" is the word the request is usually phrased in,
 // and a flag that reads like the sentence is worth two lines of plumbing.
 func TestParseNetworkAndOffline(t *testing.T) {
-	o, profileName, _, err := parse([]string{"--network", "offline", "claude"})
+	o, profileName, _, err := parse("run", []string{"--network", "offline", "claude"})
 	if err != nil {
 		t.Fatalf("--network offline: %v", err)
 	}
@@ -120,7 +120,7 @@ func TestParseNetworkAndOffline(t *testing.T) {
 		t.Errorf("network = %q, want offline", o.load.Network)
 	}
 
-	if o, _, _, err = parse([]string{"--offline", "claude"}); err != nil {
+	if o, _, _, err = parse("run", []string{"--offline", "claude"}); err != nil {
 		t.Fatalf("--offline: %v", err)
 	}
 	if o.load.Network != "offline" {
@@ -129,7 +129,7 @@ func TestParseNetworkAndOffline(t *testing.T) {
 
 	// Saying both, and disagreeing, is a mistake worth naming rather than a
 	// silent precedence puzzle.
-	if _, _, _, err = parse([]string{"--offline", "--network", "shared", "claude"}); err == nil {
+	if _, _, _, err = parse("run", []string{"--offline", "--network", "shared", "claude"}); err == nil {
 		t.Error("--offline with --network shared was accepted")
 	}
 }
@@ -276,7 +276,7 @@ func TestGlobalPositionPassesTheVerbLineThrough(t *testing.T) {
 // claude --name refactor` already does, so the label lands on the same path
 // rather than becoming a second way to hold a session.
 func TestParseReadsASessionRef(t *testing.T) {
-	o, profileName, tail, err := parse([]string{"claude@refactor", "-p", "hi"})
+	o, profileName, tail, err := parse("run", []string{"claude@refactor", "-p", "hi"})
 	if err != nil {
 		t.Fatalf("parse: %v", err)
 	}
@@ -290,7 +290,7 @@ func TestParseReadsASessionRef(t *testing.T) {
 		t.Errorf("tail = %q, want the agent's own arguments untouched", tail)
 	}
 	// The two spellings of one session agree.
-	viaFlag, _, _, err := parse([]string{"claude", "--name", "refactor"})
+	viaFlag, _, _, err := parse("run", []string{"claude", "--name", "refactor"})
 	if err != nil {
 		t.Fatalf("parse --name: %v", err)
 	}
@@ -311,7 +311,7 @@ func TestParseRefusesABadRef(t *testing.T) {
 		{"claude@my very long label"},
 		{"@refactor"},
 	} {
-		_, _, _, err := parse(args)
+		_, _, _, err := parse("run", args)
 		if err == nil {
 			t.Errorf("parse(%q) was accepted", args)
 			continue
@@ -327,7 +327,7 @@ func TestParseRefusesABadRef(t *testing.T) {
 // different sessions. A silent winner would run one of them with the other
 // still written on the command.
 func TestParseRefusesARefAndNameTogether(t *testing.T) {
-	_, _, _, err := parse([]string{"claude@refactor", "--name", "other"})
+	_, _, _, err := parse("run", []string{"claude@refactor", "--name", "other"})
 	if err == nil {
 		t.Fatal("claude@refactor --name other was accepted")
 	}
@@ -349,7 +349,7 @@ func TestParseWarnsAboutItsOwnFlagsInTheAgentTail(t *testing.T) {
 		err  error
 	)
 	warning := captureStderr(t, func() {
-		o, _, tail, err = parse([]string{"claude", "-p", "hi", "--quiet", "--cpus=2"})
+		o, _, tail, err = parse("run", []string{"claude", "-p", "hi", "--quiet", "--cpus=2"})
 	})
 	if err != nil {
 		t.Fatalf("parse: %v", err)
@@ -374,7 +374,7 @@ func TestParseWarnsAboutItsOwnFlagsInTheAgentTail(t *testing.T) {
 // for every scripted `brig exec claude -- ls` that happens to name one.
 func TestParseSaysNothingAfterAnExplicitEnd(t *testing.T) {
 	warning := captureStderr(t, func() {
-		if _, _, tail, err := parse([]string{"claude", "--", "--quiet"}); err != nil {
+		if _, _, tail, err := parse("run", []string{"claude", "--", "--quiet"}); err != nil {
 			t.Errorf("parse: %v", err)
 		} else if strings.Join(tail, " ") != "--quiet" {
 			t.Errorf("tail = %q", tail)
@@ -392,7 +392,7 @@ func TestParseReadsMemAndMemory(t *testing.T) {
 		{"claude", "--mem=2048"},
 		{"claude", "--memory", "2048"},
 	} {
-		o, _, _, err := parse(args)
+		o, _, _, err := parse("run", args)
 		if err != nil {
 			t.Errorf("parse(%q): %v", args, err)
 			continue
@@ -402,7 +402,7 @@ func TestParseReadsMemAndMemory(t *testing.T) {
 		}
 	}
 	// And it is brig's, so it is refused by name rather than forwarded.
-	if _, _, _, err := parse([]string{"claude", "--mem", "lots"}); err == nil {
+	if _, _, _, err := parse("run", []string{"claude", "--mem", "lots"}); err == nil {
 		t.Error("--mem lots was accepted")
 	} else if !strings.Contains(err.Error(), "--mem") {
 		t.Errorf("--mem lots: %v, want it to name --mem", err)
@@ -425,7 +425,7 @@ func TestParseKeepsTodaysLines(t *testing.T) {
 		{[]string{"claude", "--", "ls"}, "", "ls"},
 		{[]string{"--name", "x", "claude"}, "x", ""},
 	} {
-		o, profileName, tail, err := parse(c.args)
+		o, profileName, tail, err := parse("run", c.args)
 		if err != nil {
 			t.Errorf("parse(%q): %v", c.args, err)
 			continue

--- a/cmd/brig/main.go
+++ b/cmd/brig/main.go
@@ -309,14 +309,10 @@ func run(args []string) error {
 		verb, rest = "run", verbLine
 	}
 
-	opts, profileName, tail, err := parse(rest)
+	opts, profileName, tail, err := parse(verb, rest)
 	if err != nil {
 		return err
 	}
-	// Only run takes a positional; every other verb gets the word back where
-	// split found it. Said out loud while the meaning is changing, and only
-	// when the word survived as a project -- which is only on run.
-	opts.load.Project, tail = projectFor(verb, opts.load.Project, tail)
 	// Both at once asks for two contradictory things, and either winner would
 	// be silent about the other: the directory would be mounted with
 	// --no-project ignored, or dropped with the word the line names ignored.
@@ -680,12 +676,12 @@ func parseGlobal(args []string) (rest []string, err error) {
 }
 
 // split divides a run line into brig's own arguments, the session ref, the
-// second bare word, and the agent's tail.
+// project positional, and the agent's tail.
 //
-// The second bare word is handed back on its own rather than at the head of the
-// tail because what it means depends on the verb, and split does not know the
-// verb: on run it is the project directory to mount, and on sh it is the guest
-// command. projectFor is where that is decided.
+// The verb is a parameter because only run takes a positional: on run the
+// second bare word is a directory to mount, and on sh it is the start of the
+// guest command. Every other verb gets that word back at the head of its tail,
+// where rejectTail names it.
 //
 // This exists because the flag package stops at the first non-flag argument
 // and treats an unknown flag as an error, and brig's line is the opposite on
@@ -694,12 +690,16 @@ func parseGlobal(args []string) (rest []string, err error) {
 // runs the agent with -p hi. So the boundary is decided here, from the table,
 // and the flag package parses what is left of it.
 //
-// The state that decides it is one bit: has the ref been passed. Before it,
-// brig owns every token and an unknown flag is a brig flag that does not
-// exist. After it, brig still answers to its own flags -- `brig run claude -q`
-// is a line that works today -- but the first token it does not own ends its
-// parsing and everything from there is the agent's, warnings included.
-func split(args []string) (mine []string, ref session.Ref, word string, tail []string, err error) {
+// The rule is that the first token brig does not own ends its parsing and
+// everything from there is the agent's, warnings included. Before the ref brig
+// owns every token, so an unknown flag there is a brig flag that does not
+// exist rather than something to forward. After the ref brig still answers to
+// its own flags -- `brig run claude -q` -- and on run it owns the positional
+// too, so that does not end the parsing either: `brig run claude ~/proj --mem
+// 4096 -d` is read by brig throughout. The next bare word after the positional
+// does end it, which is where the agent's argv starts.
+func split(verb string, args []string) (mine []string, ref session.Ref, word string, tail []string, err error) {
+	takesProject := verb == "run"
 	passed := false
 	for i := 0; i < len(args); i++ {
 		a := args[i]
@@ -709,7 +709,11 @@ func split(args []string) (mine []string, ref session.Ref, word string, tail []s
 			// like one of brig's flags still reaches the agent. Nothing is
 			// said about what follows: the line already said it -- which is
 			// also why no word after it is ever read as a project.
-			return mine, ref, "", args[i+1:], nil
+			//
+			// A project already read stands. `brig run claude ~/proj -- pwd`
+			// named one before the marker, and the marker speaks for what
+			// comes after it rather than undoing what came before.
+			return mine, ref, word, args[i+1:], nil
 		case !strings.HasPrefix(a, "-"):
 			if !passed {
 				if ref, err = session.ParseRef(a); err != nil {
@@ -722,11 +726,14 @@ func split(args []string) (mine []string, ref session.Ref, word string, tail []s
 				passed = true
 				continue
 			}
-			// A second bare word, and it is still where brig stops reading its
-			// own line: the word has a meaning of its own now, and brig does
-			// not resume after it, so `brig run claude . -q` leaves -q the
-			// agent's exactly as it always did. agentTail says so.
-			return mine, ref, a, agentTail(args[i+1:]), nil
+			// A bare word after the ref. On run the first one is the
+			// project, which brig owns and so reads past; anywhere else, and
+			// for the next one on run, it is where the agent's argv starts.
+			if takesProject && word == "" {
+				word = a
+				continue
+			}
+			return mine, ref, word, agentTail(args[i:]), nil
 		default:
 			isOurs, takesValue := ours(a, posRun)
 			if !isOurs {
@@ -743,7 +750,7 @@ func split(args []string) (mine []string, ref session.Ref, word string, tail []s
 						"brig's own flags come before the profile and the agent's after it; "+
 						"put %q after the profile to pass it through, or -- to end brig's flags", a, a)
 				}
-				return mine, ref, "", agentTail(args[i:]), nil
+				return mine, ref, word, agentTail(args[i:]), nil
 			}
 			// Read off the spelling rather than the whole token, so the
 			// inline form is the same flag here as it is everywhere else, and
@@ -763,21 +770,7 @@ func split(args []string) (mine []string, ref session.Ref, word string, tail []s
 			}
 		}
 	}
-	return mine, ref, "", nil, nil
-}
-
-// projectFor decides what a verb does with the second bare word on its line.
-//
-// run is the only verb that takes a positional. On sh -- and on exec and
-// shell, the two spellings it replaces -- a second bare word is already the
-// guest command, and on the verbs that take a ref and nothing more it is still
-// a stray token for rejectTail to name. Both of those get the word back at the
-// head of their tail, exactly where split found it, so nothing but run changes.
-func projectFor(verb, word string, tail []string) (project string, rest []string) {
-	if word == "" || verb == "run" {
-		return word, tail
-	}
-	return "", append([]string{word}, tail...)
+	return mine, ref, word, nil, nil
 }
 
 // warnPositionalMeaning names both readings of a second bare word, for the one
@@ -848,14 +841,11 @@ func rejectTail(verb string, tail []string) error {
 // parse reads brig's own flags off the run line in any order and leaves
 // whatever remains for the agent. split decides where brig's arguments end;
 // the flag package turns them into values.
-func parse(args []string) (o options, profileName string, tail []string, err error) {
-	mine, ref, word, tail, err := split(args)
+func parse(verb string, args []string) (o options, profileName string, tail []string, err error) {
+	mine, ref, word, tail, err := split(verb, args)
 	if err != nil {
 		return options{}, "", nil, err
 	}
-	// The positional as split found it. Which verb may keep it is the caller's
-	// decision, not this one's: parse reads one line's flags and does not know
-	// the verb they were typed under.
 	o.load.Project = word
 
 	fs := flag.NewFlagSet("brig", flag.ContinueOnError)

--- a/cmd/brig/main.go
+++ b/cmd/brig/main.go
@@ -39,7 +39,10 @@ const sandboxPrefix = wrap.NamePrefix
 const usage = `brig -- run a coding agent in a sandbox
 
 usage:
-  brig run  <ref> [flags] [agent args...]        start the sandbox and run it
+  brig run  <ref> [project] [args...]            start the sandbox and run it. A
+                                                 project is mounted at
+                                                 /work/<name>, and the agent
+                                                 starts there
   brig sh   <ref> [command...]                   a login shell inside the sandbox,
                                                  or one command in it
   brig stop <ref>                                stop the sandbox, keep it
@@ -66,7 +69,8 @@ sandbox, and every verb above takes one.
 
 flags (before the agent's own arguments; -- ends brig's parsing):
       --image IMAGE      guest image to boot
-  -w, --workspace PATH   host directory to mount as the guest home
+      --home PATH        host directory to mount as the guest home
+                         (-w and --workspace still work, with a note)
       --mem MB           guest memory
       --cpus N           guest vCPUs
   -d, --detach           with run: start the sandbox and exit
@@ -307,6 +311,13 @@ func run(args []string) error {
 	if err != nil {
 		return err
 	}
+	// Only run takes a positional; every other verb gets the word back where
+	// split found it. Said out loud while the meaning is changing, and only
+	// when the word survived as a project -- which is only on run.
+	opts.load.Project, tail = projectFor(verb, opts.load.Project, tail)
+	if opts.load.Project != "" {
+		warnPositionalMeaning(opts.load.Project)
+	}
 	if err := rejectTail(verb, tail); err != nil {
 		return err
 	}
@@ -516,6 +527,11 @@ var brigFlags = []struct {
 }{
 	{long: "name", short: "n", value: true, position: posRun},
 	{long: "image", short: "t", value: true, position: posRun},
+	// --home is the guest home; -w and --workspace are the spellings it
+	// replaces, and all three write one value. The home and the project are
+	// two directories on one line now, and "workspace" could not say which of
+	// them it meant.
+	{long: "home", value: true, position: posRun},
 	{long: "workspace", short: "w", value: true, position: posRun},
 	// --mem is the spelling; --memory is what it was called first and still
 	// answers, because a line that works today keeps working. Both write one
@@ -542,14 +558,17 @@ var brigFlags = []struct {
 // -- and silently reinterpreting a flag two programs share is worse than saying
 // which of them read it.
 //
-// -w is the other short form going. It is absent here because #6 introduces
-// what replaces it, and pointing at a flag that does not exist yet is worse
-// than saying nothing.
+// -w and --workspace retire onto --home, both spellings named. The long one is
+// mapped and said out loud rather than aliased quietly because the word itself
+// is what is being retired: with a project on the same line there are two host
+// directories to talk about, and "workspace" never said which one it was.
 var deprecatedFlags = map[string]string{
-	"-t":     "--image",
-	"-m":     "--mem",
-	"-n":     "<agent>@<label>",
-	"--name": "<agent>@<label>",
+	"-t":          "--image",
+	"-m":          "--mem",
+	"-n":          "<agent>@<label>",
+	"--name":      "<agent>@<label>",
+	"-w":          "--home",
+	"--workspace": "--home",
 }
 
 // ours reports whether a token is one of brig's flags in the position it was
@@ -641,8 +660,13 @@ func parseGlobal(args []string) (rest []string, err error) {
 	return rest, nil
 }
 
-// split divides a run line into brig's own arguments, the session ref, and the
-// agent's tail.
+// split divides a run line into brig's own arguments, the session ref, the
+// second bare word, and the agent's tail.
+//
+// The second bare word is handed back on its own rather than at the head of the
+// tail because what it means depends on the verb, and split does not know the
+// verb: on run it is the project directory to mount, and on sh it is the guest
+// command. projectFor is where that is decided.
 //
 // This exists because the flag package stops at the first non-flag argument
 // and treats an unknown flag as an error, and brig's line is the opposite on
@@ -656,7 +680,7 @@ func parseGlobal(args []string) (rest []string, err error) {
 // exist. After it, brig still answers to its own flags -- `brig run claude -q`
 // is a line that works today -- but the first token it does not own ends its
 // parsing and everything from there is the agent's, warnings included.
-func split(args []string) (mine []string, ref session.Ref, tail []string, err error) {
+func split(args []string) (mine []string, ref session.Ref, word string, tail []string, err error) {
 	passed := false
 	for i := 0; i < len(args); i++ {
 		a := args[i]
@@ -664,8 +688,9 @@ func split(args []string) (mine []string, ref session.Ref, tail []string, err er
 		case a == "--":
 			// An explicit end to brig's parsing, so an agent argument spelled
 			// like one of brig's flags still reaches the agent. Nothing is
-			// said about what follows: the line already said it.
-			return mine, ref, args[i+1:], nil
+			// said about what follows: the line already said it -- which is
+			// also why no word after it is ever read as a project.
+			return mine, ref, "", args[i+1:], nil
 		case !strings.HasPrefix(a, "-"):
 			if !passed {
 				if ref, err = session.ParseRef(a); err != nil {
@@ -673,13 +698,16 @@ func split(args []string) (mine []string, ref session.Ref, tail []string, err er
 					// profile to go and look up: reporting it as a missing
 					// profile would name the whole token and say nothing about
 					// the part that is wrong.
-					return nil, session.Ref{}, nil, usagef("%s", err)
+					return nil, session.Ref{}, "", nil, usagef("%s", err)
 				}
 				passed = true
 				continue
 			}
-			// A second bare word is the agent's command, not a second ref.
-			return mine, ref, agentTail(args[i:]), nil
+			// A second bare word, and it is still where brig stops reading its
+			// own line: the word has a meaning of its own now, and brig does
+			// not resume after it, so `brig run claude . -q` leaves -q the
+			// agent's exactly as it always did. agentTail says so.
+			return mine, ref, a, agentTail(args[i+1:]), nil
 		default:
 			isOurs, takesValue := ours(a, posRun)
 			if !isOurs {
@@ -692,11 +720,11 @@ func split(args []string) (mine []string, ref session.Ref, tail []string, err er
 				// the flag's value and leave the line blaming the one word on it
 				// that was right, so refuse it and name it.
 				if !passed {
-					return nil, session.Ref{}, nil, usagef("unknown flag %q before the profile name. "+
+					return nil, session.Ref{}, "", nil, usagef("unknown flag %q before the profile name. "+
 						"brig's own flags come before the profile and the agent's after it; "+
 						"put %q after the profile to pass it through, or -- to end brig's flags", a, a)
 				}
-				return mine, ref, agentTail(args[i:]), nil
+				return mine, ref, "", agentTail(args[i:]), nil
 			}
 			// Read off the spelling rather than the whole token, so the
 			// inline form is the same flag here as it is everywhere else, and
@@ -716,7 +744,41 @@ func split(args []string) (mine []string, ref session.Ref, tail []string, err er
 			}
 		}
 	}
-	return mine, ref, nil, nil
+	return mine, ref, "", nil, nil
+}
+
+// projectFor decides what a verb does with the second bare word on its line.
+//
+// run is the only verb that takes a positional. On sh -- and on exec and
+// shell, the two spellings it replaces -- a second bare word is already the
+// guest command, and on the verbs that take a ref and nothing more it is still
+// a stray token for rejectTail to name. Both of those get the word back at the
+// head of their tail, exactly where split found it, so nothing but run changes.
+func projectFor(verb, word string, tail []string) (project string, rest []string) {
+	if word == "" || verb == "run" {
+		return word, tail
+	}
+	return "", append([]string{word}, tail...)
+}
+
+// warnPositionalMeaning names both readings of a second bare word, for the one
+// release in which it changes meaning.
+//
+// Until now that word ended brig's parsing and reached the AGENT: `brig run
+// claude .` passed "." to claude. It is the project directory brig mounts from
+// here on, so anyone who was passing a positional through has a line that means
+// something else now -- and this is a breaking change however additive the
+// feature looks. Naming the reading it lost, beside the one it gained, is what
+// lets somebody pick the one they meant.
+//
+// Only a word brig read itself. A tail after -- was declared the agent's by the
+// person typing it, so there is nothing to point out -- the same rule agentTail
+// follows.
+func warnPositionalMeaning(word string) {
+	fmt.Fprintf(os.Stderr, "brig: `%s` is now the project directory this run mounts, "+
+		"and brig starts the agent in it. It used to be the agent's first argument "+
+		"instead. If that is what you meant, put it after --: `brig run <ref> -- %s`. "+
+		"This notice goes in the next release.\n", word, word)
 }
 
 // agentTail hands the tail back as the agent's, saying so for any of brig's own
@@ -768,10 +830,14 @@ func rejectTail(verb string, tail []string) error {
 // whatever remains for the agent. split decides where brig's arguments end;
 // the flag package turns them into values.
 func parse(args []string) (o options, profileName string, tail []string, err error) {
-	mine, ref, tail, err := split(args)
+	mine, ref, word, tail, err := split(args)
 	if err != nil {
 		return options{}, "", nil, err
 	}
+	// The positional as split found it. Which verb may keep it is the caller's
+	// decision, not this one's: parse reads one line's flags and does not know
+	// the verb they were typed under.
+	o.load.Project = word
 
 	fs := flag.NewFlagSet("brig", flag.ContinueOnError)
 	// The flag package's own output is a usage dump on every error. brig's
@@ -786,6 +852,10 @@ func parse(args []string) (o options, profileName string, tail []string, err err
 	}{
 		{"name", "n", func(n string) { fs.StringVar(&o.load.Name, n, "", "") }},
 		{"image", "t", func(n string) { fs.StringVar(&o.load.Image, n, "", "") }},
+		// Three spellings of the guest home: --home is the one, -w and
+		// --workspace are what it replaces. They share the value, so the last
+		// one on the line wins.
+		{"home", "", func(n string) { fs.StringVar(&o.load.Workspace, n, "", "") }},
 		{"workspace", "w", func(n string) { fs.StringVar(&o.load.Workspace, n, "", "") }},
 		// Two long spellings of one value: --mem is the one the usage text
 		// gives, --memory is what it was called first. They share mem, so the

--- a/cmd/brig/main.go
+++ b/cmd/brig/main.go
@@ -71,6 +71,8 @@ flags (before the agent's own arguments; -- ends brig's parsing):
       --image IMAGE      guest image to boot
       --home PATH        host directory to mount as the guest home
                          (-w and --workspace still work, with a note)
+      --no-project       with run: this session's project is not mounted,
+                         whatever it ran with last
       --mem MB           guest memory
       --cpus N           guest vCPUs
   -d, --detach           with run: start the sandbox and exit
@@ -315,6 +317,19 @@ func run(args []string) error {
 	// split found it. Said out loud while the meaning is changing, and only
 	// when the word survived as a project -- which is only on run.
 	opts.load.Project, tail = projectFor(verb, opts.load.Project, tail)
+	// Both at once asks for two contradictory things, and either winner would
+	// be silent about the other: the directory would be mounted with
+	// --no-project ignored, or dropped with the word the line names ignored.
+	if opts.load.Project != "" && opts.load.NoProject {
+		return usagef("--no-project and the project %q ask for different things; "+
+			"drop one", opts.load.Project)
+	}
+	// --no-project is run's, like the positional it answers. Elsewhere it is a
+	// flag that does nothing, which is worse than one that is refused.
+	if opts.load.NoProject && verb != "run" {
+		return usagef("--no-project belongs to `brig run`, not `brig %s`. "+
+			"A session runs without its project from the next `brig run --no-project` onwards", verb)
+	}
 	if opts.load.Project != "" {
 		warnPositionalMeaning(opts.load.Project)
 	}
@@ -539,6 +554,10 @@ var brigFlags = []struct {
 	{long: "mem", value: true, position: posRun},
 	{long: "memory", short: "m", value: true, position: posRun},
 	{long: "cpus", value: true, position: posRun},
+	// --no-project detaches the project a session is carrying. It takes no
+	// value: a directory is what the positional says, and this says the
+	// absence of one.
+	{long: "no-project", position: posRun},
 	{long: "detach", short: "d", position: posRun},
 	{long: "skills", position: posRun},
 	{long: "network", value: true, position: posRun},
@@ -868,6 +887,8 @@ func parse(args []string) (o options, profileName string, tail []string, err err
 		// Opt-in, and only ever opt-in: this hands the guest the user's real
 		// skills and plugins, read-only.
 		{"skills", "", func(n string) { fs.BoolVar(&o.load.Skills, n, false, "") }},
+		// Run this session with no project, whatever it ran with last.
+		{"no-project", "", func(n string) { fs.BoolVar(&o.load.NoProject, n, false, "") }},
 		// The posture this run takes: shared or offline. Refused by name later
 		// if it is neither, in the one place every source of it is resolved.
 		{"network", "", func(n string) { fs.StringVar(&o.load.Network, n, "", "") }},

--- a/cmd/brig/main_test.go
+++ b/cmd/brig/main_test.go
@@ -46,7 +46,10 @@ func TestParse(t *testing.T) {
 		// of brig's flags still reaches the agent.
 		{[]string{"claude", "--", "--name", "notasession"}, "", false, "claude", "--name notasession"},
 		{[]string{}, "", false, "", ""},
-		{[]string{"claude", "echo", "hi", "there"}, "", false, "claude", "echo hi there"},
+		// The second bare word is the project now, and brig still stops
+		// reading its own line there, so what follows is the agent's. See
+		// TestRunTakesTheProjectAsAPositional for the whole grammar.
+		{[]string{"claude", "echo", "hi", "there"}, "", false, "claude", "hi there"},
 	}
 	for _, c := range cases {
 		o, template, tail, err := parse(c.args)
@@ -296,6 +299,10 @@ func TestParseBoolsTakeAnInlineValue(t *testing.T) {
 
 // A value is taken as given. `--name -p` is a session called -p, and guessing
 // otherwise would make what a flag means depend on what its value looks like.
+//
+// Which leaves "hi" as the second bare word on the line, and that is the
+// project: the flag swallowed -p, so nothing has ended brig's parsing before
+// it.
 func TestParseTakesAValueThatLooksLikeAFlag(t *testing.T) {
 	o, name, tail, err := parse([]string{"claude", "--name", "-p", "hi"})
 	if err != nil {
@@ -304,8 +311,11 @@ func TestParseTakesAValueThatLooksLikeAFlag(t *testing.T) {
 	if o.load.Name != "-p" || !o.nameGiven {
 		t.Errorf("name = %q, given = %v", o.load.Name, o.nameGiven)
 	}
-	if name != "claude" || strings.Join(tail, " ") != "hi" {
+	if name != "claude" || len(tail) != 0 {
 		t.Errorf("profile = %q, tail = %q", name, tail)
+	}
+	if o.load.Project != "hi" {
+		t.Errorf("project = %q, want hi", o.load.Project)
 	}
 }
 

--- a/cmd/brig/main_test.go
+++ b/cmd/brig/main_test.go
@@ -52,7 +52,7 @@ func TestParse(t *testing.T) {
 		{[]string{"claude", "echo", "hi", "there"}, "", false, "claude", "hi there"},
 	}
 	for _, c := range cases {
-		o, template, tail, err := parse(c.args)
+		o, template, tail, err := parse("run", c.args)
 		if err != nil {
 			t.Errorf("parse(%q) failed: %v", c.args, err)
 			continue
@@ -67,7 +67,7 @@ func TestParse(t *testing.T) {
 }
 
 func TestParseSandboxFlags(t *testing.T) {
-	o, template, tail, err := parse([]string{
+	o, template, tail, err := parse("run", []string{
 		"claude", "-t", "ghcr.io/me/img:latest", "-w", "/tmp/ws",
 		"-m", "8192", "--cpus", "2", "-d", "-p", "hi",
 	})
@@ -91,7 +91,7 @@ func TestParseSandboxFlags(t *testing.T) {
 		t.Errorf("tail = %q", tail)
 	}
 	// The inline form works for every value flag.
-	o, _, _, err = parse([]string{"claude", "--image=x", "--workspace=/w", "--memory=1024", "--cpus=1"})
+	o, _, _, err = parse("run", []string{"claude", "--image=x", "--workspace=/w", "--memory=1024", "--cpus=1"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -104,7 +104,7 @@ func TestParseSandboxFlags(t *testing.T) {
 // and never handed to the agent. It suppresses the execution envelope.
 func TestParseReadsQuiet(t *testing.T) {
 	for _, args := range [][]string{{"claude", "--quiet"}, {"claude", "-q"}} {
-		o, name, tail, err := parse(args)
+		o, name, tail, err := parse("run", args)
 		if err != nil {
 			t.Fatalf("parse(%q): %v", args, err)
 		}
@@ -114,10 +114,10 @@ func TestParseReadsQuiet(t *testing.T) {
 	}
 	// Absent by default, and after the agent's arguments begin it is the
 	// agent's word rather than brig's.
-	if o, _, _, _ := parse([]string{"claude"}); o.quiet {
+	if o, _, _, _ := parse("run", []string{"claude"}); o.quiet {
 		t.Error("quiet defaulted to on")
 	}
-	if o, _, _, _ := parse([]string{"claude", "-p", "hi", "--quiet"}); o.quiet {
+	if o, _, _, _ := parse("run", []string{"claude", "-p", "hi", "--quiet"}); o.quiet {
 		t.Error("--quiet was read out of the agent's own arguments")
 	}
 }
@@ -136,7 +136,7 @@ func TestParseRejectsBadValues(t *testing.T) {
 		{"claude", "--image"},     // value flag with nothing after it
 	}
 	for _, args := range cases {
-		if _, _, _, err := parse(args); err == nil {
+		if _, _, _, err := parse("run", args); err == nil {
 			t.Errorf("parse(%q) was accepted", args)
 		}
 	}
@@ -145,7 +145,7 @@ func TestParseRejectsBadValues(t *testing.T) {
 	for _, args := range [][]string{
 		{"claude", "--memory=0"}, {"claude", "--cpus=-1"}, {"claude", "--memory=lots"},
 	} {
-		if _, _, _, err := parse(args); err == nil {
+		if _, _, _, err := parse("run", args); err == nil {
 			t.Errorf("parse(%q) was accepted", args)
 		}
 	}
@@ -169,7 +169,7 @@ func TestParseErrorsNameTheFlagAsTyped(t *testing.T) {
 		{[]string{"claude", "-m", "8", "--memory", "0"}, "--memory needs"},
 	}
 	for _, c := range cases {
-		_, _, _, err := parse(c.args)
+		_, _, _, err := parse("run", c.args)
 		if err == nil {
 			t.Errorf("parse(%q) was accepted", c.args)
 			continue
@@ -197,7 +197,7 @@ func TestParseErrorsQuoteTheValueAsTyped(t *testing.T) {
 		{[]string{"claude", "--memory", "4 for flag x"}, `not "4 for flag x"`},
 		{[]string{"claude", "--detach=1 for x"}, `not "1 for x"`},
 	} {
-		_, _, _, err := parse(c.args)
+		_, _, _, err := parse("run", c.args)
 		if err == nil {
 			t.Errorf("parse(%q) was accepted", c.args)
 			continue
@@ -211,7 +211,7 @@ func TestParseErrorsQuoteTheValueAsTyped(t *testing.T) {
 // Numbers are decimal. Read base-0 instead, --memory 010 boots a guest a fifth
 // of the size asked for and says nothing about it.
 func TestParseReadsNumbersAsDecimal(t *testing.T) {
-	o, _, _, err := parse([]string{"claude", "--memory", "010", "--cpus", "08"})
+	o, _, _, err := parse("run", []string{"claude", "--memory", "010", "--cpus", "08"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -236,7 +236,7 @@ func TestParseHandsUnknownFlagsToTheAgent(t *testing.T) {
 		{[]string{"claude", "-d", "--resume", "-n", "foo"}, "--resume -n foo"},
 	}
 	for _, c := range cases {
-		o, name, tail, err := parse(c.args)
+		o, name, tail, err := parse("run", c.args)
 		if err != nil {
 			t.Errorf("parse(%q): %v", c.args, err)
 			continue
@@ -262,7 +262,7 @@ func TestParseOnlyTakesTheDocumentedSpellings(t *testing.T) {
 		{"claude", "-skills"},
 		{"claude", "-cpus", "2"},
 	} {
-		o, name, tail, err := parse(args)
+		o, name, tail, err := parse("run", args)
 		if err != nil {
 			t.Errorf("parse(%q): %v", args, err)
 			continue
@@ -280,7 +280,7 @@ func TestParseOnlyTakesTheDocumentedSpellings(t *testing.T) {
 // as on would turn the guest's access to the host's skills back on.
 func TestParseBoolsTakeAnInlineValue(t *testing.T) {
 	for _, args := range [][]string{{"claude", "--detach=false"}, {"claude", "--skills=false"}} {
-		o, _, _, err := parse(args)
+		o, _, _, err := parse("run", args)
 		if err != nil {
 			t.Errorf("parse(%q): %v", args, err)
 			continue
@@ -290,7 +290,7 @@ func TestParseBoolsTakeAnInlineValue(t *testing.T) {
 		}
 	}
 	// And a value that is neither is a mistake worth saying out loud.
-	if _, _, _, err := parse([]string{"claude", "--detach=garbage"}); err == nil {
+	if _, _, _, err := parse("run", []string{"claude", "--detach=garbage"}); err == nil {
 		t.Error("--detach=garbage was accepted")
 	} else if !strings.Contains(err.Error(), "--detach") || strings.Contains(err.Error(), "parse error") {
 		t.Errorf("--detach=garbage: %v, want brig's own wording naming --detach", err)
@@ -304,7 +304,7 @@ func TestParseBoolsTakeAnInlineValue(t *testing.T) {
 // project: the flag swallowed -p, so nothing has ended brig's parsing before
 // it.
 func TestParseTakesAValueThatLooksLikeAFlag(t *testing.T) {
-	o, name, tail, err := parse([]string{"claude", "--name", "-p", "hi"})
+	o, name, tail, err := parse("run", []string{"claude", "--name", "-p", "hi"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -322,18 +322,18 @@ func TestParseTakesAValueThatLooksLikeAFlag(t *testing.T) {
 // --skills hands the guest the user's real skills and plugins, so it is opt-in
 // and must never arrive from anywhere but the flag itself.
 func TestParseSkillsIsOptIn(t *testing.T) {
-	o, _, _, err := parse([]string{"claude"})
+	o, _, _, err := parse("run", []string{"claude"})
 	if err != nil {
 		t.Fatal(err)
 	}
 	if o.load.Skills {
 		t.Error("skills defaulted to on")
 	}
-	if o, _, _, _ = parse([]string{"claude", "--skills"}); !o.load.Skills {
+	if o, _, _, _ = parse("run", []string{"claude", "--skills"}); !o.load.Skills {
 		t.Error("--skills did not set it")
 	}
 	// After the agent's arguments start it is the agent's word, not brig's.
-	if o, _, _, _ = parse([]string{"claude", "-p", "hi", "--skills"}); o.load.Skills {
+	if o, _, _, _ = parse("run", []string{"claude", "-p", "hi", "--skills"}); o.load.Skills {
 		t.Error("--skills was read out of the agent's own arguments")
 	}
 }

--- a/cmd/brig/project_test.go
+++ b/cmd/brig/project_test.go
@@ -1,0 +1,135 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// `brig run <ref> [project] [agent args...]`. The second bare word is the
+// project directory, and brig's parsing still ends there: everything after it
+// is the agent's, exactly as it was when the word itself was.
+func TestRunTakesTheProjectAsAPositional(t *testing.T) {
+	for _, c := range []struct {
+		args    []string
+		project string
+		tail    string
+	}{
+		{[]string{"claude", "/tmp/p"}, "/tmp/p", ""},
+		{[]string{"claude", "/tmp/p", "-p", "hi"}, "/tmp/p", "-p hi"},
+		{[]string{"claude", "-q", "/tmp/p"}, "/tmp/p", ""},
+		// brig stops reading at the project, so a word after it is the
+		// agent's -- the boundary has not moved, only what the word means.
+		{[]string{"claude", "/tmp/p", "status"}, "/tmp/p", "status"},
+		// An explicit -- declares the rest the agent's, project included: the
+		// line has already said which reading it wants.
+		{[]string{"claude", "--", "/tmp/p"}, "", "/tmp/p"},
+		{[]string{"claude"}, "", ""},
+		{[]string{"claude", "-p", "hi"}, "", "-p hi"},
+	} {
+		o, profileName, tail, err := parse(c.args)
+		if err != nil {
+			t.Errorf("parse(%q): %v", c.args, err)
+			continue
+		}
+		if profileName != "claude" {
+			t.Errorf("parse(%q) resolved the profile %q, want claude", c.args, profileName)
+		}
+		if o.load.Project != c.project || strings.Join(tail, " ") != c.tail {
+			t.Errorf("parse(%q) = project %q, tail %q; want %q and %q",
+				c.args, o.load.Project, strings.Join(tail, " "), c.project, c.tail)
+		}
+	}
+}
+
+// Only run takes a positional. On sh -- and on the two spellings it replaces --
+// a second bare word is already the guest command, and on the verbs that take a
+// ref and nothing more it is still a mistake for rejectTail to name.
+func TestOnlyRunKeepsTheSecondBareWord(t *testing.T) {
+	project, tail := projectFor("run", "myproject", []string{"-p", "hi"})
+	if project != "myproject" || strings.Join(tail, " ") != "-p hi" {
+		t.Errorf("run: project %q, tail %q; want myproject and -p hi", project, tail)
+	}
+	for _, verb := range []string{"sh", "shell", "exec", "create", "stop", "rm", "info", "env"} {
+		project, tail := projectFor(verb, "echo", []string{"hi"})
+		if project != "" {
+			t.Errorf("%s took %q as a project", verb, project)
+		}
+		if strings.Join(tail, " ") != "echo hi" {
+			t.Errorf("%s: tail %q, want the word back at the head (echo hi)", verb, tail)
+		}
+	}
+	// Nothing to decide when there is no second bare word.
+	if project, tail := projectFor("run", "", []string{"-p", "hi"}); project != "" ||
+		strings.Join(tail, " ") != "-p hi" {
+		t.Errorf("no positional: project %q, tail %q", project, tail)
+	}
+}
+
+// The one-release warning. A bare word after the ref used to end brig's
+// parsing and reach the AGENT, so giving it a new meaning is a breaking change
+// for anyone who passed one through. Both readings are named, so a user can
+// pick one before the notice goes.
+func TestASecondBareWordWarnsAndNamesBothReadings(t *testing.T) {
+	scratchHost(t)
+	notice := captureStderr(t, func() { _, _ = captureStdout(t, func() error { return run([]string{"run", "claude", "."}) }) })
+	for _, want := range []string{"project", "--", "`.`"} {
+		if !strings.Contains(notice, want) {
+			t.Errorf("the notice does not name %s:\n%s", want, notice)
+		}
+	}
+
+	// After an explicit -- there is nothing to point out: the line said what
+	// the word is, and the word is not a project.
+	scratchHost(t)
+	notice = captureStderr(t, func() {
+		_, _ = captureStdout(t, func() error { return run([]string{"run", "claude", "--", "."}) })
+	})
+	if strings.Contains(notice, "project directory") {
+		t.Errorf("a tail after -- was warned about:\n%s", notice)
+	}
+
+	// And a run that names no positional at all hears nothing.
+	scratchHost(t)
+	notice = captureStderr(t, func() {
+		_, _ = captureStdout(t, func() error { return run([]string{"run", "claude", "-p", "hi"}) })
+	})
+	if strings.Contains(notice, "project directory") {
+		t.Errorf("a run with no positional was warned about:\n%s", notice)
+	}
+}
+
+// --home is what sets the guest home now. Both older spellings keep working --
+// a line that works today has to keep working -- and each says the one word
+// that replaces it.
+func TestHomeReplacesWorkspace(t *testing.T) {
+	for _, c := range []struct {
+		args   []string
+		notice string
+	}{
+		{[]string{"claude", "--home", "/h"}, ""},
+		{[]string{"claude", "--home=/h"}, ""},
+		{[]string{"claude", "-w", "/h"}, "`-w` is now `--home`"},
+		{[]string{"claude", "--workspace", "/h"}, "`--workspace` is now `--home`"},
+		{[]string{"claude", "--workspace=/h"}, "`--workspace` is now `--home`"},
+	} {
+		var o options
+		var err error
+		notice := captureStderr(t, func() { o, _, _, err = parse(c.args) })
+		if err != nil {
+			t.Errorf("parse(%q): %v", c.args, err)
+			continue
+		}
+		if o.load.Workspace != "/h" {
+			t.Errorf("parse(%q) set the home to %q, want /h", c.args, o.load.Workspace)
+		}
+		if c.notice == "" {
+			if strings.Contains(notice, "is now") {
+				t.Errorf("parse(%q) printed a notice:\n%s", c.args, notice)
+			}
+			continue
+		}
+		if !strings.Contains(notice, c.notice) {
+			t.Errorf("parse(%q) does not say %q:\n%s", c.args, c.notice, notice)
+		}
+	}
+}

--- a/cmd/brig/project_test.go
+++ b/cmd/brig/project_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"strings"
 	"testing"
 )
@@ -130,6 +131,57 @@ func TestHomeReplacesWorkspace(t *testing.T) {
 		}
 		if !strings.Contains(notice, c.notice) {
 			t.Errorf("parse(%q) does not say %q:\n%s", c.args, c.notice, notice)
+		}
+	}
+}
+
+// --no-project is a run-line flag like the positional it answers, so it parses
+// between the verb and the ref and reaches wrap.Options.
+func TestNoProjectParses(t *testing.T) {
+	o, _, tail, err := parse([]string{"--no-project", "claude"})
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if !o.load.NoProject {
+		t.Error("--no-project did not reach the options")
+	}
+	if len(tail) != 0 {
+		t.Errorf("--no-project left a tail: %q", tail)
+	}
+}
+
+// Both at once ask for two contradictory things, and either winner would be
+// silent about the other: the directory mounted with --no-project ignored, or
+// dropped with the word the line names ignored. Refuse and name both.
+func TestNoProjectWithAPositionalIsRefused(t *testing.T) {
+	t.Setenv("BRIG_PROFILE_DIR", t.TempDir())
+	dir := t.TempDir()
+	err := run([]string{"run", "--no-project", "claude", dir})
+	if err == nil {
+		t.Fatal("--no-project alongside a project was accepted")
+	}
+	var ue *usageError
+	if !errors.As(err, &ue) {
+		t.Errorf("error is %T, want a usage error: %v", err, err)
+	}
+	if !strings.Contains(err.Error(), dir) || !strings.Contains(err.Error(), "--no-project") {
+		t.Errorf("the error does not name both: %v", err)
+	}
+}
+
+// Elsewhere the flag would do nothing, which is worse than being refused: a
+// user would think the session had been detached and find it still mounted.
+func TestNoProjectOnAnotherVerbIsRefused(t *testing.T) {
+	t.Setenv("BRIG_PROFILE_DIR", t.TempDir())
+	for _, verb := range []string{"sh", "info", "stop"} {
+		err := run([]string{verb, "--no-project", "claude"})
+		if err == nil {
+			t.Errorf("brig %s --no-project was accepted", verb)
+			continue
+		}
+		var ue *usageError
+		if !errors.As(err, &ue) {
+			t.Errorf("brig %s --no-project: error is %T, want a usage error", verb, err)
 		}
 	}
 }

--- a/cmd/brig/project_test.go
+++ b/cmd/brig/project_test.go
@@ -18,16 +18,20 @@ func TestRunTakesTheProjectAsAPositional(t *testing.T) {
 		{[]string{"claude", "/tmp/p"}, "/tmp/p", ""},
 		{[]string{"claude", "/tmp/p", "-p", "hi"}, "/tmp/p", "-p hi"},
 		{[]string{"claude", "-q", "/tmp/p"}, "/tmp/p", ""},
-		// brig stops reading at the project, so a word after it is the
-		// agent's -- the boundary has not moved, only what the word means.
+		// brig reads past the project, which is its own operand, and stops
+		// at the next bare word: that is where the agent's argv starts.
 		{[]string{"claude", "/tmp/p", "status"}, "/tmp/p", "status"},
+		{[]string{"claude", "/tmp/p", "-q", "status"}, "/tmp/p", "status"},
 		// An explicit -- declares the rest the agent's, project included: the
 		// line has already said which reading it wants.
 		{[]string{"claude", "--", "/tmp/p"}, "", "/tmp/p"},
+		// A project named before the marker stands: -- speaks for what comes
+		// after it, not for what came before.
+		{[]string{"claude", "/tmp/p", "--", "--version"}, "/tmp/p", "--version"},
 		{[]string{"claude"}, "", ""},
 		{[]string{"claude", "-p", "hi"}, "", "-p hi"},
 	} {
-		o, profileName, tail, err := parse(c.args)
+		o, profileName, tail, err := parse("run", c.args)
 		if err != nil {
 			t.Errorf("parse(%q): %v", c.args, err)
 			continue
@@ -44,25 +48,98 @@ func TestRunTakesTheProjectAsAPositional(t *testing.T) {
 
 // Only run takes a positional. On sh -- and on the two spellings it replaces --
 // a second bare word is already the guest command, and on the verbs that take a
-// ref and nothing more it is still a mistake for rejectTail to name.
+// ref and nothing more it is still a mistake for rejectTail to name. Both get
+// the word back at the head of their tail, and brig stops reading there: a
+// flag after the guest command is the guest's.
 func TestOnlyRunKeepsTheSecondBareWord(t *testing.T) {
-	project, tail := projectFor("run", "myproject", []string{"-p", "hi"})
-	if project != "myproject" || strings.Join(tail, " ") != "-p hi" {
-		t.Errorf("run: project %q, tail %q; want myproject and -p hi", project, tail)
+	_, _, word, tail, err := split("run", []string{"claude", "myproject", "-p", "hi"})
+	if err != nil {
+		t.Fatalf("split(run): %v", err)
+	}
+	if word != "myproject" || strings.Join(tail, " ") != "-p hi" {
+		t.Errorf("run: project %q, tail %q; want myproject and -p hi", word, tail)
 	}
 	for _, verb := range []string{"sh", "shell", "exec", "create", "stop", "rm", "info", "env"} {
-		project, tail := projectFor(verb, "echo", []string{"hi"})
-		if project != "" {
-			t.Errorf("%s took %q as a project", verb, project)
+		_, _, word, tail, err := split(verb, []string{"claude", "echo", "hi"})
+		if err != nil {
+			t.Errorf("split(%s): %v", verb, err)
+			continue
+		}
+		if word != "" {
+			t.Errorf("%s took %q as a project", verb, word)
 		}
 		if strings.Join(tail, " ") != "echo hi" {
 			t.Errorf("%s: tail %q, want the word back at the head (echo hi)", verb, tail)
 		}
 	}
 	// Nothing to decide when there is no second bare word.
-	if project, tail := projectFor("run", "", []string{"-p", "hi"}); project != "" ||
-		strings.Join(tail, " ") != "-p hi" {
-		t.Errorf("no positional: project %q, tail %q", project, tail)
+	if _, _, word, tail, err := split("run", []string{"claude", "-p", "hi"}); err != nil ||
+		word != "" || strings.Join(tail, " ") != "-p hi" {
+		t.Errorf("no positional: project %q, tail %q, err %v", word, tail, err)
+	}
+}
+
+// Brig's own flags keep working after the project positional.
+//
+// The positional is brig's operand, like the ref before it, so it does not end
+// brig's reading of the line -- split's rule is that the first token brig does
+// not own ends it, and this is a token brig owns. Before this, every brig flag
+// after the path went to the agent: `brig run claude ~/proj --mem 4096 -d
+// --offline` booted in the foreground with default memory and the network on,
+// warned about but not acted on.
+func TestBrigFlagsAfterTheProjectAreStillBrigs(t *testing.T) {
+	o, _, tail, err := parse("run", []string{"claude", "/tmp/p", "--mem", "4096", "-d", "--offline"})
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if o.load.Project != "/tmp/p" {
+		t.Errorf("project = %q, want /tmp/p", o.load.Project)
+	}
+	if o.load.Mem != 4096 || !o.detach || !o.offline {
+		t.Errorf("mem=%d detach=%v offline=%v, want 4096 true true", o.load.Mem, o.detach, o.offline)
+	}
+	if len(tail) != 0 {
+		t.Errorf("tail = %q, want empty", tail)
+	}
+
+	// A flag brig does not own still ends the reading, and a third bare word
+	// still does: those are the agent's, and the boundary rule is unchanged.
+	for _, c := range []struct {
+		args []string
+		tail string
+	}{
+		{[]string{"claude", "/tmp/p", "--resume"}, "--resume"},
+		{[]string{"claude", "/tmp/p", "npm", "test"}, "npm test"},
+		{[]string{"claude", "/tmp/p", "-d", "npm", "test"}, "npm test"},
+	} {
+		o, _, tail, err := parse("run", c.args)
+		if err != nil {
+			t.Errorf("parse(%q): %v", c.args, err)
+			continue
+		}
+		if o.load.Project != "/tmp/p" || strings.Join(tail, " ") != c.tail {
+			t.Errorf("parse(%q) = project %q, tail %q; want /tmp/p and %q",
+				c.args, o.load.Project, strings.Join(tail, " "), c.tail)
+		}
+	}
+}
+
+// The contradiction is refused in the spelling people type, not only in the
+// one where the flag comes first. Reaching it is what the positional no longer
+// ending brig's reading buys.
+func TestNoProjectAfterThePositionalIsRefused(t *testing.T) {
+	t.Setenv("BRIG_PROFILE_DIR", t.TempDir())
+	dir := t.TempDir()
+	for _, args := range [][]string{
+		{"run", "--no-project", "claude", dir},
+		{"run", "claude", dir, "--no-project"},
+	} {
+		err := run(args)
+		var ue *usageError
+		if !errors.As(err, &ue) {
+			t.Errorf("brig %s: error is %T (%v), want a usage error",
+				strings.Join(args, " "), err, err)
+		}
 	}
 }
 
@@ -115,7 +192,7 @@ func TestHomeReplacesWorkspace(t *testing.T) {
 	} {
 		var o options
 		var err error
-		notice := captureStderr(t, func() { o, _, _, err = parse(c.args) })
+		notice := captureStderr(t, func() { o, _, _, err = parse("run", c.args) })
 		if err != nil {
 			t.Errorf("parse(%q): %v", c.args, err)
 			continue
@@ -138,7 +215,7 @@ func TestHomeReplacesWorkspace(t *testing.T) {
 // --no-project is a run-line flag like the positional it answers, so it parses
 // between the verb and the ref and reaches wrap.Options.
 func TestNoProjectParses(t *testing.T) {
-	o, _, tail, err := parse([]string{"--no-project", "claude"})
+	o, _, tail, err := parse("run", []string{"--no-project", "claude"})
 	if err != nil {
 		t.Fatalf("parse: %v", err)
 	}

--- a/internal/wrap/config.go
+++ b/internal/wrap/config.go
@@ -177,8 +177,14 @@ type Options struct {
 	// the directory the command was invoked from, because `brig run claude .`
 	// is the line the positional exists for.
 	Project string
-	Mem     int
-	CPUs    int
+	// NoProject asks for this run to have no project at all, and is the only
+	// way to say so once a project is remembered: a positional names a
+	// directory, and no directory names absence. Without it a session handed a
+	// project keeps it for the rest of its life, since every later flagless
+	// verb inherits it.
+	NoProject bool
+	Mem       int
+	CPUs      int
 	// Skills opts in to projecting the host's own agent config (skills,
 	// plugins) read-only into the guest. Off unless asked for: it is the
 	// user's real config, and handing it to a sandbox should be a decision.
@@ -380,11 +386,25 @@ func Load(t profile.Profile, o Options, rt runtime.Runtime) (*Config, error) {
 	// destroyed the mount, the guest's memory-only state and the index entry
 	// recording it. Looked up by ref and sandbox, so it has to happen here,
 	// after both are resolved. See rememberedProject and projectShareStale.
-	if o.Project != "" {
+	//
+	// --no-project is the third answer, and the reason it exists: inheriting
+	// left no way to say "not this time". It is read here rather than as an
+	// empty Project, because empty is what an invocation that said nothing
+	// looks like and those two have to stay apart.
+	switch {
+	case o.NoProject:
+		// Nothing to mount, and nothing remembered is consulted. The sandbox
+		// recreates without the share, which is projectShareStale's
+		// c.Project == "" branch reached deliberately for once.
+	case o.Project != "":
 		if err := c.mountProject(o.Project); err != nil {
 			return nil, err
 		}
-	} else if remembered := rememberedProject(sessionKey(t.Name, slug), vmName); remembered != "" {
+	default:
+		remembered := rememberedProject(sessionKey(t.Name, slug), vmName)
+		if remembered == "" {
+			break
+		}
 		// The error is dropped rather than returned, which is the one place the
 		// two steps differ. A directory this line never named is not the user's
 		// to fix, so a remembered project that has since been renamed or

--- a/internal/wrap/config.go
+++ b/internal/wrap/config.go
@@ -118,6 +118,24 @@ type Config struct {
 	Cwd      string
 	GuestCwd string
 
+	// Project is the host directory this run was told to mount beside the
+	// guest home, and GuestProject is where it lands in the guest. Both are
+	// empty on a run that named none, which is what every path below reads to
+	// tell the two shapes apart.
+	//
+	// A second mount rather than a redirection of the first, because the guest
+	// home IS the agent's home: its dotfiles, its onboarding state, its
+	// caches. Pointing that mount at a repository would put all of it in the
+	// repository. So the home stays brig's own and the project arrives
+	// alongside it, outside the home -- see GuestProject.
+	//
+	// Per run, not per session: the session's identity is its ref, which is
+	// the agent and the label, which is the home. Two runs of one session on
+	// two projects are the same session, so nothing here reaches the sandbox
+	// name or the slug. See mountProject and sessionEntry.
+	Project      string
+	GuestProject string
+
 	// HostCred is the credential read from the host during BuildEnv, kept so
 	// the status report can say where the guest login comes from without
 	// paying for a second keychain read.
@@ -154,8 +172,13 @@ type Options struct {
 	Name      string // session name, as typed
 	Image     string
 	Workspace string
-	Mem       int
-	CPUs      int
+	// Project is the directory named as run's positional argument, to be
+	// mounted beside the guest home. Relative is fine: it is resolved against
+	// the directory the command was invoked from, because `brig run claude .`
+	// is the line the positional exists for.
+	Project string
+	Mem     int
+	CPUs    int
 	// Skills opts in to projecting the host's own agent config (skills,
 	// plugins) read-only into the guest. Off unless asked for: it is the
 	// user's real config, and handing it to a sandbox should be a decision.
@@ -343,6 +366,15 @@ func Load(t profile.Profile, o Options, rt runtime.Runtime) (*Config, error) {
 		return nil, strictErr
 	}
 	c.GuestCwd = GuestCwd(cwd, c.Workspace, t.GuestHome)
+	// And then, if this run named a project, the project instead: it is a
+	// directory of its own, mounted beside the home, so the derivation above
+	// has nothing to say about it. Resolved after the Config exists because it
+	// reads the cwd this run resolved and writes three of its fields.
+	if o.Project != "" {
+		if err := c.mountProject(o.Project); err != nil {
+			return nil, err
+		}
+	}
 	// After the Config is built, because the notice reads the pair this run
 	// resolved to and reports it against the pair the old one had.
 	c.slugMigration = c.slugMigrationNotice(base, vmBase)
@@ -539,6 +571,68 @@ func GuestCwd(cwd, workspace, guestHome string) string {
 // host uses.
 func path(base, rel string) string {
 	return strings.TrimSuffix(base, "/") + "/" + filepath.ToSlash(rel)
+}
+
+// guestProjectRoot is where a named project is mounted in the guest, and the
+// one thing about it that matters is that it is not under any profile's
+// GuestHome.
+//
+// That is the mechanical guarantee behind mounting a project at all: a
+// directory under /work cannot be mistaken for home state and cannot collide
+// with the agent's dotfiles, by layout rather than by a convention someone has
+// to remember. A constant rather than a profile field because it is a fact
+// about brig's mount layout, not about any one agent.
+const guestProjectRoot = "/work"
+
+// GuestProject is where the host directory dir is mounted in the guest:
+// /work/<basename>.
+//
+// The basename rather than the whole path, so the agent's prompt and every
+// path it prints name the project the way its owner does. Two projects with
+// one basename cannot be mounted at once, and nothing tries to: one run mounts
+// one project.
+func GuestProject(dir string) string {
+	return guestProjectRoot + "/" + filepath.Base(dir)
+}
+
+// mountProject resolves the project this run named: the host directory, the
+// guest path it is mounted at, and the working directory the agent starts in.
+//
+// The directory has to be there. Under the old grammar this word reached the
+// agent, so a line that passed one through is a line this release changes the
+// meaning of -- and failing here, naming both the directory and the way past
+// it, is what makes that legible. The alternative considered on #6 was to read
+// the word as a project only when it names an existing directory, which was
+// dropped for good reason: the meaning of an argument would then depend on the
+// filesystem, which is hard to explain and harder to script. The meaning is
+// fixed; a directory that is not there is simply an error.
+func (c *Config) mountProject(dir string) error {
+	abs, err := filepath.Abs(dir)
+	if err != nil {
+		return err
+	}
+	info, err := os.Stat(abs)
+	if err == nil && !info.IsDir() {
+		err = fmt.Errorf("it is not a directory")
+	}
+	if err != nil {
+		return fmt.Errorf("cannot mount %s as this run's project: %w. brig run reads the "+
+			"word after the ref as a directory to mount; if it is an argument for the "+
+			"agent, put it after -- instead", abs, err)
+	}
+	// A filesystem root has no basename to mount it under -- filepath.Base
+	// gives back the separator -- and /work// is not a guest path. Nobody means
+	// to hand an agent the whole machine, so say what to name instead.
+	if filepath.Base(abs) == string(filepath.Separator) {
+		return fmt.Errorf("cannot mount %s as this run's project: it has no name to "+
+			"mount it under; name a project directory rather than a filesystem root", abs)
+	}
+	c.Project = abs
+	c.GuestProject = GuestProject(abs)
+	// The point of naming a directory: the agent starts in it. The cwd-under-
+	// home derivation above still decides this for a run that names none.
+	c.GuestCwd = c.GuestProject
+	return nil
 }
 
 // hostProjections resolves the host directories a profile wants to hand the

--- a/internal/wrap/config.go
+++ b/internal/wrap/config.go
@@ -658,13 +658,43 @@ func (c *Config) mountProject(dir string) error {
 			"word after the ref as a directory to mount; if it is an argument for the "+
 			"agent, put it after -- instead", abs, err)
 	}
+	// Resolved before it is judged, because filepath.Abs cleans a path
+	// lexically and stops there: `/Users/..` collapses to `/`, but `~/mnt ->
+	// /` does not, and the guard below was reading the spelling rather than
+	// the directory. A link is a way around every rule made about a path
+	// unless the rule is made about what the path resolves to -- and the
+	// person who follows a link is not necessarily the person who made it.
+	real, err := filepath.EvalSymlinks(abs)
+	if err != nil {
+		// It stats, so this is a path brig cannot establish the truth about
+		// rather than one that is not there. Refused rather than checked
+		// lexically and let through, because the lexical check is exactly the
+		// one that does not hold here.
+		return fmt.Errorf("cannot mount %s as this run's project: its real path could not be "+
+			"resolved: %w", abs, err)
+	}
 	// A filesystem root has no basename to mount it under -- filepath.Base
 	// gives back the separator -- and /work// is not a guest path. Nobody means
 	// to hand an agent the whole machine, so say what to name instead.
-	if filepath.Base(abs) == string(filepath.Separator) {
-		return fmt.Errorf("cannot mount %s as this run's project: it has no name to "+
-			"mount it under; name a project directory rather than a filesystem root", abs)
+	if filepath.Base(real) == string(filepath.Separator) {
+		// The resolution is named only when it is the thing the reader cannot
+		// see. `brig run claude /` needs no explaining; a link's own name
+		// plainly has a basename, so there "it has no name to mount it under"
+		// would read as nonsense against the word on the line.
+		subject := "it has"
+		if real != abs {
+			subject = fmt.Sprintf("it resolves to %s, which has", real)
+		}
+		return fmt.Errorf("cannot mount %s as this run's project: %s no name to "+
+			"mount it under; name a project directory rather than a filesystem root",
+			abs, subject)
 	}
+	// Resolved to judge it, and the path as typed is what gets mounted. A link
+	// is the name its owner uses for the project, so /work/<link> is the path
+	// the agent should see and the host path it came from is the one to record
+	// and print -- resolving those too would rewrite `/tmp/x` to `/private/tmp/x`
+	// on every macOS host, for a directory the VMM resolves at mount time
+	// anyway.
 	c.Project = abs
 	c.GuestProject = GuestProject(abs)
 	// The point of naming a directory: the agent starts in it. The cwd-under-

--- a/internal/wrap/config.go
+++ b/internal/wrap/config.go
@@ -366,14 +366,32 @@ func Load(t profile.Profile, o Options, rt runtime.Runtime) (*Config, error) {
 		return nil, strictErr
 	}
 	c.GuestCwd = GuestCwd(cwd, c.Workspace, t.GuestHome)
-	// And then, if this run named a project, the project instead: it is a
-	// directory of its own, mounted beside the home, so the derivation above
-	// has nothing to say about it. Resolved after the Config exists because it
-	// reads the cwd this run resolved and writes three of its fields.
+	// And then the project, which replaces that derivation: it is a directory
+	// of its own, mounted beside the home, so the cwd-under-home rule has
+	// nothing to say about it. Resolved after the Config exists because it
+	// reads the workspace and the cwd this run resolved and writes three of its
+	// fields.
+	//
+	// A positional on this invocation wins, and when there is none the project
+	// the sandbox was started with stands -- the same two-step the workspace
+	// above follows, for the same reason and by the same read. An invocation
+	// that names no directory is not asking for a different one: `brig sh
+	// claude@x` said nothing about a project, and taking that for "no project"
+	// destroyed the mount, the guest's memory-only state and the index entry
+	// recording it. Looked up by ref and sandbox, so it has to happen here,
+	// after both are resolved. See rememberedProject and projectShareStale.
 	if o.Project != "" {
 		if err := c.mountProject(o.Project); err != nil {
 			return nil, err
 		}
+	} else if remembered := rememberedProject(sessionKey(t.Name, slug), vmName); remembered != "" {
+		// The error is dropped rather than returned, which is the one place the
+		// two steps differ. A directory this line never named is not the user's
+		// to fix, so a remembered project that has since been renamed or
+		// deleted leaves the run with no project instead of refusing it -- and
+		// EnsureRunning then names it, in the warning about the restart that
+		// takes the dead mount away.
+		_ = c.mountProject(remembered)
 	}
 	// After the Config is built, because the notice reads the pair this run
 	// resolved to and reports it against the pair the old one had.

--- a/internal/wrap/envelope.go
+++ b/internal/wrap/envelope.go
@@ -65,6 +65,18 @@ func (c *Config) envelope(set creds.Set) []envelopeRow {
 		// a place to say so in the row it already has, instead of needing a new
 		// one.
 		envelopeRow{"WORKSPACE", fmt.Sprintf("%s (read-write)", c.Workspace)},
+	)
+	// Directly under the home, because it is the same subject read twice: two
+	// host directories this run is about to hand a sandbox read-write. Only
+	// when there is one -- a run that named no project has no second mount to
+	// report, and a row saying so on every ordinary run is a row people learn
+	// to skip. The guest path is named beside the host path because it is the
+	// answer to the question the row raises, which is where the agent will be.
+	if c.Project != "" {
+		rows = append(rows, envelopeRow{"PROJECT",
+			fmt.Sprintf("%s (read-write, mounted at %s)", c.Project, c.GuestProject)})
+	}
+	rows = append(rows,
 		// The pull policy, the same detail the full report prints beside the
 		// image. Whether the signature verified is a separate fact that the
 		// verify-mode row will carry, so it is deliberately not folded in here.

--- a/internal/wrap/index.go
+++ b/internal/wrap/index.go
@@ -83,8 +83,7 @@ const (
 // Home is the guest's home directory on the host -- the same path the run
 // calls the workspace. It is named for what it is to the session rather than
 // for the flag that supplies it, because it is the directory that makes the
-// session the session: an entry with a different home is a different session,
-// and #6 adds the per-run project mount beside it, which is not.
+// session the session: an entry with a different home is a different session.
 //
 // Sandbox is the instance carrying the session at the moment, which is the
 // part that is not identity: it is removed and recreated by an ordinary
@@ -93,9 +92,19 @@ const (
 // and ForgetSandbox -- and because it is what tells an entry about the sandbox
 // this invocation is addressing from one about a differently named sandbox of
 // the same session. See rememberedWorkspace.
+//
+// Project is the host directory the session LAST RAN with, and the only key
+// here that is not the session at all. It is omitted when there is none, which
+// is most sessions: the identity is the ref, and the ref is the agent plus the
+// label, which is the home. Two runs of one session on two projects are the
+// same session, so an entry with a different project is the same entry with a
+// new value -- which is exactly what makes it worth recording, because a share
+// cannot be attached to a live sandbox and this is what the next run compares
+// against to find out whether it has to recreate one. See projectShareStale.
 type sessionEntry struct {
 	Home    string `json:"home"`
 	Sandbox string `json:"sandbox"`
+	Project string `json:"project,omitempty"`
 }
 
 // stateDir is where brig keeps what has to outlive a single invocation.
@@ -241,6 +250,21 @@ func rememberedWorkspace(ref, vmName string) string {
 	return entry.Home
 }
 
+// rememberedProject is the project the sandbox of this session last ran with,
+// or "" when there was none, when nothing has been recorded, or when what is
+// recorded belongs to a differently named sandbox.
+//
+// The sandbox has to agree for the same reason rememberedWorkspace requires it:
+// BRIG_NAME renames the sandbox without changing the ref, and the mounts of one
+// instance say nothing about the mounts of another.
+func rememberedProject(ref, vmName string) string {
+	entry := readSessionIndex()[ref]
+	if entry.Sandbox != vmName {
+		return ""
+	}
+	return entry.Project
+}
+
 // WorkspaceOfSandbox is the workspace recorded for whichever session is
 // carrying this sandbox, or "" when none is.
 //
@@ -337,8 +361,8 @@ func PruneSessions(live []string) {
 }
 
 // rememberSession records what this run has just started: the ref it is filed
-// under, the directory the sandbox was given as its home, and the sandbox
-// carrying it.
+// under, the directory the sandbox was given as its home, the sandbox carrying
+// it, and the project it was started on if it named one.
 //
 // Also called when the running sandbox already matches, which is what fills
 // the index in for a session created before it existed: the entry is written
@@ -352,7 +376,7 @@ func PruneSessions(live []string) {
 func (c *Config) rememberSession() {
 	dropLegacyWorkspaceIndex()
 	key := sessionKey(c.Profile.Name, c.Slug)
-	entry := sessionEntry{Home: c.Workspace, Sandbox: c.VMName}
+	entry := sessionEntry{Home: c.Workspace, Sandbox: c.VMName, Project: c.Project}
 	index := readSessionIndex()
 	if index[key] == entry {
 		return

--- a/internal/wrap/project_test.go
+++ b/internal/wrap/project_test.go
@@ -120,6 +120,62 @@ func TestAProjectThatIsNotADirectoryIsRefused(t *testing.T) {
 	}
 }
 
+// A link is followed before the root is ruled out, and mounted under the name
+// that was typed.
+//
+// Both halves are the point. filepath.Abs cleans a path lexically and stops
+// there, so `~/mnt -> /` reached the guard as "mnt" and passed it: the guard
+// was reading the spelling rather than the directory. A path is what it
+// resolves to, and that is what has to be checked -- otherwise a link is a way
+// around every rule the guard makes, and the person who follows one is not
+// necessarily the person who made it.
+//
+// The mount keeps the typed basename all the same. The link is the name its
+// owner uses, so /work/<link> is the path the agent should see; resolving that
+// too would rename every legitimate link's mount to whatever it points at.
+func TestALinkIsResolvedBeforeTheRootGuardAndMountedUnderItsOwnName(t *testing.T) {
+	isolateState(t)
+	dir := t.TempDir()
+
+	root := filepath.Join(dir, "myroot")
+	if err := os.Symlink("/", root); err != nil {
+		t.Fatal(err)
+	}
+	c := &Config{}
+	err := c.mountProject(root)
+	if err == nil {
+		t.Fatalf("a link to / was accepted, and mounted at %q", c.GuestProject)
+	}
+	// Named as what it resolves to as well as what was typed: "myroot has no
+	// name to mount it under" would read as nonsense on a path that plainly
+	// has one.
+	if !strings.Contains(err.Error(), root) || !strings.Contains(err.Error(), "filesystem root") {
+		t.Errorf("the refusal does not say what was typed and why it fails: %v", err)
+	}
+
+	// An ordinary link is not collateral: it mounts, under its own name, from
+	// the directory it resolves to.
+	target := filepath.Join(dir, "elsewhere")
+	mustMkdir(t, target)
+	link := filepath.Join(dir, "myproject")
+	if err := os.Symlink(target, link); err != nil {
+		t.Fatal(err)
+	}
+	c = &Config{}
+	mustMountProject(t, c, link)
+	if want := "/work/myproject"; c.GuestProject != want {
+		t.Errorf("the link mounted at %q, want %q -- the name typed, not the one it points at",
+			c.GuestProject, want)
+	}
+	// And the host side is the path as typed. The link is what the share is
+	// asked for and what the VMM resolves; recording the target instead would
+	// rewrite every path under a symlinked parent -- /tmp on this host among
+	// them -- for no gain the mount does not already give.
+	if c.Project != link {
+		t.Errorf("the share exports %q, want the link as typed %q", c.Project, link)
+	}
+}
+
 // The project is a SECOND share. The home share is what makes the session the
 // session, so it stays exactly where it was -- first, and mounting the
 // workspace at the guest home.

--- a/internal/wrap/project_test.go
+++ b/internal/wrap/project_test.go
@@ -1,0 +1,291 @@
+package wrap
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/brig-sh/brig/internal/creds"
+	"github.com/brig-sh/brig/internal/profile"
+	"github.com/brig-sh/brig/internal/runtime"
+)
+
+// The project a run names is mounted at /work/<basename>, OUTSIDE the guest
+// home, and the agent starts in it.
+//
+// Outside is the whole property: the guest home is the agent's home, dotfiles
+// and state included, so a project directory landing under it could be
+// mistaken for home state or collide with the agent's own files. Under /work
+// it cannot, by layout rather than by convention.
+func TestLoadMountsANamedProjectOutsideTheGuestHome(t *testing.T) {
+	isolateState(t)
+	home, project := t.TempDir(), filepath.Join(t.TempDir(), "myproject")
+	mustMkdir(t, project)
+
+	c := mustLoad(t, Options{Workspace: home, Project: project})
+
+	if c.Project != project {
+		t.Errorf("Project = %q, want %q", c.Project, project)
+	}
+	if want := "/work/myproject"; c.GuestProject != want {
+		t.Errorf("GuestProject = %q, want %q", c.GuestProject, want)
+	}
+	if c.GuestCwd != c.GuestProject {
+		t.Errorf("GuestCwd = %q, want the project at %q", c.GuestCwd, c.GuestProject)
+	}
+	if strings.HasPrefix(c.GuestProject, c.Profile.GuestHome+"/") {
+		t.Errorf("the project landed inside the guest home: %q is under %q",
+			c.GuestProject, c.Profile.GuestHome)
+	}
+	// The home is the session's, and naming a project does not move it.
+	if c.Workspace != home {
+		t.Errorf("Workspace = %q, want the home %q", c.Workspace, home)
+	}
+}
+
+// A relative project is resolved against the directory the command was invoked
+// from, because `brig run claude .` is the line this exists for.
+func TestARelativeProjectIsResolvedAgainstTheCwd(t *testing.T) {
+	isolateState(t)
+	c := mustLoad(t, Options{Workspace: t.TempDir(), Project: "."})
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if c.Project != cwd {
+		t.Errorf("Project = %q, want the cwd %q", c.Project, cwd)
+	}
+	if want := "/work/" + filepath.Base(cwd); c.GuestProject != want {
+		t.Errorf("GuestProject = %q, want %q", c.GuestProject, want)
+	}
+}
+
+// The regression that matters most: with no project named, nothing moves. The
+// guest working directory is derived from the cwd and the home exactly as it
+// was before the positional existed, and no second mount is resolved.
+func TestLoadWithoutAProjectIsUnchanged(t *testing.T) {
+	isolateState(t)
+	home := t.TempDir()
+
+	c := mustLoad(t, Options{Workspace: home})
+
+	if c.Project != "" || c.GuestProject != "" {
+		t.Errorf("a run that named no project resolved one: %q at %q", c.Project, c.GuestProject)
+	}
+	if want := GuestCwd(c.Cwd, c.Workspace, c.Profile.GuestHome); c.GuestCwd != want {
+		t.Errorf("GuestCwd = %q, want the cwd-under-home derivation %q", c.GuestCwd, want)
+	}
+}
+
+// A word that names no directory is refused, and the refusal names the escape.
+//
+// This is the breaking change made legible: the word after the ref used to
+// reach the agent, so a line that passed one through now fails here rather
+// than mounting something that is not there. The message has to carry the way
+// past it, which is `--`.
+func TestAProjectThatIsNotADirectoryIsRefused(t *testing.T) {
+	isolateState(t)
+	dir := t.TempDir()
+	file := filepath.Join(dir, "file")
+	if err := os.WriteFile(file, []byte("x\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	p, ok := profile.Lookup("claude-code")
+	if !ok {
+		t.Fatal("the claude-code profile is not loaded")
+	}
+	for _, project := range []string{filepath.Join(dir, "absent"), file} {
+		_, err := Load(p, Options{Workspace: dir, Project: project}, nil)
+		if err == nil {
+			t.Errorf("%q was accepted as a project", project)
+			continue
+		}
+		if !strings.Contains(err.Error(), project) {
+			t.Errorf("the refusal does not name the directory: %v", err)
+		}
+		if !strings.Contains(err.Error(), "--") {
+			t.Errorf("the refusal does not name the way past it: %v", err)
+		}
+	}
+
+	// The filesystem root is a directory and still has no name to mount it
+	// under, so it is refused on its own terms rather than becoming /work//.
+	if _, err := Load(p, Options{Workspace: dir, Project: "/"}, nil); err == nil {
+		t.Error("/ was accepted as a project")
+	} else if !strings.Contains(err.Error(), "filesystem root") {
+		t.Errorf("the refusal does not say why / cannot be mounted: %v", err)
+	}
+}
+
+// The project is a SECOND share. The home share is what makes the session the
+// session, so it stays exactly where it was -- first, and mounting the
+// workspace at the guest home.
+func TestTheProjectIsASecondShareAndTheHomeIsUnchanged(t *testing.T) {
+	rt := &livenessRuntime{}
+	c := livenessConfig(t, rt)
+	project := filepath.Join(t.TempDir(), "myproject")
+	mustMkdir(t, project)
+	mustMountProject(t, c, project)
+
+	if err := c.EnsureRunning(creds.Set{}); err != nil {
+		t.Fatalf("the run failed: %v", err)
+	}
+	want := []runtime.Share{
+		{Host: c.Workspace, Guest: c.Profile.GuestHome},
+		{Host: project, Guest: "/work/myproject"},
+	}
+	if len(rt.spec.Shares) != len(want) {
+		t.Fatalf("shares = %+v, want %+v", rt.spec.Shares, want)
+	}
+	for i, w := range want {
+		if rt.spec.Shares[i] != w {
+			t.Errorf("share %d = %+v, want %+v", i, rt.spec.Shares[i], w)
+		}
+	}
+}
+
+// And with no project the mount set is the one share it always was.
+func TestWithoutAProjectTheMountSetIsUnchanged(t *testing.T) {
+	rt := &livenessRuntime{}
+	c := livenessConfig(t, rt)
+
+	if err := c.EnsureRunning(creds.Set{}); err != nil {
+		t.Fatalf("the run failed: %v", err)
+	}
+	want := []runtime.Share{{Host: c.Workspace, Guest: c.Profile.GuestHome}}
+	if len(rt.spec.Shares) != 1 || rt.spec.Shares[0] != want[0] {
+		t.Errorf("shares = %+v, want %+v", rt.spec.Shares, want)
+	}
+}
+
+// A share cannot be attached to a live sandbox -- shares are --shared-dir
+// arguments to `hull run`, and the Runtime interface has no add-share method --
+// so a run that names a different project has to recreate the sandbox. That is
+// cheap precisely because the home is a host directory which survives it.
+func TestASandboxIsRecreatedWhenTheProjectChanges(t *testing.T) {
+	rt := &livenessRuntime{running: true}
+	c := livenessConfig(t, rt)
+	first := filepath.Join(t.TempDir(), "first")
+	mustMkdir(t, first)
+	mustMountProject(t, c, first)
+
+	// A sandbox brig has no project recorded for is not one it can assume has
+	// this project mounted, so the first run on a project recreates it. Wrong
+	// in the cheap direction: a boot that was not needed, rather than an agent
+	// working in a directory nothing mounted.
+	if err := c.EnsureRunning(creds.Set{}); err != nil {
+		t.Fatalf("the first run failed: %v", err)
+	}
+	if rt.boots != 1 {
+		t.Fatalf("a running sandbox with no project recorded booted %d times, want 1", rt.boots)
+	}
+
+	// The same project again: nothing to change, so nothing is torn down.
+	rt.boots, rt.stops, rt.removes = 0, 0, 0
+	if err := c.EnsureRunning(creds.Set{}); err != nil {
+		t.Fatalf("the second run failed: %v", err)
+	}
+	if rt.boots != 0 || rt.stops != 0 || rt.removes != 0 {
+		t.Errorf("the same project restarted the sandbox (%d boots, %d stops, %d removes)",
+			rt.boots, rt.stops, rt.removes)
+	}
+
+	second := filepath.Join(t.TempDir(), "second")
+	mustMkdir(t, second)
+	mustMountProject(t, c, second)
+	if err := c.EnsureRunning(creds.Set{}); err != nil {
+		t.Fatalf("the run on a new project failed: %v", err)
+	}
+	if rt.boots != 1 {
+		t.Errorf("a new project booted %d sandboxes, want 1", rt.boots)
+	}
+	if rt.stops == 0 || rt.removes == 0 {
+		t.Errorf("the old sandbox was not torn down (%d stops, %d removes)", rt.stops, rt.removes)
+	}
+	if rt.spec.Shares[1].Host != second {
+		t.Errorf("the recreated sandbox mounts %q, want %q", rt.spec.Shares[1].Host, second)
+	}
+
+	// And the other direction: a later run of the same session that names no
+	// project has to lose the mount, or the agent would keep a host directory
+	// the line said nothing about. These are the fields Load leaves empty for
+	// such a run.
+	rt.boots, rt.stops, rt.removes = 0, 0, 0
+	c.Project, c.GuestProject = "", ""
+	c.GuestCwd = GuestCwd(c.Cwd, c.Workspace, c.Profile.GuestHome)
+	if err := c.EnsureRunning(creds.Set{}); err != nil {
+		t.Fatalf("the run naming no project failed: %v", err)
+	}
+	if rt.boots != 1 {
+		t.Errorf("dropping the project booted %d sandboxes, want 1", rt.boots)
+	}
+	if len(rt.spec.Shares) != 1 {
+		t.Errorf("the recreated sandbox still has %+v mounted", rt.spec.Shares)
+	}
+}
+
+// Trust follows the project. The key is the guest directory the agent will be
+// in, so with a project mounted it is the project -- otherwise the agent starts
+// in /work/<basename> and asks whether you trust a directory brig just handed
+// it.
+func TestTheTrustKeyFollowsTheProject(t *testing.T) {
+	home := t.TempDir()
+	c := testConfig(t, home, home)
+	if want := TrustKey(c.Cwd, c.Workspace, c.Profile.GuestHome); c.trustKey() != want {
+		t.Errorf("without a project the key is %q, want the home's %q", c.trustKey(), want)
+	}
+
+	project := filepath.Join(t.TempDir(), "myproject")
+	mustMkdir(t, filepath.Join(project, ".git"))
+	mustMountProject(t, c, project)
+	// A repository root, and the mount root, and the directory the agent
+	// starts in: all three are the project, so the key is its guest path.
+	if want := "/work/myproject"; c.trustKey() != want {
+		t.Errorf("with a project the key is %q, want %q", c.trustKey(), want)
+	}
+}
+
+// The index records the project the session last ran with, and leaves the key
+// out when there was none: most sessions have no project, and the field is a
+// record of the last invocation rather than part of the session's identity.
+func TestTheIndexRecordsTheProjectAndOmitsItWhenAbsent(t *testing.T) {
+	dir := isolateState(t)
+	project := filepath.Join(t.TempDir(), "myproject")
+	mustMkdir(t, project)
+
+	mustLoad(t, Options{Workspace: t.TempDir(), Project: project}).rememberSession()
+	if blob := mustReadIndex(t, dir); !strings.Contains(blob, `"project": "`+project+`"`) {
+		t.Errorf("the index does not record the project:\n%s", blob)
+	}
+
+	bare := isolateState(t)
+	mustLoad(t, Options{Workspace: t.TempDir()}).rememberSession()
+	if blob := mustReadIndex(t, bare); strings.Contains(blob, "project") {
+		t.Errorf("a session with no project still has the key:\n%s", blob)
+	}
+}
+
+// mustMountProject applies to a hand-built Config what Load does for a run
+// that named a project, so a case about the mount does not have to go through
+// the whole of resolution to get one.
+func mustMountProject(t *testing.T, c *Config, dir string) {
+	t.Helper()
+	if err := c.mountProject(dir); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// mustReadIndex is the session index as it was written, read back as text: the
+// cases above are about the shape of the file, `project` present or absent,
+// which a decoded struct cannot tell apart from a zero value.
+func mustReadIndex(t *testing.T, dir string) string {
+	t.Helper()
+	blob, err := os.ReadFile(filepath.Join(dir, sessionIndexName))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(blob)
+}

--- a/internal/wrap/project_test.go
+++ b/internal/wrap/project_test.go
@@ -289,3 +289,119 @@ func mustReadIndex(t *testing.T, dir string) string {
 	}
 	return string(blob)
 }
+
+// The defect real-runtime testing found. A session created with a project and
+// then addressed by a verb that names none -- `brig sh claude@x`, or a bare
+// `brig run` -- presented as project-less: the mount was destroyed, the guest's
+// in-memory state with it, and the index entry was overwritten without the key.
+//
+// The home already worked this way and the project did not. An invocation that
+// names no directory is not asking for the default one, so the path the sandbox
+// was started with is read back -- exactly what rememberedWorkspace does for
+// the home, and for the reason index.go's header gives.
+func TestAProjectGivenOnceIsFoundAgainWithoutThePositional(t *testing.T) {
+	dir := isolateState(t)
+	home := t.TempDir()
+	project := filepath.Join(t.TempDir(), "myproject")
+	mustMkdir(t, project)
+
+	mustLoad(t, Options{Workspace: home, Project: project}).rememberSession()
+
+	next := mustLoad(t, Options{})
+	if next.Project != project {
+		t.Errorf("a flagless verb resolved the project %q, want %q", next.Project, project)
+	}
+	if want := "/work/myproject"; next.GuestProject != want || next.GuestCwd != want {
+		t.Errorf("guest project %q and cwd %q, want %q for both",
+			next.GuestProject, next.GuestCwd, want)
+	}
+	// So the running sandbox is carrying what this run wants, and nothing is
+	// torn down.
+	if stale := next.projectShareStale(); stale != "" {
+		t.Errorf("a flagless verb read the sandbox as stale: %s", stale)
+	}
+	// And recording again keeps the key rather than dropping it, which is what
+	// the flagless verb was doing to the entry.
+	next.rememberSession()
+	if blob := mustReadIndex(t, dir); !strings.Contains(blob, `"project": "`+project+`"`) {
+		t.Errorf("a flagless verb dropped the project from the index:\n%s", blob)
+	}
+}
+
+// An explicit positional still beats what was recorded, and still recreates:
+// asking for a different directory is something a user is entitled to do,
+// restart and all. Same rule the home follows.
+func TestAnExplicitProjectBeatsTheRememberedOne(t *testing.T) {
+	isolateState(t)
+	home := t.TempDir()
+	first := filepath.Join(t.TempDir(), "first")
+	second := filepath.Join(t.TempDir(), "second")
+	mustMkdir(t, first)
+	mustMkdir(t, second)
+
+	mustLoad(t, Options{Workspace: home, Project: first}).rememberSession()
+
+	next := mustLoad(t, Options{Workspace: home, Project: second})
+	if next.Project != second {
+		t.Fatalf("the positional resolved %q, want %q", next.Project, second)
+	}
+	if stale := next.projectShareStale(); stale == "" {
+		t.Error("a different project did not read as stale, so the sandbox would keep the old mount")
+	} else if !strings.Contains(stale, first) || !strings.Contains(stale, second) {
+		t.Errorf("the reason names neither directory clearly: %s", stale)
+	}
+}
+
+// A remembered project that has since gone is dropped rather than refused. This
+// line named no directory, so there is nothing here for the user to fix; the
+// recreate that follows is what tells them the mount went, and it names the
+// directory.
+func TestARememberedProjectThatIsGoneIsDropped(t *testing.T) {
+	isolateState(t)
+	home := t.TempDir()
+	project := filepath.Join(t.TempDir(), "myproject")
+	mustMkdir(t, project)
+
+	mustLoad(t, Options{Workspace: home, Project: project}).rememberSession()
+	if err := os.Remove(project); err != nil {
+		t.Fatal(err)
+	}
+
+	next := mustLoad(t, Options{})
+	if next.Project != "" {
+		t.Errorf("a project that is no longer there was mounted: %q", next.Project)
+	}
+	if want := GuestCwd(next.Cwd, next.Workspace, next.Profile.GuestHome); next.GuestCwd != want {
+		t.Errorf("GuestCwd = %q, want the home derivation %q", next.GuestCwd, want)
+	}
+	if stale := next.projectShareStale(); stale == "" {
+		t.Error("the sandbox still mounting the vanished project did not read as stale")
+	}
+}
+
+// The staleness read itself, on the three answers it has. An entry with no
+// project against a run that has one is the case that survives the inheritance
+// above: nothing was recorded, so nothing establishes that the running sandbox
+// has this mount, and recreating is the safe direction.
+func TestProjectShareStaleReadsTheIndex(t *testing.T) {
+	isolateState(t)
+	home := t.TempDir()
+	project := filepath.Join(t.TempDir(), "myproject")
+	mustMkdir(t, project)
+
+	// Nothing recorded at all, and a project named: stale.
+	c := mustLoad(t, Options{Workspace: home, Project: project})
+	if c.projectShareStale() == "" {
+		t.Error("an unrecorded session with a project did not read as stale")
+	}
+	// Nothing recorded and no project named: not stale, which is every
+	// ordinary run of every session that has never had one.
+	if bare := mustLoad(t, Options{Workspace: home}); bare.projectShareStale() != "" {
+		t.Errorf("a session with no project read as stale: %s", bare.projectShareStale())
+	}
+	// Recorded and unchanged: not stale.
+	c.rememberSession()
+	if again := mustLoad(t, Options{Workspace: home, Project: project}); again.projectShareStale() != "" {
+		t.Errorf("the recorded project read as stale: %s", again.projectShareStale())
+	}
+}

--- a/internal/wrap/project_test.go
+++ b/internal/wrap/project_test.go
@@ -405,3 +405,75 @@ func TestProjectShareStaleReadsTheIndex(t *testing.T) {
 		t.Errorf("the recorded project read as stale: %s", again.projectShareStale())
 	}
 }
+
+// --no-project detaches a project a session is carrying, and it is the only
+// way to say so: a positional names a directory, and no directory names
+// absence. Without it a session handed a project once keeps it for the rest of
+// its life, because every later flagless verb inherits it.
+func TestNoProjectDropsTheRememberedOne(t *testing.T) {
+	dir := isolateState(t)
+	home := t.TempDir()
+	project := filepath.Join(t.TempDir(), "myproject")
+	mustMkdir(t, project)
+
+	mustLoad(t, Options{Workspace: home, Project: project}).rememberSession()
+
+	next := mustLoad(t, Options{NoProject: true})
+	if next.Project != "" || next.GuestProject != "" {
+		t.Errorf("--no-project kept project %q (guest %q)", next.Project, next.GuestProject)
+	}
+	// Back to the home, which is where a run with no project has always
+	// started.
+	if next.GuestCwd != next.Profile.GuestHome {
+		t.Errorf("--no-project left the cwd at %q, want the guest home %q",
+			next.GuestCwd, next.Profile.GuestHome)
+	}
+	// The running sandbox is still carrying the mount this run does not want,
+	// so it has to be rebuilt -- projectShareStale's c.Project == "" branch,
+	// reached deliberately rather than by an invocation that said nothing.
+	if next.projectShareStale() == "" {
+		t.Error("--no-project left the sandbox with its project mount standing")
+	}
+	// And the entry loses the key, so the detach outlives this one command.
+	next.rememberSession()
+	if blob := mustReadIndex(t, dir); strings.Contains(blob, `"project"`) {
+		t.Errorf("--no-project left the project in the index:\n%s", blob)
+	}
+}
+
+// The detach sticks: the flagless verb after it inherits nothing. This is the
+// pair to TestAProjectGivenOnceIsFoundAgainWithoutThePositional -- one proves
+// the project survives an invocation that says nothing, the other that it stays
+// gone once it has been dropped.
+func TestAFlaglessVerbAfterNoProjectInheritsNothing(t *testing.T) {
+	isolateState(t)
+	home := t.TempDir()
+	project := filepath.Join(t.TempDir(), "myproject")
+	mustMkdir(t, project)
+
+	mustLoad(t, Options{Workspace: home, Project: project}).rememberSession()
+	mustLoad(t, Options{NoProject: true}).rememberSession()
+
+	next := mustLoad(t, Options{})
+	if next.Project != "" {
+		t.Errorf("a flagless verb resurrected the project %q", next.Project)
+	}
+	if stale := next.projectShareStale(); stale != "" {
+		t.Errorf("a flagless verb after a detach read the sandbox as stale: %s", stale)
+	}
+}
+
+// A session that never had a project is unaffected, so the flag is a no-op
+// rather than an error where there is nothing to detach.
+func TestNoProjectOnASessionWithoutOneChangesNothing(t *testing.T) {
+	isolateState(t)
+	home := t.TempDir()
+
+	plain := mustLoad(t, Options{Workspace: home})
+	with := mustLoad(t, Options{Workspace: home, NoProject: true})
+
+	if with.Project != plain.Project || with.GuestCwd != plain.GuestCwd {
+		t.Errorf("--no-project changed a project-less run: project %q cwd %q, want %q and %q",
+			with.Project, with.GuestCwd, plain.Project, plain.GuestCwd)
+	}
+}

--- a/internal/wrap/run.go
+++ b/internal/wrap/run.go
@@ -512,9 +512,19 @@ func (c *Config) shares(home string, volumes []runtime.Share) []runtime.Share {
 // is the safe direction: it recreates a sandbox that might have been fine
 // rather than running an agent in a directory nothing mounted.
 //
-// Both directions are stale. A run that names no project against a sandbox
-// that has one has to lose the mount, or the agent would keep a host directory
-// this line said nothing about.
+// So what reaches here as a change is a user asking for a different directory,
+// which is a request rather than an accident, and restart and all is what they
+// asked for.
+//
+// The c.Project == "" branch is not how a flagless verb arrives. Load reads the
+// remembered project back when the invocation names none, exactly as it does
+// for the home, so `brig sh claude@x` carries the project the session was
+// started with and compares equal here. The branch is still reached, and still
+// right, in the two cases where nothing establishes that the sandbox has the
+// mount: an index entry that is missing or unusable, and a remembered project
+// that has since gone off disk. Asking for no project is not expressible on a
+// line today -- there is no flag for it -- which is a gap and not this branch's
+// job to fill.
 func (c *Config) projectShareStale() string {
 	was := rememberedProject(sessionKey(c.Profile.Name, c.Slug), c.VMName)
 	switch {

--- a/internal/wrap/run.go
+++ b/internal/wrap/run.go
@@ -224,7 +224,22 @@ func (c *Config) EnsureRunning(set creds.Set) error {
 			"refusing to start a second one over it: %w", c.VMName, err)
 	}
 	if running {
-		if c.guestMountsWorkspace() {
+		// Two things can be wrong with the mounts of a sandbox that is up, and
+		// both are answered the same way, so they share the one recreate below
+		// rather than growing a second path: a share is bound at boot and
+		// cannot be changed on a live guest, whichever of the two moved.
+		//
+		// Recreate rather than fail: all persistent state lives in the
+		// workspace on the host, so restarting costs nothing but the boot.
+		switch stale := c.projectShareStale(); {
+		case !c.guestMountsWorkspace():
+			c.warnf("the running sandbox is not mounting %s -- its share went stale (the "+
+				"directory was renamed or replaced, or the workspace changed). Restarting "+
+				"it; any other session using this sandbox will be disconnected.", c.Workspace)
+		case stale != "":
+			c.warnf("%s. A share cannot be attached to a live sandbox, so it is being "+
+				"restarted; any other session using this sandbox will be disconnected.", stale)
+		default:
 			// The guest has confirmed this workspace, so record it. Nothing has
 			// changed for a session brig already knows about; for one created
 			// before the index existed, this is where its entry appears.
@@ -241,11 +256,6 @@ func (c *Config) EnsureRunning(set creds.Set) error {
 			// credential reaches a live session.
 			return c.deliverSecretFiles()
 		}
-		// Recreate rather than fail: all persistent state lives in the
-		// workspace on the host, so restarting costs nothing but the boot.
-		c.warnf("the running sandbox is not mounting %s -- its share went stale (the "+
-			"directory was renamed or replaced, or the workspace changed). Restarting "+
-			"it; any other session using this sandbox will be disconnected.", c.Workspace)
 		_ = c.Runtime.Stop(c.VMName)
 		_ = c.Runtime.Remove(c.VMName)
 	}
@@ -306,12 +316,12 @@ func (c *Config) EnsureRunning(set creds.Set) error {
 		Net:    c.Network.RuntimeNet(),
 		Mem:    c.Mem,
 		CPUs:   c.CPUs,
-		// The workspace, which is the guest's home. The host's agent
-		// configuration is copied into it rather than mounted, so it needs no
-		// share of its own -- see seedHostConfig. volumeShares is empty on
-		// hull and carries the profile's hostmounts on a container runtime.
-		Shares: append([]runtime.Share{{Host: ws.dir, Guest: c.Profile.GuestHome}},
-			volumeShares...),
+		// The workspace first, which is the guest's home, then this run's
+		// project if it named one. The host's agent configuration is copied
+		// into the workspace rather than mounted, so it needs no share of its
+		// own -- see seedHostConfig. volumeShares is empty on hull and carries
+		// the profile's hostmounts on a container runtime.
+		Shares:   c.shares(ws.dir, volumeShares),
 		Tmpfs:    tmpfs,
 		Env:      set.Vars,
 		GUI:      c.Profile.IsGUI(),
@@ -466,6 +476,59 @@ func (c *Config) guestMountsWorkspace() bool {
 		return false
 	}
 	return strings.TrimSpace(seen) == strings.TrimSpace(string(want))
+}
+
+// shares is the mount set this run hands the runtime: the guest home, the
+// project when there is one, then whatever the profile's volumes need on a
+// runtime that cannot mount after boot.
+//
+// The home is first and unconditional. It is what makes the session the
+// session -- the stale-share check reads its marker back out of it, and the
+// smoke test reads the first share as the home -- so a project arrives after
+// it rather than in front of it or instead of it.
+//
+// The home's host path comes from the caller rather than from c.Workspace: it
+// is the path re-resolved through a held directory handle just above, which is
+// the whole point of holding one. The project has no such handle. It is a
+// directory the user named on this command line, not one brig created and the
+// guest has had read-write for however long the sandbox has been up, so the
+// swap the workspace check defends against has nobody to do it.
+func (c *Config) shares(home string, volumes []runtime.Share) []runtime.Share {
+	shares := []runtime.Share{{Host: home, Guest: c.Profile.GuestHome}}
+	if c.Project != "" {
+		shares = append(shares, runtime.Share{Host: c.Project, Guest: c.GuestProject})
+	}
+	return append(shares, volumes...)
+}
+
+// projectShareStale says why the running sandbox cannot carry this run's
+// project, or "" when it can.
+//
+// The comparison is against the index rather than against the guest, and the
+// guest could not answer it anyway: a different project is mounted at a
+// different guest path, so there is nothing to ask about by name. The index
+// records the project a session last ran with for exactly this read -- see
+// sessionEntry -- and an absent or unusable entry reads as "no project", which
+// is the safe direction: it recreates a sandbox that might have been fine
+// rather than running an agent in a directory nothing mounted.
+//
+// Both directions are stale. A run that names no project against a sandbox
+// that has one has to lose the mount, or the agent would keep a host directory
+// this line said nothing about.
+func (c *Config) projectShareStale() string {
+	was := rememberedProject(sessionKey(c.Profile.Name, c.Slug), c.VMName)
+	switch {
+	case was == c.Project:
+		return ""
+	case c.Project == "":
+		return fmt.Sprintf("the running sandbox has %s mounted as its project and this "+
+			"run names none", was)
+	case was == "":
+		return fmt.Sprintf("the running sandbox has no project mounted and this run "+
+			"names %s", c.Project)
+	}
+	return fmt.Sprintf("the running sandbox has %s mounted as its project and this run "+
+		"names %s", was, c.Project)
 }
 
 // Stop shuts the sandbox down and leaves it there.

--- a/internal/wrap/running_test.go
+++ b/internal/wrap/running_test.go
@@ -24,18 +24,25 @@ type livenessRuntime struct {
 	// workspace is the directory the guest is pretending to mount, so Output
 	// can read back the marker brig wrote there.
 	workspace string
-	boots     int
-	stops     int
-	removes   int
+	// spec is the last boot request, for the cases that ask what brig handed
+	// the runtime rather than only whether it booted at all.
+	spec    runtime.RunSpec
+	boots   int
+	stops   int
+	removes int
 }
 
 func (r *livenessRuntime) Kind() string                 { return "hull" }
 func (r *livenessRuntime) Running(string) (bool, error) { return r.running, r.runningErr }
 func (r *livenessRuntime) Stop(string) error            { r.stops++; return nil }
 func (r *livenessRuntime) Remove(string) error          { r.removes++; return nil }
-func (r *livenessRuntime) Run(runtime.RunSpec) error    { r.boots++; return nil }
-func (r *livenessRuntime) Probe(runtime.ExecSpec) bool  { return true }
-func (r *livenessRuntime) LogsHint(name string) string  { return "hull logs " + name }
+func (r *livenessRuntime) Run(spec runtime.RunSpec) error {
+	r.spec = spec
+	r.boots++
+	return nil
+}
+func (r *livenessRuntime) Probe(runtime.ExecSpec) bool { return true }
+func (r *livenessRuntime) LogsHint(name string) string { return "hull logs " + name }
 
 // Output stands in for the guest reading its own home: a guest that mounts the
 // workspace reads back the marker brig put there.

--- a/internal/wrap/workspace.go
+++ b/internal/wrap/workspace.go
@@ -197,6 +197,27 @@ func TrustKey(cwd, workspace, guestHome string) string {
 	return guestCwd
 }
 
+// trustKey is the directory this run has to pre-trust: the guest path the
+// agent will actually be in.
+//
+// With a project mounted that is the project, not anything under the home.
+// Otherwise the agent starts in /work/<basename> and asks whether you trust a
+// directory brig just handed it, which is the one thing this seeding exists to
+// prevent.
+//
+// The project is passed as its own workspace, because to the guest that is what
+// it is: /work/<basename> is the mount, and nothing above it is visible in
+// there. So the repository walk has no room to move -- the same reason the
+// home's walk stops at the workspace -- and the key is the project's guest
+// path whether or not it is a git repository. Routed through TrustKey anyway,
+// so one function decides what a trust key is.
+func (c *Config) trustKey() string {
+	if c.Project != "" {
+		return TrustKey(c.Project, c.Project, c.GuestProject)
+	}
+	return TrustKey(c.Cwd, c.Workspace, c.Profile.GuestHome)
+}
+
 func under(cwd, workspace string) bool {
 	rel, err := filepath.Rel(workspace, cwd)
 	if err != nil {
@@ -241,7 +262,7 @@ func (c *Config) trustGuestCwd(r *workspaceRoot) error {
 		return nil // nothing to edit; the agent creates it on first run
 	}
 
-	key := TrustKey(c.Cwd, c.Workspace, c.Profile.GuestHome)
+	key := c.trustKey()
 
 	// UseNumber keeps every number exactly as written. Decoding into float64
 	// would round-trip a millisecond timestamp as 1.7e+12 and quietly rewrite

--- a/script/smoke.sh
+++ b/script/smoke.sh
@@ -347,6 +347,57 @@ grep -q -- '-- bash -lc echo hi' "$STUB_LOG" \
 grep -q 'project directory this run mounts' "$WORK/shproj.err" \
   && bad "sh warned about its own guest command" \
   || ok "sh says nothing about its guest command"
+
+# The project is inherited by a verb that names none, the way the home already
+# is. Reading that silence as "no project" is what real-runtime testing caught:
+# `brig sh <ref>` after a run with a project stopped, removed and recreated the
+# sandbox without the mount, taking the guest's memory-only state with it and
+# overwriting the index entry that recorded the project.
+#
+# Driven on the ubuntu profile, which delivers no credential files and so
+# reaches the guest exec on any host -- which is what makes the working
+# directory assertable rather than only the boot.
+"$WORK/brig" rm --all > /dev/null 2>&1
+: > "$STUB_LOG"
+"$WORK/brig" run ubuntu "$PROJ" -- pwd > /dev/null 2>&1
+grep -q -- "--shared-dir $PROJ:/work/myproject" "$STUB_LOG" \
+  && ok "a shell profile takes a project too" \
+  || bad "a shell profile takes a project too -- got: $(grep '^argv: run' "$STUB_LOG")"
+grep -q -- '--cwd /work/myproject' "$STUB_LOG" \
+  && ok "the run starts in the project" \
+  || bad "the run starts in the project -- got: $(grep '^argv: exec' "$STUB_LOG" | tail -1)"
+
+: > "$STUB_LOG"
+"$WORK/brig" sh ubuntu -- pwd > /dev/null 2>&1
+grep -q '^argv: run ' "$STUB_LOG" \
+  && bad "a flagless sh recreated the sandbox" \
+  || ok "a flagless sh keeps the sandbox it was given"
+grep -q -- '--cwd /work/myproject' "$STUB_LOG" \
+  && ok "a flagless sh inherits the project" \
+  || bad "a flagless sh inherits the project -- got: $(grep '^argv: exec' "$STUB_LOG" | tail -1)"
+grep -q "\"project\": \"$PROJ\"" "$BRIG_STATE_DIR/sessions.json" \
+  && ok "the index keeps the project across a flagless verb" \
+  || bad "the index keeps the project -- got: $(cat "$BRIG_STATE_DIR/sessions.json" 2>&1)"
+
+: > "$STUB_LOG"
+"$WORK/brig" run ubuntu -- pwd > /dev/null 2>&1
+grep -q '^argv: run ' "$STUB_LOG" \
+  && bad "a flagless run recreated the sandbox" \
+  || ok "a flagless run keeps the sandbox it was given"
+grep -q -- '--cwd /work/myproject' "$STUB_LOG" \
+  && ok "a flagless run inherits the project" \
+  || bad "a flagless run inherits the project -- got: $(grep '^argv: exec' "$STUB_LOG" | tail -1)"
+
+# Naming a different one is a request rather than an accident, so it still
+# recreates -- inheritance is only about a line that named nothing.
+: > "$STUB_LOG"
+"$WORK/brig" run ubuntu "$OTHER" -- pwd > /dev/null 2>&1
+grep -q '^argv: run ' "$STUB_LOG" \
+  && ok "a different project still recreates the sandbox" \
+  || bad "a different project still recreates the sandbox"
+grep -q -- '--cwd /work/otherproject' "$STUB_LOG" \
+  && ok "the recreated sandbox starts in the new project" \
+  || bad "the recreated sandbox starts in the new project -- got: $(grep '^argv: exec' "$STUB_LOG" | tail -1)"
 "$WORK/brig" rm --all > /dev/null 2>&1
 
 echo "== the home flag =="

--- a/script/smoke.sh
+++ b/script/smoke.sh
@@ -47,11 +47,19 @@ case "$verb" in
   run)
     # Remember the instance name and the shared directory the way a real
     # runtime binds them at boot.
+    #
+    # Every share is logged, and the FIRST one is the home: brig puts the
+    # workspace first and a project after it, and it is the home the marker is
+    # read back out of below.
     name=""; share=""
+    : > "$STUB_STATE.shares"
     while [ $# -gt 0 ]; do
       case "$1" in
         --name) name="$2"; shift 2 ;;
-        --shared-dir) share="$2"; shift 2 ;;
+        --shared-dir)
+          printf '%s\n' "$2" >> "$STUB_STATE.shares"
+          [ -z "$share" ] && share="$2"
+          shift 2 ;;
         *) shift ;;
       esac
     done
@@ -238,6 +246,136 @@ CLAUDE_CODE_OAUTH_TOKEN=env-token-secret "$WORK/brig" run claude -p again \
 grep -q '^argv: run ' "$STUB_LOG" \
   && bad "a second run booted a second sandbox" \
   || ok "a running sandbox is reused, not rebooted"
+
+echo "== project =="
+# The positional: `brig run <ref> <project>` mounts that directory at
+# /work/<basename>, OUTSIDE the guest home, and starts the agent in it. Outside
+# is the property that matters -- the home is the agent's home, dotfiles and
+# state included, and a project under it could be mistaken for either.
+"$WORK/brig" rm --all > /dev/null 2>&1
+PROJ="$WORK/myproject"
+mkdir -p "$PROJ"
+: > "$STUB_LOG"
+CLAUDE_CODE_OAUTH_TOKEN=env-token-secret \
+  "$WORK/brig" run claude "$PROJ" -p hi > "$WORK/proj.out" 2> "$WORK/proj.err"
+rc=$?
+[ "$rc" = 0 ] && ok "a run with a project exits 0" \
+  || bad "a run with a project exits 0 -- got $rc: $(cat "$WORK/proj.err")"
+grep -q -- "--shared-dir $PROJ:/work/myproject" "$STUB_LOG" \
+  && ok "the project is mounted at /work/<basename>" \
+  || bad "the project is mounted at /work/<basename> -- got: $(grep '^argv: run' "$STUB_LOG")"
+grep -q -- "--shared-dir $WS:/home/claude" "$STUB_LOG" \
+  && ok "the home share is unchanged by a project" \
+  || bad "the home share is unchanged by a project -- got: $(grep '^argv: run' "$STUB_LOG")"
+grep -q -- '--cwd /work/myproject' "$STUB_LOG" \
+  && ok "the agent starts in the project" \
+  || bad "the agent starts in the project -- got: $(grep '^argv: exec' "$STUB_LOG" | tail -1)"
+grep -q -- '-- claude -p hi' "$STUB_LOG" \
+  && ok "agent arguments still pass through beside a project" \
+  || bad "agent arguments still pass through beside a project"
+grep -q "^PROJECT .*myproject (read-write, mounted at /work/myproject)" "$WORK/proj.err" \
+  && ok "the envelope names the project" \
+  || bad "the envelope names the project -- got: $(cat "$WORK/proj.err")"
+grep -q "\"project\": \"$PROJ\"" "$BRIG_STATE_DIR/sessions.json" \
+  && ok "the index records the project the session ran with" \
+  || bad "the index records the project -- got: $(cat "$BRIG_STATE_DIR/sessions.json" 2>&1)"
+
+# The one-release warning. That word used to reach the AGENT, so giving it a
+# new meaning is a breaking change, and the notice names both readings so
+# somebody can pick the one they meant before it goes.
+grep -q 'project directory this run mounts' "$WORK/proj.err" \
+  && ok "a second bare word says what it now means" \
+  || bad "a second bare word says what it now means -- got: $(cat "$WORK/proj.err")"
+grep -q -- 'put it after --' "$WORK/proj.err" \
+  && ok "the notice names the way to keep the old reading" \
+  || bad "the notice names the way to keep the old reading"
+
+# A share is bound at boot and cannot be attached to a live sandbox, so the
+# same project reuses the sandbox and a different one recreates it.
+: > "$STUB_LOG"
+CLAUDE_CODE_OAUTH_TOKEN=env-token-secret \
+  "$WORK/brig" run claude "$PROJ" -p again > /dev/null 2>&1
+grep -q '^argv: run ' "$STUB_LOG" \
+  && bad "the same project restarted the sandbox" \
+  || ok "the same project reuses the sandbox"
+OTHER="$WORK/otherproject"
+mkdir -p "$OTHER"
+: > "$STUB_LOG"
+CLAUDE_CODE_OAUTH_TOKEN=env-token-secret \
+  "$WORK/brig" run claude "$OTHER" -p again > /dev/null 2> "$WORK/reproj.err"
+grep -q '^argv: run ' "$STUB_LOG" \
+  && ok "a different project recreates the sandbox" \
+  || bad "a different project recreates the sandbox -- got: $(cat "$WORK/reproj.err")"
+grep -q -- "--shared-dir $OTHER:/work/otherproject" "$STUB_LOG" \
+  && ok "the recreated sandbox mounts the new project" \
+  || bad "the recreated sandbox mounts the new project -- got: $(grep '^argv: run' "$STUB_LOG")"
+
+# And after an explicit -- there is nothing to point out: the line said the
+# word is the agent's, and it still reaches the agent untouched. This run names
+# no project, so it recreates the sandbox the block above left mounting one --
+# which is the same rule, read in the other direction.
+: > "$STUB_LOG"
+CLAUDE_CODE_OAUTH_TOKEN=env-token-secret \
+  "$WORK/brig" run claude --quiet -- --version > /dev/null 2> "$WORK/dashdash.err"
+grep -q 'project directory this run mounts' "$WORK/dashdash.err" \
+  && bad "a tail after -- was warned about -- got: $(cat "$WORK/dashdash.err")" \
+  || ok "a tail after -- is not warned about"
+grep -q -- '-- claude --version' "$STUB_LOG" \
+  && ok "a word after -- still reaches the agent" \
+  || bad "a word after -- still reaches the agent -- got: $(grep '^argv: exec' "$STUB_LOG" | tail -1)"
+
+# A word that names no directory is refused rather than mounted, and the
+# refusal carries the way past it. This is the line the grammar change breaks,
+# so it has to fail loudly instead of booting something odd.
+out="$("$WORK/brig" run claude notadirectory -p hi 2>&1)"; rc=$?
+[ "$rc" != 0 ] && ok "a project that is not a directory refuses the run" \
+  || bad "a project that is not a directory started anyway: $out"
+case "$out" in
+  *"put it after --"*) ok "the refusal names the way past it" ;;
+  *) bad "the refusal names the way past it -- got: $out" ;;
+esac
+
+# sh takes no positional: a second bare word there is already the guest
+# command, and this change must not take it away.
+"$WORK/brig" rm --all > /dev/null 2>&1
+"$WORK/brig" run claude -d > /dev/null 2>&1
+: > "$STUB_LOG"
+"$WORK/brig" sh claude echo hi > /dev/null 2> "$WORK/shproj.err"
+grep -q -- '-- bash -lc echo hi' "$STUB_LOG" \
+  && ok "sh still reads a second bare word as the guest command" \
+  || bad "sh still reads a second bare word as the guest command -- got: $(grep '^argv: exec' "$STUB_LOG" | tail -1)"
+grep -q 'project directory this run mounts' "$WORK/shproj.err" \
+  && bad "sh warned about its own guest command" \
+  || ok "sh says nothing about its guest command"
+"$WORK/brig" rm --all > /dev/null 2>&1
+
+echo "== the home flag =="
+# --home is what sets the guest home now. -w and --workspace keep working and
+# each say the one word that replaces them: a line that works today has to keep
+# working, and a spelling that works silently never teaches anyone the new one.
+HOMEDIR="$WORK/named-home"
+: > "$STUB_LOG"
+env -u BRIG_WORKSPACE "$WORK/brig" run claude --home "$HOMEDIR" -d \
+  > /dev/null 2> "$WORK/home.err"
+grep -q -- "--shared-dir $HOMEDIR:/home/claude" "$STUB_LOG" \
+  && ok "--home is mounted as the guest home" \
+  || bad "--home is mounted as the guest home -- got: $(grep '^argv: run' "$STUB_LOG")"
+grep -q 'is now' "$WORK/home.err" \
+  && bad "--home printed a deprecation notice -- got: $(cat "$WORK/home.err")" \
+  || ok "--home prints no notice"
+"$WORK/brig" rm --all > /dev/null 2>&1
+for spelling in -w --workspace; do
+  : > "$STUB_LOG"
+  env -u BRIG_WORKSPACE "$WORK/brig" run claude "$spelling" "$HOMEDIR" -d \
+    > /dev/null 2> "$WORK/oldhome.err"
+  grep -q -- "--shared-dir $HOMEDIR:/home/claude" "$STUB_LOG" \
+    && ok "$spelling still sets the guest home" \
+    || bad "$spelling still sets the guest home -- got: $(grep '^argv: run' "$STUB_LOG")"
+  grep -q "is now \`--home\`" "$WORK/oldhome.err" \
+    && ok "$spelling names --home as its replacement" \
+    || bad "$spelling names --home -- got: $(cat "$WORK/oldhome.err")"
+  "$WORK/brig" rm --all > /dev/null 2>&1
+done
 
 echo "== network =="
 # The posture the run resolved to is the posture the runtime is told about.
@@ -894,8 +1032,11 @@ grep -q 'ghcr.io/me/img:latest' "$STUB_LOG" \
 "$WORK/brig" rm --all > /dev/null 2>&1
 
 echo "== ubuntu =="
+# The command goes after --, because run's second bare word is the project
+# directory now: for a shell profile the trailing words are the guest command,
+# and -- is what still says so.
 : > "$STUB_LOG"
-"$WORK/brig" run ubuntu uname -a > /dev/null 2>&1
+"$WORK/brig" run ubuntu -- uname -a > /dev/null 2>&1
 grep -q -- '-- bash -lc uname -a' "$STUB_LOG" \
   && ok "a shell profile runs the command in a shell" \
   || bad "a shell profile runs the command in a shell"


### PR DESCRIPTION
## Summary

`cd ~/src/myproject && brig run claude .` did not do what it looks like: `.` reached the agent as its
first argument. This makes it the project directory.

The reason it was not simply the workspace: the workspace **is** the guest's home, so pointing it at
a repository would put the agent's dotfiles in that repository. #47 rejected a positional home for
that reason. This adds a second mount instead — the home stays brig-owned, the project mounts beside
it, and the agent starts in the project.

## Related issues

Fixes #6. Part of #47. **Stacked on #120** — base `feat/114-drop-slug-cap`.
Merge order: #113, #115, #117, #118, #119, #120, this.

#6 and #47 were never in conflict; they argued about two different mounts. That is recorded in a
comment on the issue.

## Changes

- `brig run <ref> [project] [agent args...]`. `run` only — `sh` gets no positional, since a second
  bare word there is already the guest command.
- The project mounts at `/work/<basename>`, **outside every profile's `GuestHome`**
  (`/home/claude`, `/home/codex`, `/root/work`). That layout is the guarantee: a project cannot be
  mistaken for home state or collide with the agent's dotfiles, by construction rather than
  convention. Basename rather than the full path so the agent's prompt names the project the way its
  owner does.
- `GuestCwd` points at the project. The cwd-under-home derivation is untouched when no positional is
  given.
- `--home PATH` for the guest home. `-w` and `--workspace` keep working and print a notice.
- Running the same ref with a different project recreates the sandbox, reusing `EnsureRunning`'s
  existing stale-share path. Shares are `--shared-dir` arguments to `hull run` and the `Runtime`
  interface has no add-share method, so a project cannot be attached to a live sandbox. Recreating is
  cheap because the home is a host directory that survives it.
- The trust key is computed for the project path when one is mounted. `trustGuestCwd` pre-trusts the
  directory the agent starts in; without this the agent would start in `/work/<basename>` and prompt
  for trust on a directory brig had just handed it. Git identity does not move — it writes
  git-over-HTTPS files into the guest home, which is global config, not per-repository.
- `sessionEntry` gains `Project string \`json:"project,omitempty"\``, the field #109 deferred here.
  `omitempty` because it records the project a session last ran with rather than part of its
  identity; the identity is the ref, which is the home.
- The envelope names the project: `PROJECT  <path> (read-write, mounted at /work/<basename>)`.

### The one-release notice, and its cost

A bare word after the ref previously ended brig's parsing and reached the agent, so this reassigns
that word. The notice names both readings and points at `--`:

```
brig: `<path>` is now the project directory this run mounts, and brig starts the agent
in it. It used to be the agent's first argument instead. If that is what you meant, put
it after --: `brig run <ref> -- <path>`. This notice goes in the next release.
```

**It fires on every positional use, including intended ones.** The two readings are syntactically
identical, and #6 rejected the alternative of deciding by whether the word names an existing
directory — that makes an argument's meaning depend on the filesystem, which is hard to explain and
hard to script. So the new feature nags for one release. That is the accepted cost of not silently
changing what an existing command line does.

`brig run <ref> -- <word>` is silent and still passes the word to the agent.

### One existing command line broke, and it is in this repo

`script/smoke.sh` drove `brig run ubuntu uname -a`, which now reads `uname` as the project and
refuses the run. Changed to `brig run ubuntu -- uname -a` — same assertion text, corrected command.
This is exactly the break the notice exists for.

I scanned `README.md` and `docs/*.md` for the same shape. No documented example breaks: every
`brig run <agent> <word>` hit is `brig run <agent>` followed by a `#` comment, which is not an
argument.

## Testing

`script/smoke.sh`: 225 → 244 passing. FAIL 11 → 16.

**No regressions**: the set of assertions that passed on the parent and fail here is empty,
verified with `comm` in both directions. The suite passes in CI (`ci.yml:62`).

The 5 additional FAIL lines are new assertions added by this change, and all five need an exec
inside the guest — which the stub runtime cannot complete, on the parent commit as much as here.
CI is where they are actually exercised, and it is green.

The 19 new passing assertions cover both shares, the index entry, the notice and its absence after
`--`, reuse on the same project, recreate on a different one, the refusal of a non-directory,
`--home`, and the `-w`/`--workspace` notices.

Unit: `internal/wrap/project_test.go` (291), `cmd/brig/project_test.go` (135), plus additions to
`running_test.go` and `main_test.go`. The regression test that matters most is
`TestLoadWithoutAProjectIsUnchanged` — with no positional, the mount set and `GuestCwd` are as
before.

## Manual testing

Against a real runtime, on the `ubuntu` profile: it is `kind: shell`, its guest home is
`/root/work`, and it declares no credential files, so nothing here depends on a configured agent.

```bash
make build

export BRIG=./brig
mkdir -p /tmp/rtproj /tmp/other
git -C /tmp/rtproj init -q
echo marker > /tmp/rtproj/marker.txt
echo other  > /tmp/other/other.txt
```

**1. The mount layout.** The guest home stays brig's own; the project mounts beside it.

```bash
$BRIG run -d ubuntu@rt /tmp/rtproj
$BRIG sh ubuntu@rt ls -a /work/rtproj      # marker.txt and .git
$BRIG sh ubuntu@rt ls -a /root/work        # the guest home, no marker.txt
ls -a /tmp/rtproj                          # unchanged: no dotfile, nothing added
```

That last line is the point of the design. If a dotfile appears in `/tmp/rtproj`, the mount is
wrong however well the rest behaves.

**2. The envelope names both.**

```bash
$BRIG info ubuntu@rt
```

A `PROJECT` line giving the host path, `/work/rtproj`, and `read-write`, beside the `WORKSPACE`
line for the home.

**3. A verb that names no project inherits it.** This is the case a stub cannot reach, and the one
that was wrong until `a60b575`.

```bash
$BRIG sh ubuntu@rt pwd            # /work/rtproj
cat ~/.brig/sessions.json         # the entry still carries "project"
$BRIG ls                          # still running: no restart happened
$BRIG sh ubuntu@rt                # a login shell, also in /work/rtproj
```

Before the fix the first line printed the guest home, because the flagless verb tore the sandbox
down and rebuilt it without the mount. The index key is the better signal: it was being dropped,
which lost the mount for every later command too.

**4. Arguments pass through beside a project.**

```bash
$BRIG run ubuntu@rt /tmp/rtproj 'pwd; ls -a'
```

`/work/rtproj` and its contents. No `--` and no `-lc`: brig wraps a `kind: shell` tail as
`bash -lc <tail>` already, so the whole script goes as one quoted argument.

**5. The one-release notice.** Every command above that named a positional printed it. It fires on
every positional use, not only on the old meaning — brig cannot tell "mount this" from "pass this
to the agent", they are the same syntax, and deciding by whether the word names an existing
directory would make an argument's meaning depend on the filesystem.

```bash
$BRIG run ubuntu@rt -- 'echo an-argument-not-a-project'
```

Silent, and the string reaches the guest: after an explicit `--` the line has already said the
rest is the agent's.

**6. A different project recreates; the same one does not.**

```bash
$BRIG run -d ubuntu@rt /tmp/other     # warns that it is restarting
$BRIG sh ubuntu@rt pwd                # /work/other
$BRIG sh ubuntu@rt ls /work/other     # other.txt
$BRIG run -d ubuntu@rt /tmp/other     # same project: no restart
```

A share cannot be attached to a live sandbox, so a different project means a rebuild. The
workspace survives on the host; the guest's memory-only state does not.

**7. `--no-project` detaches, and the detach sticks.**

```bash
$BRIG run -d --no-project ubuntu@rt
$BRIG sh ubuntu@rt pwd            # /root/work
$BRIG sh ubuntu@rt ls /work       # empty or absent: the mount is gone
cat ~/.brig/sessions.json         # no "project" key for ubuntu@rt
$BRIG sh ubuntu@rt pwd            # still /root/work, one command later
```

**8. The two refusals.** Both exit 1 rather than picking a winner.

```bash
$BRIG run --no-project ubuntu@rt /tmp/rtproj    # names both the flag and the directory
$BRIG sh --no-project ubuntu@rt                 # --no-project belongs to `brig run`
```

**9. A session with no project is unchanged.** This is the regression guard for every existing
invocation.

```bash
$BRIG run -d ubuntu@plain
$BRIG sh ubuntu@plain pwd         # /root/work
$BRIG info ubuntu@plain           # no PROJECT line
cat ~/.brig/sessions.json         # no "project" key for ubuntu@plain
```

No positional notice either.

**10. The line the feature exists for.**

```bash
cd /tmp/rtproj
$BRIG run -d ubuntu@dot .
$BRIG sh ubuntu@dot pwd           # /work/rtproj
$BRIG sh ubuntu@dot ls            # marker.txt
```

The basename, resolved from `.` against the directory the command ran in.

**Cleanup.**

```bash
$BRIG rm ubuntu@rt ; $BRIG rm ubuntu@plain ; $BRIG rm ubuntu@dot
$BRIG ls                          # empty
rm -rf ~/brig/ubuntu-rt ~/brig/ubuntu-plain ~/brig/ubuntu-dot /tmp/rtproj /tmp/other
```

## Checklist

- [x] `make all` passes (vet, test, build)
- [x] `script/smoke.sh` passes
- [x] I have added or updated tests covering the change
- [x] I have run `go test ./... -race`, if the change touches concurrency, subprocesses or the daemon
- [ ] I have exercised the change against a real runtime (`brig run <agent>`), if it touches the run, exec or credential path
- [x] I have updated the affected docs (README, `docs/security.md`, `docs/profiles.md`, `docs/brigd.md`)

`script/smoke.sh` is ticked on CI. Locally 16 fail, of which 11 predate the branch and 5 are new
assertions blocked by the same host condition; no assertion that passed on the parent fails here.

Real runtime: not booted. Exercised against the stub, which covers the whole path except the VM.
This one is worth a real boot before merge more than the others in the stack, because it adds a mount.

Docs: README teaches the positional and `--home`. The structural rewrite is #111.

## Credentials and the sandbox boundary

**This widens what the guest can see, and that is the point of the change.** Until now a sandbox saw
one host directory: its home. It now sees a second, the project, read-write.

- It is mounted only when named. No positional, no second mount — asserted by
  `TestLoadWithoutAProjectIsUnchanged`.
- It is mounted at `/work/<basename>`, outside `GuestHome`, so it cannot shadow or be shadowed by
  home state.
- The trust key moves with the guest cwd, so brig is not pre-trusting a directory other than the one
  the agent is actually started in.
- No new forwarded variable, and no change to credential resolution or delivery.

`docs/security.md` describes the boundary as one directory. That sentence is now incomplete; #111
owns the rewrite and this PR does not touch it.

## LLM usage

Authored with assistance from Claude Code (Opus 5). Verification re-run independently of the agent
that wrote the change: `gofmt`, `make all`, the smoke sets diffed against `db5415a` in both
directions with `comm`, the notice and its absence after `--` probed against the built binary, and
`README.md` plus `docs/*.md` scanned for command lines the new grammar would break.

`Fixes: #6` sits on the first commit rather than the last; GitHub closes the issue on merge either
way. All three commits are unsigned — SSH signing does not work non-interactively in the environment
they were produced in. The `main` ruleset does not require signatures.

