### PR TITLE
test(smoke): make the smoke test pass on a developer's machine

### DIFF
--- a/script/smoke.sh
+++ b/script/smoke.sh
@@ -95,8 +95,23 @@ case "$verb" in
         # `stat -f -c %T <path>` asks what a path sits on; `stat -c ...` asks
         # about the file itself.
         if [ "${2:-}" = -f ]; then
+          # A path inherits the filesystem of the nearest mount point above
+          # it, so walk up until one matches rather than asking only about the
+          # path itself: a credential file created inside a tmpfs has no mount
+          # entry of its own, and answering virtiofs for it is a fstype the
+          # guest would never report. Match on field 5, the mount point --
+          # field 4 is the mount's root and reads `/` on every line, so a
+          # looser match answers for a path under no mount at all.
           target="${5:-}"
-          line=$(grep " $target " "$STUB_STATE.mounts" 2>/dev/null | tail -1)
+          line=""
+          probe="$target"
+          while [ -n "$probe" ]; do
+            line=$(awk -v p="$probe" '$5 == p' "$STUB_STATE.mounts" 2>/dev/null | tail -1)
+            [ -n "$line" ] && break
+            [ "$probe" = / ] && break
+            probe="${probe%/*}"
+            [ -z "$probe" ] && probe=/
+          done
           case "$line" in
             *tmpfs) printf 'tmpfs\n' ;;
             *fuseblk) printf 'fuseblk\n' ;;

--- a/script/smoke.sh
+++ b/script/smoke.sh
@@ -10,6 +10,17 @@
 set -uo pipefail
 cd "$(dirname "$0")/.."
 
+# Nothing here is answered by a person. Several cases assert the outcome brig
+# reaches when it has nobody to ask -- a bad signature refused, a profile rm
+# that will not guess -- and brig decides that by looking at its own stdin.
+# `out="$(brig ... 2>&1)"` redirects stdout and stderr and leaves stdin alone,
+# so run from a terminal those same cases found one, printed a [y/N] into the
+# captured stream where nobody could see it, and blocked on the answer. CI has
+# no terminal and never hit it. Detach stdin once, here, so the script behaves
+# the same either way; the two `profile import -` cases feed brig through a
+# pipe and supply their own.
+exec < /dev/null
+
 WORK="$(mktemp -d)"
 trap 'rm -rf "$WORK"' EXIT
 export STUB_LOG="$WORK/argv.log"


### PR DESCRIPTION
## Summary

`script/smoke.sh` was broken on macOS in two independent ways. Neither can
happen on a Linux CI runner, so both went unnoticed.

**Cases failed from the first `brig run` onwards.** The stub's `stat -f -c %T`
grepped its mount table for the exact path it was given and answered `virtiofs`
on a miss. A file inside a tmpfs has no mount entry of its own, so the stub
called `/home/claude/.claude/.credentials.json` `virtiofs` where a real guest
says `tmpfs` -- exactly the fstype `verifySecretFile` refuses rather than put a
credential on host disk. The first `brig run` exited 1 and everything downstream
of a booted sandbox failed with it. brig is right here; the stub was lying.

Needs a credential to deliver, so only macOS hits it: `claude-credentials` is
`required: false`, sourced from the macOS keychain or
`~/.claude/.credentials.json`. A Linux runner has neither and skips the whole
path.

**Then it hung.** From a terminal, the script stopped after
`ok an older hull boots the tag` and waited on a keypress with no prompt in
sight. The next case drives a bad signature, which under `BRIG_VERIFY=warn` asks
instead of refusing. `Config.confirm` checks brig's own stdin --
`out="$(brig ... 2>&1)"` redirects stdout and stderr but *not* stdin, so brig
found the terminal, wrote `Boot it anyway? [y/N]` into the captured stream where
nobody could see it, and blocked. On a runner there's no tty, `confirm` refuses
immediately, exit 5 -- which is what the case asserts. Its label already said
"with no terminal to ask"; nothing arranged for that, it was just true by
accident.

## Related issues

None.

## Changes

- Stub `stat -f` walks up to the nearest recorded mount point instead of
  matching the exact path -- what the kernel does, and what `guestFake.fstypeOf`
  in `internal/wrap/secretfiles_test.go` already did. The walk matches on field
  5, the mount point: field 4 is the mount's root and reads `/` on every line,
  so a whole-line match would hand a path under no mount whichever fstype was
  recorded last, rather than the `virtiofs` fallback. `fuseblk` for bind mounts
  and the `virtiofs` fallback are unchanged, and no assertion relied on the old
  behaviour.
- `exec < /dev/null` at the top of the script. Central rather than per call: the
  no-terminal assumption belongs to the whole script, and cases added later
  inherit it. The two `profile import -` cases pipe into brig and keep their own
  stdin.

Harness only, no production code.

## Checklist

- [x] `make all` passes (vet, test, build)
- [x] `script/smoke.sh` passes
- [ ] ~~I have added or updated tests covering the change~~ -- this *is* the test
- [ ] ~~I have run `go test ./... -race`~~ -- no Go code changed
- [ ] ~~I have exercised the change against a real runtime~~ -- stub only
- [ ] ~~I have updated the affected docs~~ -- no documented behaviour changed

## Testing

Rebased onto `c06f9bc`; both commits applied cleanly. macOS arm64, where both
failures reproduce:

| | before | after |
|---|---|---|
| stdin not a tty | `FAILURES` | `PASS`, 269 assertions, exit 0 |
| real pty on stdin | hung; killed at 60s | `PASS`, exit 0 in 15s |

Failure counts are host-specific -- they depend on having a credential to
deliver -- so the table says what the run does, not how many cases it takes with
it. The hang was reproduced under a `pty.openpty()` stdin first and re-run after
the fix, not inferred from reading `confirm`. Also runs clean under the system
bash 3.2 (`/bin/bash`), not just bash 5. `make all` green.

The mount-point anchoring was checked directly: with mounts
`/home/claude/.claude tmpfs` and `/home/claude fuseblk` recorded in either
order, `.credentials.json` answers `tmpfs`, `work.txt` answers `fuseblk`, and
`/nonexistent` and `/home` answer `virtiofs`. `/`, `//`, `/a` and `/a/b/c/d/e`
all terminate.

## LLM usage

Authored with assistance from Claude Code; I have reviewed every line and am
accountable for the change.
