### PR TITLE
feat(cli): say less by default, and put the machinery behind --verbose

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,12 +170,25 @@ the agent the vocabulary is the agent's, and `--` ends brig's parsing outright,
 so an agent flag spelled like one of brig's still reaches it.
 
 brig does still read its own flags after the agent, because `brig run claude -q`
-is a line that works. What ends brig's reading is the first token it does not
-own. On `run` that is not the project directory -- the second bare word is
+is a line that works -- `-q` has moved left of the verb, and the old spelling
+keeps working for this release and says so. What ends brig's reading is the
+first token it does not own. On `run` that is not the project directory -- the second bare word is
 brig's own operand, so brig reads past it and on to the next token; see
 [The project you name](#the-project-you-name). Once an unknown token has ended
 brig's reading, a brig flag further along belongs to the agent -- and brig says
 so, without taking the token, so a line that works today keeps working.
+
+| global flag | what it does |
+| --- | --- |
+| `--verbose` | brig's own progress and the runtime's own output. No short form: `-v` is Claude Code's version flag, codex's verbose flag and Docker's volume flag, so brig does not claim the letter |
+| `-q, --quiet` | identifiers and errors only, for a script. It drops the execution envelope and brig's warnings; on `ls` it prints the refs alone. Still read after the verb for this release, with a note |
+
+By default a run prints the execution envelope, then anything you have to act
+on, then the agent. brig's own progress lines and the runtime's own output wait
+for `--verbose` -- except that a boot which fails quotes what the runtime said
+whether or not you asked, because that is the only evidence there is. A long
+download gets one line saying it started and one saying it finished, rather than
+a stream.
 
 | flag | what it does |
 | --- | --- |
@@ -486,7 +499,7 @@ brig:   GH_TOKEN(secret)
 The block at the top is the execution envelope: the boundary the run would
 trust, printed before the sandbox boots. `brig run` prints the same block before
 it starts one, so what you preview is what you get. Names only, never values.
-`--quiet` drops it.
+`brig -q` drops it.
 
 A secret a profile declares but the store does not have fails the run before
 any sandbox is created, naming every one that is missing and the command that

--- a/README.md
+++ b/README.md
@@ -180,15 +180,23 @@ so, without taking the token, so a line that works today keeps working.
 
 | global flag | what it does |
 | --- | --- |
-| `--verbose` | brig's own progress and the runtime's own output. No short form: `-v` is Claude Code's version flag, codex's verbose flag and Docker's volume flag, so brig does not claim the letter |
-| `-q, --quiet` | identifiers and errors only, for a script. It drops the execution envelope and brig's warnings; on `ls` it prints the refs alone. Still read after the verb for this release, with a note |
+| `--verbose` | the execution envelope, brig's own progress and the runtime's own output. No short form: `-v` is Claude Code's version flag, codex's verbose flag and Docker's volume flag, so brig does not claim the letter |
+| `-q, --quiet` | identifiers and errors only, for a script. It drops brig's warnings; on `ls` it prints the refs alone. A verification that did not hold is printed even here. Still read after the verb for this release, with a note |
 
-By default a run prints the execution envelope, then anything you have to act
-on, then the agent. brig's own progress lines and the runtime's own output wait
-for `--verbose` -- except that a boot which fails quotes what the runtime said
-whether or not you asked, because that is the only evidence there is. A long
-download gets one line saying it started and one saying it finished, rather than
-a stream.
+By default a run prints what you have to act on, then the agent: warnings,
+errors, and one line saying verification held. The execution envelope, brig's
+own progress lines and the runtime's own output wait for `--verbose` -- except
+that a boot which fails quotes what the runtime said whether or not you asked,
+because that is the only evidence there is. A long download gets one line saying
+it started and one saying it finished, rather than a stream. `brig info` prints
+the envelope on demand, without booting anything.
+
+Verification is the exception at both ends. A check that did **not** hold --
+a signature that failed, a bundle brig does not publish, a missing `cosign`,
+`BRIG_VERIFY=off` -- prints at every level, `-q` included: it is the one claim
+brig exists to make, and a scripted run is where an unchecked image matters
+most. A check that held prints one line, which `-q` drops. The policy those
+held under is the envelope's `VERIFY` row.
 
 | flag | what it does |
 | --- | --- |
@@ -491,6 +499,7 @@ SANDBOX      brig-claude-code (hull)
 ISOLATION    microVM (hull, vz backend)
 WORKSPACE    /Users/you/brig/claude-code (read-write)
 IMAGE        ghcr.io/brig-sh/claude-code-stock:latest (pull missing)
+VERIFY       warn, against brig's own trust policy
 CREDENTIALS  GH_TOKEN
 brig: forwarding to guest:
 brig:   GH_TOKEN(secret)
@@ -520,7 +529,7 @@ repository *and* the workflow file, so a signature from anywhere else fails.
 
 | situation | what happens |
 | --- | --- |
-| image under `ghcr.io/brig-sh/`, signature verifies | one line saying so, boots |
+| image under `ghcr.io/brig-sh/`, signature verifies | one line saying so, boots. `--verbose` adds the per-check detail |
 | image published by someone else | **warning**, boots. Bring-your-own images are a supported way to use brig |
 | `cosign` not installed | **warning**, boots. "Could not check" is not "failed" |
 | image under `ghcr.io/brig-sh/`, signature does **not** verify | **stops and asks** `[y/N]`. With no terminal it refuses |

--- a/cmd/brig/hygiene_test.go
+++ b/cmd/brig/hygiene_test.go
@@ -233,10 +233,12 @@ func TestBrigFlagsOverlapWithClaudeCodeOnlyWhereKnown(t *testing.T) {
 	}
 }
 
-// The global position -- left of the verb -- is closed. #24 filled it with
-// --verbose and -q; everything else is still a token to name rather than a
-// command to run or a word to forward, and #11 and #30 are what fill in the
-// rest.
+// Global flags go left of the verb, and the set is closed: an unknown token
+// there is a usage error naming it, not an operand and not an agent argument.
+// No agent is named yet at that point, so nothing else can claim it.
+//
+// The tokens below are not brig flags. Adding one as a global flag means
+// removing it here.
 func TestGlobalPositionRefusesAnUnknownToken(t *testing.T) {
 	for _, args := range [][]string{
 		{"--json", "run", "claude"},

--- a/cmd/brig/hygiene_test.go
+++ b/cmd/brig/hygiene_test.go
@@ -84,7 +84,7 @@ func TestLsAndRemoveAllRefuseArguments(t *testing.T) {
 		fn   func([]string) error
 		args []string
 	}{
-		{"ls", listSandboxes, []string{"claude"}},
+		{"ls", func(args []string) error { return listSandboxes(args, false) }, []string{"claude"}},
 		{"rm --all", func(args []string) error { return removeAll("brig rm --all", args) },
 			[]string{"--dry-run"}},
 		{"reset", func(args []string) error { return removeAll("brig reset", args) },
@@ -200,6 +200,15 @@ func TestBrigFlagsOverlapWithClaudeCodeOnlyWhereKnown(t *testing.T) {
 	}
 	found := map[string]bool{}
 	for _, f := range brigFlags {
+		// Only the run line can collide. A global flag stands left of the verb
+		// and the agent's words stand right of the ref, so the two never occupy
+		// the same place: `brig --verbose run claude` is brig's and `brig run
+		// claude --verbose` is claude's, and neither reading is in doubt. That
+		// is a reason to put a flag brig shares with an agent in the global
+		// position rather than a reason to list it here.
+		if f.position == posGlobal {
+			continue
+		}
 		spellings := []string{"--" + f.long}
 		if f.short != "" {
 			spellings = append(spellings, "-"+f.short)
@@ -224,17 +233,17 @@ func TestBrigFlagsOverlapWithClaudeCodeOnlyWhereKnown(t *testing.T) {
 	}
 }
 
-// The global position -- left of the verb -- is closed. It holds no flags yet:
-// every flag brig has is on the run line, and #24, #11 and #30 are what fill
-// this in. Closed and empty is the point, so that a flag written there is
-// named rather than read as a command.
+// The global position -- left of the verb -- is closed. #24 filled it with
+// --verbose and -q; everything else is still a token to name rather than a
+// command to run or a word to forward, and #11 and #30 are what fill in the
+// rest.
 func TestGlobalPositionRefusesAnUnknownToken(t *testing.T) {
 	for _, args := range [][]string{
 		{"--json", "run", "claude"},
 		{"--nope", "ls"},
 		{"-y", "rm", "claude"},
 	} {
-		_, err := parseGlobal(args)
+		_, _, err := parseGlobal(args)
 		if err == nil {
 			t.Errorf("parseGlobal(%q) was accepted", args)
 			continue
@@ -261,7 +270,7 @@ func TestGlobalPositionPassesTheVerbLineThrough(t *testing.T) {
 		{"version"},
 		{"run", "claude", "--json"},
 	} {
-		rest, err := parseGlobal(args)
+		_, rest, err := parseGlobal(args)
 		if err != nil {
 			t.Errorf("parseGlobal(%q): %v", args, err)
 			continue

--- a/cmd/brig/listing_test.go
+++ b/cmd/brig/listing_test.go
@@ -90,11 +90,11 @@ func TestListingQuietPrintsRefsOnly(t *testing.T) {
 	// -q is a flag on ls, and the only one. Anything else is still refused.
 	scratchHost(t)
 	for _, args := range [][]string{{"-q"}, {"--quiet"}} {
-		if _, err := captureStdout(t, func() error { return listSandboxes(args) }); err != nil {
+		if _, err := captureStdout(t, func() error { return listSandboxes(args, false) }); err != nil {
 			t.Errorf("brig ls %s: %v", args[0], err)
 		}
 	}
-	if _, err := captureStdout(t, func() error { return listSandboxes([]string{"-x"}) }); err == nil {
+	if _, err := captureStdout(t, func() error { return listSandboxes([]string{"-x"}, false) }); err == nil {
 		t.Error("brig ls -x was accepted")
 	}
 }

--- a/cmd/brig/main.go
+++ b/cmd/brig/main.go
@@ -68,11 +68,13 @@ to rewrite is refused rather than rewritten. brig ls prints the ref of every
 sandbox, and every verb above takes one.
 
 global flags (left of the command, as in: brig -q run claude):
-      --verbose          print brig's own progress and the runtime's own
-                         output. No short form: -v belongs to the agents
+      --verbose          the execution envelope, brig's own progress and the
+                         runtime's own output. No short form: -v belongs to
+                         the agents
   -q, --quiet            identifiers and errors only, for a script. It drops
-                         the execution envelope and brig's warnings; with ls
-                         it prints the refs, one per line
+                         brig's warnings; with ls it prints the refs, one per
+                         line. A verification that did not hold is printed
+                         even here
                          (-q after the verb still works this release)
 
 flags (before the agent's own arguments; -- ends brig's parsing):
@@ -90,10 +92,11 @@ flags (before the agent's own arguments; -- ends brig's parsing):
       --offline          shorthand for --network offline: the agent runs, the
                          workspace is there, nothing leaves
 
-By default a run prints the execution envelope, then anything you have to act
-on, then the agent. brig's own progress and the runtime's output are held back
-until --verbose asks for them -- and a boot that fails quotes what the runtime
-said whether or not you asked.
+By default a run prints what you have to act on, then the agent: warnings,
+errors, and one line saying verification held. The execution envelope, brig's
+own progress and the runtime's output wait for --verbose -- and a boot that
+fails quotes what the runtime said whether or not you asked. brig info prints
+the envelope on demand, without booting anything.
 
 Workspaces persist. The sandbox keeps running between commands, so a second
 run is immediate; state lives in the workspace on the host either way.
@@ -428,12 +431,26 @@ func run(args []string) error {
 	}
 
 	// The execution envelope: the boundary this run is about to trust, printed
-	// before the sandbox boots so the user sees it before it matters. Only run
-	// and create print it. sh continues an existing session and stays quiet;
+	// before the sandbox boots so the user sees it before it matters.
+	//
+	// Behind --verbose, which reverses part of #10 and part of #24's own text.
+	// The block was on every run, and reading a default run beside a quiet one
+	// settled it: nine rows of boundary before the agent says anything is the
+	// machinery this issue is about, whoever wrote the machinery. It is not
+	// gone and it is not harder to reach -- `brig info` is the command whose
+	// whole output it is, it answers without booting anything, and --verbose
+	// puts it back on a run. Do not restore it to the default: that is the
+	// user's decision, not an oversight.
+	//
+	// What a default run still says about the boundary is the part nobody can
+	// be asked to go and look up: a verification that did not hold prints at
+	// every level, and one that did prints above -q. See alertf and
+	// sayVerified.
+	//
+	// Only run and create, as before. sh continues an existing session, and
 	// when there is no sandbox yet it lets EnsureRunning start one without
 	// printing the block, so a scripted `brig sh` is not interrupted.
-	// --quiet drops it for a script or a returning session.
-	if (verb == "run" || verb == "create") && verbosity > wrap.Quiet {
+	if showsEnvelope(verb, verbosity) {
 		cfg.PrintPreRunEnvelope(set)
 	}
 
@@ -470,6 +487,21 @@ func run(args []string) error {
 		return cfg.Exec(set, tail, isTerminal())
 	}
 	return runAgent(cfg, set, t, tail, opts.detach)
+}
+
+// showsEnvelope reports whether this invocation prints the execution envelope
+// before it boots. Two rules, and they are independent: which verbs have a
+// boundary worth naming, and whether the reader asked to see it.
+//
+// A function rather than a condition at the call site because both rules have
+// caught something. sh was carved out when a scripted `brig sh` on a cold
+// sandbox printed a block nobody was reading, and the level is what #24 moved.
+func showsEnvelope(verb string, v wrap.Verbosity) bool {
+	switch verb {
+	case "run", "create":
+		return v >= wrap.Verbose
+	}
+	return false
 }
 
 func runAgent(cfg *wrap.Config, set creds.Set, t profile.Profile, tail []string, detach bool) error {

--- a/cmd/brig/main.go
+++ b/cmd/brig/main.go
@@ -67,6 +67,14 @@ and the label reaching the agent as its display name. A label brig would have
 to rewrite is refused rather than rewritten. brig ls prints the ref of every
 sandbox, and every verb above takes one.
 
+global flags (left of the command, as in: brig -q run claude):
+      --verbose          print brig's own progress and the runtime's own
+                         output. No short form: -v belongs to the agents
+  -q, --quiet            identifiers and errors only, for a script. It drops
+                         the execution envelope and brig's warnings; with ls
+                         it prints the refs, one per line
+                         (-q after the verb still works this release)
+
 flags (before the agent's own arguments; -- ends brig's parsing):
       --image IMAGE      guest image to boot
       --home PATH        host directory to mount as the guest home
@@ -76,14 +84,16 @@ flags (before the agent's own arguments; -- ends brig's parsing):
       --mem MB           guest memory
       --cpus N           guest vCPUs
   -d, --detach           with run: start the sandbox and exit
-  -q, --quiet            with run: do not print the execution envelope before
-                         the agent starts. With ls: print the refs and nothing
-                         else, one per line, for a script to read
       --skills           project your own ~/.claude skills and plugins into
                          the guest, read-only (or BRIG_SKILLS=1)
       --network MODE     shared, isolated or offline (or BRIG_NETWORK)
       --offline          shorthand for --network offline: the agent runs, the
                          workspace is there, nothing leaves
+
+By default a run prints the execution envelope, then anything you have to act
+on, then the agent. brig's own progress and the runtime's output are held back
+until --verbose asks for them -- and a boot that fails quotes what the runtime
+said whether or not you asked.
 
 Workspaces persist. The sandbox keeps running between commands, so a second
 run is immediate; state lives in the workspace on the host either way.
@@ -147,10 +157,17 @@ func notFoundf(format string, a ...any) error { return &notFoundError{fmt.Sprint
 func run(args []string) error {
 	// The global position first, so a flag written left of the verb is named
 	// rather than read as a command.
-	verbLine, err := parseGlobal(args)
+	g, verbLine, err := parseGlobal(args)
 	if err != nil {
 		return err
 	}
+	// And how much this invocation says, before anything says it. That is what
+	// the global position buys: `brig -q run claude` is quiet from the first
+	// line, the notices about profiles below included. The run-line spelling of
+	// -q is read much later -- it sits on the far side of the ref -- so those
+	// notices have already printed by the time it is known, which is one more
+	// reason the flag has moved.
+	verbosity = g.verbosity()
 	if len(verbLine) == 0 {
 		// No verb: a bare `brig`, or global flags and nothing to do with them.
 		fmt.Print(usage)
@@ -162,14 +179,14 @@ func run(args []string) error {
 	// in for a built-in. A broken file is reported and skipped rather than
 	// taking down the profile you were actually asking for.
 	if err := profile.Load(profile.Dir()); err != nil {
-		fmt.Fprintln(os.Stderr, "brig: "+err.Error())
+		warnf("%s", err)
 	}
 	// Files left in the pre-profile directory are read by nothing and look
 	// exactly like files that work: the profile they were pinning silently
 	// reverts to brig's own. Nothing is moved for you -- these name credential
 	// variables, and there is no safe guess about which you still want.
 	if hint := profile.LegacyHint(); hint != "" {
-		fmt.Fprintln(os.Stderr, "brig: "+hint)
+		warnf("%s", hint)
 	}
 	warnDeprecatedProfileKeys()
 
@@ -227,7 +244,11 @@ func run(args []string) error {
 		}
 		return agentCmd(rest)
 	case "ls":
-		return listSandboxes(rest)
+		// The global -q reaches ls as its own meaning: refs and nothing else.
+		// The two readings agree -- bare refs ARE identifiers only -- and ls
+		// still reads -q after the verb itself, which is the spelling #5
+		// documented and the round-trip test consumes.
+		return listSandboxes(rest, verbosity <= wrap.Quiet)
 	case "reset":
 		// reset was the one verb whose name did not say what it acts on, which
 		// is the whole of its problem: it removes every sandbox brig has, and it
@@ -326,6 +347,12 @@ func run(args []string) error {
 		return usagef("--no-project belongs to `brig run`, not `brig %s`. "+
 			"A session runs without its project from the next `brig run --no-project` onwards", verb)
 	}
+	// The run-line spelling of -q, for the one release in which both work. It
+	// is read here rather than in the global position, so everything above has
+	// already printed: that asymmetry is the notice's point, not a gap in it.
+	if opts.quiet {
+		verbosity = wrap.Quiet
+	}
 	if opts.load.Project != "" {
 		warnPositionalMeaning(opts.load.Project)
 	}
@@ -372,6 +399,7 @@ func run(args []string) error {
 		}
 		rt = nil
 	}
+	opts.load.Verbosity = verbosity
 	cfg, err := wrap.Load(t, opts.load, rt)
 	if err != nil {
 		return err
@@ -381,8 +409,7 @@ func run(args []string) error {
 	// whenever the two differ. A name that sanitises onto another session's
 	// sandbox is refused later, at EnsureRunning; this only names the directory.
 	if cfg.RawName != "" && cfg.RawName != cfg.Slug {
-		fmt.Fprintf(os.Stderr, "brig: session %q uses %s (sandbox %s)\n",
-			cfg.RawName, cfg.Workspace, cfg.VMName)
+		warnf("session %q uses %s (sandbox %s)", cfg.RawName, cfg.Workspace, cfg.VMName)
 	}
 
 	// Stopping and removing need nothing but the instance name, and are
@@ -406,7 +433,7 @@ func run(args []string) error {
 	// when there is no sandbox yet it lets EnsureRunning start one without
 	// printing the block, so a scripted `brig sh` is not interrupted.
 	// --quiet drops it for a script or a returning session.
-	if (verb == "run" || verb == "create") && !opts.quiet {
+	if (verb == "run" || verb == "create") && verbosity > wrap.Quiet {
 		cfg.PrintPreRunEnvelope(set)
 	}
 
@@ -457,8 +484,7 @@ func runAgent(cfg *wrap.Config, set creds.Set, t profile.Profile, tail []string,
 	}
 	switch {
 	case t.IsGUI():
-		fmt.Fprintf(os.Stderr, "brig: sandbox %s is running; the %s window should be visible.\n",
-			cfg.VMName, t.GUITitle)
+		warnf("sandbox %s is running; the %s window should be visible.", cfg.VMName, t.GUITitle)
 		return nil
 	case detach:
 		// The sandbox is up and will stay up; print the name so a script can
@@ -535,6 +561,16 @@ var brigFlags = []struct {
 	short    string
 	value    bool // takes a value, so the next argument may belong to it
 	position position
+	// retiredAs and retiredTo are the notice for a flag whose POSITION is
+	// going, rather than its spelling: what to stop writing, and what to write
+	// instead. Empty on a flag that is not retiring here.
+	//
+	// On the entry rather than in deprecatedFlags because that map is keyed by
+	// spelling and cannot say this: -q is not going anywhere, its place on the
+	// line is, and the same spelling in the other position is the replacement.
+	// The table already carries a position per flag, so this is a field on the
+	// row rather than a case in split.
+	retiredAs, retiredTo string
 }{
 	{long: "name", short: "n", value: true, position: posRun},
 	{long: "image", short: "t", value: true, position: posRun},
@@ -558,7 +594,26 @@ var brigFlags = []struct {
 	{long: "skills", position: posRun},
 	{long: "network", value: true, position: posRun},
 	{long: "offline", position: posRun},
-	{long: "quiet", short: "q", position: posRun},
+	// --verbose is brig's own progress and the runtime's own output, and it is
+	// global because it is a fact about the whole invocation rather than about
+	// one run line.
+	//
+	// It has NO short form, on purpose and permanently. -v is Claude Code's
+	// version flag, codex's verbose flag and Docker's volume flag: brig owns
+	// none of those readings, and taking the letter would make `brig run
+	// claude -v` mean one thing to brig and another to everything else the
+	// reader has ever typed it at. Do not add it back as an obvious
+	// convenience.
+	{long: "verbose", position: posGlobal},
+	// -q is global from this release. It was on the run line, and `brig run
+	// claude -q` is a line people have written, so the run-line spelling below
+	// keeps working for one release and says where the flag went -- the same
+	// two-release window every other retiring spelling took. Global-only would
+	// have sent that -q to the agent, silently changing what a working command
+	// does.
+	{long: "quiet", short: "q", position: posGlobal},
+	{long: "quiet", short: "q", position: posRun,
+		retiredAs: "brig <verb> <ref> -q", retiredTo: "brig -q <verb> <ref>"},
 }
 
 // deprecatedFlags are the spellings on their way out, and what replaces each.
@@ -595,28 +650,52 @@ var deprecatedFlags = map[string]string{
 // being greedier here silently eats an agent's own flag: `brig run claude
 // -image x` has to stay the agent's -image.
 func ours(arg string, at position) (mine bool, takesValue bool) {
+	mine, takesValue, _ = oursAt(arg, at)
+	return mine, takesValue
+}
+
+// oursAt is ours with the position the match was found in, which only matters
+// when the search was posAny: a flag brig read nowhere on this line still has a
+// place it belongs, and that is what the tail notice has to name.
+func oursAt(arg string, at position) (mine bool, takesValue bool, found position) {
 	name, _, inline := strings.Cut(arg, "=")
 	for _, f := range brigFlags {
 		if at != posAny && f.position != at {
 			continue
 		}
 		if name == "--"+f.long || (f.short != "" && name == "-"+f.short) {
-			return true, f.value && !inline
+			return true, f.value && !inline, f.position
 		}
 	}
-	return false, false
+	return false, false, 0
+}
+
+// retiredAt reports the notice for a flag written in a position it is leaving:
+// the spelling to stop writing and the one that replaces it, or two empty
+// strings when the flag is not retiring here. See brigFlags.
+func retiredAt(arg string, at position) (was, now string) {
+	name, _, _ := strings.Cut(arg, "=")
+	for _, f := range brigFlags {
+		if f.position != at || f.retiredTo == "" {
+			continue
+		}
+		if name == "--"+f.long || (f.short != "" && name == "-"+f.short) {
+			return f.retiredAs, f.retiredTo
+		}
+	}
+	return "", ""
 }
 
 // splitGlobal finds the verb and refuses anything standing left of it.
 //
-// The global position is closed and, today, empty: every entry in brigFlags is
-// on the run line, so ours answers no to every token here. Establishing it
-// while it is empty is the point. `brig --json run claude` is a line someone
-// will type, and the two ways to read a token brig does not own are "the
-// command is --json" and "the agent wants it" -- one reports a command that
-// does not exist and the other hands a word to an agent that does not have it.
-// Naming the token is the third reading, and it is the one that is true.
-// #24, #11 and #30 are what put flags in here.
+// The global position is closed, and #24 is what put the first flags in it:
+// --verbose and -q, both facts about the whole invocation rather than about one
+// run line. It stays closed. `brig --json run claude` is a line someone will
+// type, and the two ways to read a token brig does not own are "the command is
+// --json" and "the agent wants it" -- one reports a command that does not exist
+// and the other hands a word to an agent that does not have it. Naming the
+// token is the third reading, and it is the one that is true. #11 and #30 are
+// what fill the rest of it in.
 //
 // A flag-shaped verb -- -h, --help, --version -- is a verb, not a token in this
 // position: those are the spellings brig has always answered to.
@@ -652,27 +731,55 @@ func verbSpelling(arg string) bool {
 	return false
 }
 
+// globals are brig's flags in the global position: how much this invocation
+// says about itself, which is a property of the whole command rather than of
+// the run line inside it.
+type globals struct {
+	quiet   bool
+	verbose bool
+}
+
+// verbosity is the level these two flags ask for. Neither given is the default,
+// which is what a person reads.
+func (g globals) verbosity() wrap.Verbosity {
+	switch {
+	case g.quiet:
+		return wrap.Quiet
+	case g.verbose:
+		return wrap.Verbose
+	}
+	return wrap.Normal
+}
+
 // parseGlobal reads brig's global flags -- the ones legal left of the verb --
-// and returns the verb and everything after it.
+// and returns them with the verb and everything after it.
 //
-// There are none yet, so this parses an empty list. It exists anyway so that
-// adding a global flag is the same two-step adding a run-line flag is, a table
-// entry and a registration, and so that doing only the first half fails here
-// with the flag package's "not defined" rather than accepting the flag and
-// dropping it on the floor.
-func parseGlobal(args []string) (rest []string, err error) {
+// Registering a flag here is the second half of adding a global one; the table
+// entry in brigFlags is the first. Doing only the first half fails here with
+// the flag package's "not defined" rather than accepting the flag and dropping
+// it on the floor.
+func parseGlobal(args []string) (g globals, rest []string, err error) {
 	mine, rest, err := splitGlobal(args)
 	if err != nil {
-		return nil, err
+		return globals{}, nil, err
 	}
 	fs := flag.NewFlagSet("brig", flag.ContinueOnError)
 	fs.SetOutput(io.Discard)
 	fs.Usage = func() {}
-	// Nothing is registered here yet. See the doc comment.
-	if err := fs.Parse(mine); err != nil {
-		return nil, rewriteFlagError(err)
+	// No short form for --verbose, deliberately and permanently. See brigFlags.
+	fs.BoolVar(&g.verbose, "verbose", false, "")
+	for _, spelling := range []string{"quiet", "q"} {
+		fs.BoolVar(&g.quiet, spelling, false, "")
 	}
-	return rest, nil
+	if err := fs.Parse(mine); err != nil {
+		return globals{}, nil, rewriteFlagError(err)
+	}
+	// Both at once asks to be told more and less about the same run, and either
+	// winner would leave the line reading like it asked for the opposite.
+	if g.quiet && g.verbose {
+		return globals{}, nil, usagef("--quiet and --verbose ask for different things; drop one")
+	}
+	return g, rest, nil
 }
 
 // split divides a run line into brig's own arguments, the session ref, the
@@ -759,6 +866,12 @@ func split(verb string, args []string) (mine []string, ref session.Ref, word str
 			// and reaches this loop as a value, not as a token.
 			if spelling, _, _ := strings.Cut(a, "="); deprecatedFlags[spelling] != "" {
 				deprecated(spelling, deprecatedFlags[spelling])
+			} else if was, now := retiredAt(a, posRun); now != "" {
+				// A flag whose place on the line is what retires, not its
+				// spelling. Said here, where the position is known, rather than
+				// after the flag package has read it and forgotten where it
+				// stood.
+				deprecated(was, now)
 			}
 			mine = append(mine, a)
 			if takesValue && i+1 < len(args) {
@@ -787,10 +900,10 @@ func split(verb string, args []string) (mine []string, ref session.Ref, word str
 // person typing it, so there is nothing to point out -- the same rule agentTail
 // follows.
 func warnPositionalMeaning(word string) {
-	fmt.Fprintf(os.Stderr, "brig: `%s` is now the project directory this run mounts, "+
+	warnf("`%s` is now the project directory this run mounts, "+
 		"and brig starts the agent in it. It used to be the agent's first argument "+
 		"instead. If that is what you meant, put it after --: `brig run <ref> -- %s`. "+
-		"This notice goes in the next release.\n", word, word)
+		"This notice goes in the next release.", word, word)
 }
 
 // agentTail hands the tail back as the agent's, saying so for any of brig's own
@@ -808,12 +921,22 @@ func warnPositionalMeaning(word string) {
 // already made.
 func agentTail(tail []string) []string {
 	for _, a := range tail {
-		if mine, _ := ours(a, posAny); mine {
-			name, _, _ := strings.Cut(a, "=")
-			fmt.Fprintf(os.Stderr, "brig: %s is one of brig's own flags, but here it is the "+
-				"agent's: brig stopped reading the line at the argument before it. "+
-				"Put %s before the profile for brig to read it.\n", name, name)
+		mine, _, at := oursAt(a, posAny)
+		if !mine {
+			continue
 		}
+		// Where the flag actually belongs, which is not the same place for
+		// every flag any more: --verbose and -q stand left of the verb, and
+		// telling their reader to put one before the profile would send them to
+		// a position that refuses it.
+		where := "before the profile"
+		if at == posGlobal {
+			where = "before the command"
+		}
+		name, _, _ := strings.Cut(a, "=")
+		warnf("%s is one of brig's own flags, but here it is the "+
+			"agent's: brig stopped reading the line at the argument before it. "+
+			"Put %s %s for brig to read it.", name, name, where)
 	}
 	return tail
 }
@@ -1050,7 +1173,7 @@ func spell(name string) string {
 // It leads with the ref, which is what every other verb takes: a listing whose
 // identifier no verb accepts is a listing a reader cannot act on, and copying
 // what it printed used to be an error.
-func listSandboxes(args []string) error {
+func listSandboxes(args []string, quiet bool) error {
 	// ls names no session and -q is the only flag it has, so anything else here
 	// is a token it would otherwise read and discard -- `brig ls claude` looks
 	// like it filters to one agent and does not. Refuse it rather than answer a
@@ -1061,7 +1184,6 @@ func listSandboxes(args []string) error {
 	// parser exists to find where brig's arguments stop, which on this verb is
 	// immediately. Both spellings, because -q and --quiet are one flag
 	// everywhere else brig reads them.
-	quiet := false
 	for _, a := range args {
 		switch a {
 		case "-q", "--quiet":
@@ -1396,13 +1518,13 @@ func removeAll(spelling string, args []string) error {
 		wrap.ForgetSandbox(inst.Name)
 		wrap.ForgetSlugClaim(inst.Name)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "brig: could not remove %s: %v\n", inst.Name, err)
+			warnf("could not remove %s: %v", inst.Name, err)
 			continue
 		}
 		fmt.Println(inst.Name)
 		removed++
 	}
-	fmt.Fprintf(os.Stderr, "brig: removed %d sandbox(es). Workspaces are untouched.\n", removed)
+	warnf("removed %d sandbox(es). Workspaces are untouched.", removed)
 	// A network whose sandbox was removed outside brig is not reachable
 	// through Remove, because that sandbox is not in the list any more. This is
 	// the one command that leaves nothing behind, so it prunes those too. Only
@@ -2179,7 +2301,31 @@ func confirmRemoveProfile(arg, resolved string, files []string, yes bool) error 
 // something being piped. Kept for one release: one commit of published history
 // is not long enough to have broken anyone's muscle memory on purpose.
 func deprecated(old, replacement string) {
-	fmt.Fprintf(os.Stderr, "brig: `%s` is now `%s`\n", old, replacement)
+	warnf("`%s` is now `%s`", old, replacement)
+}
+
+// verbosity is how much this invocation says about itself, read off the global
+// position before anything prints. See wrap.Verbosity for the rule.
+//
+// Package state rather than a value threaded through, because every notice
+// below is at the top of its own call chain: there is nothing above them
+// holding a writer to hand in, and they are lines brig prints about a command
+// rather than values a command returns. run sets it on every invocation, so a
+// test that drives run twice does not inherit the first one's level.
+var verbosity = wrap.Normal
+
+// warnf prints one of brig's own notices to stderr: a warning, a deprecation, a
+// word about what a line now means.
+//
+// It stays in the default output -- a warning is an action -- and goes only
+// under -q, which is a script asking for identifiers and errors. An error is
+// never printed through here: errors are returned, and main prints them at
+// every level.
+func warnf(format string, a ...any) {
+	if verbosity < wrap.Normal {
+		return
+	}
+	fmt.Fprintf(os.Stderr, "brig: "+format+"\n", a...)
 }
 
 // warnDeprecatedProfileKeys says that a profile FILE still carries
@@ -2204,10 +2350,10 @@ func warnDeprecatedProfileKeys() {
 		if path, ok := profile.Path(p.Name); ok {
 			where = path
 		}
-		fmt.Fprintf(os.Stderr, "brig: hostCredential: in %s is deprecated and goes in the "+
+		warnf("hostCredential: in %s is deprecated and goes in the "+
 			"next release -- it reads another application's keychain on every run. "+
 			"Declare the credential under secrets: with sources: instead, then: "+
-			"brig secret import %s\n", where, p.Name)
+			"brig secret import %s", where, p.Name)
 	}
 }
 

--- a/cmd/brig/main.go
+++ b/cmd/brig/main.go
@@ -249,8 +249,8 @@ func run(args []string) error {
 	case "ls":
 		// The global -q reaches ls as its own meaning: refs and nothing else.
 		// The two readings agree -- bare refs ARE identifiers only -- and ls
-		// still reads -q after the verb itself, which is the spelling #5
-		// documented and the round-trip test consumes.
+		// still reads -q after the verb itself, which is the spelling the
+		// round-trip test consumes.
 		return listSandboxes(rest, verbosity <= wrap.Quiet)
 	case "reset":
 		// reset was the one verb whose name did not say what it acts on, which
@@ -433,10 +433,8 @@ func run(args []string) error {
 	// The execution envelope: the boundary this run is about to trust, printed
 	// before the sandbox boots so the user sees it before it matters.
 	//
-	// Behind --verbose, which reverses part of #10 and part of #24's own text.
-	// The block was on every run, and reading a default run beside a quiet one
-	// settled it: nine rows of boundary before the agent says anything is the
-	// machinery this issue is about, whoever wrote the machinery. It is not
+	// Behind --verbose. Nine rows of boundary before the agent says anything is
+	// the machinery a quiet default is meant to remove. It is not
 	// gone and it is not harder to reach -- `brig info` is the command whose
 	// whole output it is, it answers without booting anything, and --verbose
 	// puts it back on a run. Do not restore it to the default: that is the
@@ -494,8 +492,8 @@ func run(args []string) error {
 // boundary worth naming, and whether the reader asked to see it.
 //
 // A function rather than a condition at the call site because both rules have
-// caught something. sh was carved out when a scripted `brig sh` on a cold
-// sandbox printed a block nobody was reading, and the level is what #24 moved.
+// caught something: a scripted `brig sh` on a cold sandbox printed a block
+// nobody was reading, and the level moved after that.
 func showsEnvelope(verb string, v wrap.Verbosity) bool {
 	switch verb {
 	case "run", "create":
@@ -720,14 +718,13 @@ func retiredAt(arg string, at position) (was, now string) {
 
 // splitGlobal finds the verb and refuses anything standing left of it.
 //
-// The global position is closed, and #24 is what put the first flags in it:
-// --verbose and -q, both facts about the whole invocation rather than about one
-// run line. It stays closed. `brig --json run claude` is a line someone will
-// type, and the two ways to read a token brig does not own are "the command is
-// --json" and "the agent wants it" -- one reports a command that does not exist
-// and the other hands a word to an agent that does not have it. Naming the
-// token is the third reading, and it is the one that is true. #11 and #30 are
-// what fill the rest of it in.
+// The global position is closed. --verbose and -q live there, both facts about
+// the whole invocation rather than about one run line, and a token brig does
+// not own is refused rather than read as something else. `brig --json run
+// claude` is a line someone will type, and the two other readings are "the
+// command is --json" and "the agent wants it": one reports a command that does
+// not exist, the other hands a word to an agent that does not have it. Naming
+// the token is the reading that is true.
 //
 // A flag-shaped verb -- -h, --help, --version -- is a verb, not a token in this
 // position: those are the spellings brig has always answered to.

--- a/cmd/brig/runtime_guard_test.go
+++ b/cmd/brig/runtime_guard_test.go
@@ -45,7 +45,7 @@ func TestLsSurfacesUnknownRuntime(t *testing.T) {
 	t.Setenv("BRIG_PROFILE_DIR", t.TempDir())
 	t.Setenv("BRIG_RUNTIME", "podman")
 
-	err := listSandboxes(nil)
+	err := listSandboxes(nil, false)
 	if err == nil {
 		t.Fatal("brig ls with an unknown BRIG_RUNTIME was accepted")
 	}
@@ -93,7 +93,7 @@ func TestLsWithoutARuntimeSaysNothingToList(t *testing.T) {
 	t.Setenv("BRIG_RUNTIME", "")
 	emptyPath(t)
 
-	if err := listSandboxes(nil); err != nil {
+	if err := listSandboxes(nil, false); err != nil {
 		t.Errorf("ls with no runtime on PATH failed instead of listing nothing: %v", err)
 	}
 }

--- a/cmd/brig/verbosity_test.go
+++ b/cmd/brig/verbosity_test.go
@@ -17,9 +17,8 @@ func atLevel(t *testing.T, v wrap.Verbosity) {
 	verbosity = v
 }
 
-// The global position was built closed and empty by #108. --verbose and -q are
-// its first inhabitants, which is the thing that proves the mechanism was worth
-// building.
+// --verbose and -q are read left of the verb. Both are facts about the whole
+// invocation rather than about one run line.
 func TestGlobalPositionReadsVerboseAndQuiet(t *testing.T) {
 	for _, tc := range []struct {
 		args []string
@@ -128,10 +127,8 @@ func TestQuietSuppressesBrigsOwnNotices(t *testing.T) {
 	}
 }
 
-// The envelope is behind --verbose. Nine rows of boundary before the agent says
-// anything is the machinery #24 is about, whoever wrote the machinery, and the
-// block is not gone: `brig info` is the command whose whole output it is, and
-// it answers without booting anything.
+// The envelope is behind --verbose. It is not gone: `brig info` is the command
+// whose whole output it is, and it answers without booting anything.
 //
 // Both of showsEnvelope's rules are here, because a change to either is silent:
 // a verb that starts printing the block interrupts a script, and a level that

--- a/cmd/brig/verbosity_test.go
+++ b/cmd/brig/verbosity_test.go
@@ -1,0 +1,129 @@
+package main
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/brig-sh/brig/internal/wrap"
+)
+
+// atLevel pins the package's verbosity for one test and puts it back, so a
+// test that reads a notice does not decide whether the next one sees any.
+func atLevel(t *testing.T, v wrap.Verbosity) {
+	t.Helper()
+	old := verbosity
+	t.Cleanup(func() { verbosity = old })
+	verbosity = v
+}
+
+// The global position was built closed and empty by #108. --verbose and -q are
+// its first inhabitants, which is the thing that proves the mechanism was worth
+// building.
+func TestGlobalPositionReadsVerboseAndQuiet(t *testing.T) {
+	for _, tc := range []struct {
+		args []string
+		want wrap.Verbosity
+		rest string
+	}{
+		{[]string{"--verbose", "run", "claude"}, wrap.Verbose, "run claude"},
+		{[]string{"--quiet", "run", "claude"}, wrap.Quiet, "run claude"},
+		{[]string{"-q", "ls"}, wrap.Quiet, "ls"},
+		{[]string{"run", "claude"}, wrap.Normal, "run claude"},
+	} {
+		g, rest, err := parseGlobal(tc.args)
+		if err != nil {
+			t.Errorf("parseGlobal(%q): %v", tc.args, err)
+			continue
+		}
+		if g.verbosity() != tc.want {
+			t.Errorf("parseGlobal(%q) = level %d, want %d", tc.args, g.verbosity(), tc.want)
+		}
+		if strings.Join(rest, " ") != tc.rest {
+			t.Errorf("parseGlobal(%q) left %q, want %q", tc.args, rest, tc.rest)
+		}
+	}
+}
+
+// -v is not brig's. It is Claude Code's version flag, codex's verbose flag and
+// Docker's volume flag, so brig owns none of those readings and does not claim
+// the letter -- left of the verb it is an unknown token, and right of the ref
+// it is the agent's word, untouched.
+func TestVerboseHasNoShortForm(t *testing.T) {
+	_, _, err := parseGlobal([]string{"-v", "run", "claude"})
+	if err == nil {
+		t.Fatal("-v was accepted as a brig flag")
+	}
+	var ue *usageError
+	if !errors.As(err, &ue) {
+		t.Errorf("parseGlobal(-v): %v, want a usageError", err)
+	}
+
+	// And after the ref it reaches the agent rather than being read.
+	_, _, tail, parseErr := parse("run", []string{"claude", "-v"})
+	if parseErr != nil {
+		t.Fatalf("parse: %v", parseErr)
+	}
+	if strings.Join(tail, " ") != "-v" {
+		t.Errorf("tail = %q, want -v handed to the agent", tail)
+	}
+}
+
+// Asking to be told more and less at once is a mistake worth naming: either
+// winner would leave the line reading like it asked for the opposite.
+func TestVerboseAndQuietTogetherAreRefused(t *testing.T) {
+	if _, _, err := parseGlobal([]string{"--quiet", "--verbose", "run", "claude"}); err == nil {
+		t.Error("--quiet with --verbose was accepted")
+	}
+}
+
+// -q moved to the global position, and moving it must not break the line it
+// works on today: `brig run claude -q` still means quiet, and says where the
+// flag lives now. The run-line spelling goes in v0.3.
+func TestQuietOnTheRunLineStillWorksAndSaysWhereItMoved(t *testing.T) {
+	atLevel(t, wrap.Normal)
+	for _, args := range [][]string{{"claude", "-q"}, {"claude", "--quiet"}} {
+		var o options
+		said := captureStderr(t, func() {
+			var err error
+			o, _, _, err = parse("run", args)
+			if err != nil {
+				t.Fatalf("parse(%q): %v", args, err)
+			}
+		})
+		if !o.quiet {
+			t.Errorf("parse(%q) did not read the flag", args)
+		}
+		if !strings.Contains(said, "brig -q") {
+			t.Errorf("parse(%q) said %q, want a notice naming the global position", args, said)
+		}
+	}
+}
+
+// The global spelling is where the flag lives now, so it says nothing.
+func TestQuietInTheGlobalPositionIsNotDeprecated(t *testing.T) {
+	atLevel(t, wrap.Normal)
+	said := captureStderr(t, func() {
+		if _, _, err := parseGlobal([]string{"-q", "run", "claude"}); err != nil {
+			t.Fatal(err)
+		}
+	})
+	if said != "" {
+		t.Errorf("the global -q printed a notice: %q", said)
+	}
+}
+
+// -q is identifiers and errors only, so brig's own notices go with it.
+func TestQuietSuppressesBrigsOwnNotices(t *testing.T) {
+	atLevel(t, wrap.Quiet)
+	said := captureStderr(t, func() { warnf("something worth saying") })
+	if said != "" {
+		t.Errorf("-q printed a notice: %q", said)
+	}
+
+	atLevel(t, wrap.Normal)
+	said = captureStderr(t, func() { warnf("something worth saying") })
+	if !strings.Contains(said, "something worth saying") {
+		t.Errorf("the default output dropped a notice: %q", said)
+	}
+}

--- a/cmd/brig/verbosity_test.go
+++ b/cmd/brig/verbosity_test.go
@@ -127,3 +127,33 @@ func TestQuietSuppressesBrigsOwnNotices(t *testing.T) {
 		t.Errorf("the default output dropped a notice: %q", said)
 	}
 }
+
+// The envelope is behind --verbose. Nine rows of boundary before the agent says
+// anything is the machinery #24 is about, whoever wrote the machinery, and the
+// block is not gone: `brig info` is the command whose whole output it is, and
+// it answers without booting anything.
+//
+// Both of showsEnvelope's rules are here, because a change to either is silent:
+// a verb that starts printing the block interrupts a script, and a level that
+// starts printing it undoes this issue.
+func TestTheEnvelopeIsBehindVerbose(t *testing.T) {
+	for _, tc := range []struct {
+		verb  string
+		level wrap.Verbosity
+		want  bool
+	}{
+		{"run", wrap.Quiet, false},
+		{"run", wrap.Normal, false},
+		{"run", wrap.Verbose, true},
+		{"create", wrap.Verbose, true},
+		// sh continues a session whose boundary the reader has already met, and
+		// a scripted one on a cold sandbox must not be interrupted by a block.
+		{"sh", wrap.Verbose, false},
+		{"info", wrap.Verbose, false},
+		{"stop", wrap.Verbose, false},
+	} {
+		if got := showsEnvelope(tc.verb, tc.level); got != tc.want {
+			t.Errorf("showsEnvelope(%q, %d) = %v, want %v", tc.verb, tc.level, got, tc.want)
+		}
+	}
+}

--- a/cmd/brigd/main.go
+++ b/cmd/brigd/main.go
@@ -524,10 +524,10 @@ func (d *daemon) config(req Request) (*wrap.Config, *bytes.Buffer, error) {
 	// on it. It goes to the daemon's stderr instead, which is its log and the
 	// one place a line saying a boot has started is worth having.
 	cfg.Progress = os.Stderr
-	// And it keeps narrating there. #24 puts brig's own progress and the
-	// runtime's output behind --verbose, which is a decision about a terminal
-	// somebody is reading; the daemon's stderr is a log, and a log with the
-	// boot lines missing is the wrong trade. The client is unaffected either
+	// And it keeps narrating there. Progress and the runtime's output sit behind
+	// --verbose for a terminal somebody is reading; the daemon's stderr is a
+	// log, and a log with the boot lines missing is the wrong trade. The client
+	// is unaffected either
 	// way: its warnings come from Err, which is the buffer above.
 	cfg.Verbosity = wrap.Verbose
 	cfg.NoTerminal = true

--- a/cmd/brigd/main.go
+++ b/cmd/brigd/main.go
@@ -524,6 +524,12 @@ func (d *daemon) config(req Request) (*wrap.Config, *bytes.Buffer, error) {
 	// on it. It goes to the daemon's stderr instead, which is its log and the
 	// one place a line saying a boot has started is worth having.
 	cfg.Progress = os.Stderr
+	// And it keeps narrating there. #24 puts brig's own progress and the
+	// runtime's output behind --verbose, which is a decision about a terminal
+	// somebody is reading; the daemon's stderr is a log, and a log with the
+	// boot lines missing is the wrong trade. The client is unaffected either
+	// way: its warnings come from Err, which is the buffer above.
+	cfg.Verbosity = wrap.Verbose
 	cfg.NoTerminal = true
 	return cfg, said, nil
 }

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -47,17 +47,19 @@ The first run is the slow one. In order:
   ```
 
   Credentials are named, never printed. `brig info claude` shows the same block
-  without starting anything, and `--quiet` drops it.
+  without starting anything, and `brig -q run` drops it.
 - **The image is pulled.** The guest image comes down from the registry once.
   Later runs use the copy already on disk.
 - **The image is verified.** brig checks that the image was built by the
-  workflow that publishes it, and prints one line:
+  workflow that publishes it. A check that passed says nothing -- there is
+  nothing to do about it -- and `brig --verbose run` shows the line:
 
   ```
   brig: image ghcr.io/brig-sh/claude-code-stock:latest: signature verified
   ```
 
-  Then it starts the sandbox:
+  A check that fails, or one that could not be made, prints without being
+  asked. Then it starts the sandbox, which is another line `--verbose` carries:
 
   ```
   brig: starting sandbox brig-claude-code...

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -34,8 +34,9 @@ name for the `claude-code` profile.
 
 The first run is the slow one. In order:
 
-- **The envelope is printed.** Before anything boots, brig names the boundary
-  the run is about to trust:
+- **The boundary is named, if you ask.** `brig info claude` prints the
+  execution envelope without starting anything, and `brig --verbose run` prints
+  it before the boot:
 
   ```
   PROFILE      claude-code
@@ -43,23 +44,31 @@ The first run is the slow one. In order:
   ISOLATION    microVM (hull, vz backend)
   WORKSPACE    /Users/you/brig/claude-code (read-write)
   IMAGE        ghcr.io/brig-sh/claude-code-stock:latest (pull missing)
+  VERIFY       warn, against brig's own trust policy
   CREDENTIALS  GH_TOKEN
   ```
 
-  Credentials are named, never printed. `brig info claude` shows the same block
-  without starting anything, and `brig -q run` drops it.
+  Credentials are named, never printed. An ordinary run goes straight to the
+  work rather than printing this first.
 - **The image is pulled.** The guest image comes down from the registry once.
   Later runs use the copy already on disk.
-- **The image is verified.** brig checks that the image was built by the
-  workflow that publishes it. A check that passed says nothing -- there is
-  nothing to do about it -- and `brig --verbose run` shows the line:
+- **The image is verified.** brig checks that the image, and the kernel it
+  boots, were built by the workflow that publishes them. The run says so in one
+  line:
+
+  ```
+  brig: image and boot assets verified
+  ```
+
+  The `VERIFY` row above names the policy that line held under. A check that
+  did **not** hold prints at every level, `-q` included. The per-check detail
+  is `--verbose`'s:
 
   ```
   brig: image ghcr.io/brig-sh/claude-code-stock:latest: signature verified
   ```
 
-  A check that fails, or one that could not be made, prints without being
-  asked. Then it starts the sandbox, which is another line `--verbose` carries:
+  Then it starts the sandbox, which is another line `--verbose` carries:
 
   ```
   brig: starting sandbox brig-claude-code...

--- a/internal/runtime/bootfetch.go
+++ b/internal/runtime/bootfetch.go
@@ -2,6 +2,7 @@ package runtime
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	goruntime "runtime"
@@ -42,7 +43,11 @@ var lookPath = exec.LookPath
 // client in would cost brig its single-dependency go.mod, so brig shells out to
 // oras exactly as it shells out to cosign for signatures: use the tool when it
 // is present, say so plainly when it is not.
-func orasFetch(dir string) error {
+//
+// One line each end and the stream behind Progress, the same shape the hull
+// path takes: a first run downloads a bundle, and the reader is owed the fact
+// that it is downloading rather than every layer of how.
+func orasFetch(dir string, notice, progress io.Writer) error {
 	bin, err := lookPath("oras")
 	if err != nil {
 		return fmt.Errorf("oras is not installed, so the kernel and initrd cannot be downloaded. "+
@@ -52,13 +57,20 @@ func orasFetch(dir string) error {
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		return fmt.Errorf("create boot asset directory %s: %w", dir, err)
 	}
+	noticef(notice, "downloading the kernel and initrd this profile boots (once)...")
 	cmd := exec.Command(bin, "pull", bootAssetsRef(), "--output", dir)
-	// Progress belongs on stderr: brig's stdout is the workload's.
-	cmd.Stdout = os.Stderr
-	cmd.Stderr = os.Stderr
+	said := narrate(progress)
+	cmd.Stdout, cmd.Stderr = said, said
 	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("oras pull %s: %w (if the package is private, run "+
-			"`oras login ghcr.io` with a read:packages token)", bootAssetsRef(), err)
+		return said.explain(fmt.Errorf("oras pull %s: %w (if the package is private, run "+
+			"`oras login ghcr.io` with a read:packages token)", bootAssetsRef(), err))
 	}
+	noticef(notice, "kernel and initrd downloaded")
 	return nil
+}
+
+// orasFetcher binds the Linux download to one run's writers, the way the hull
+// adapter binds its own.
+func orasFetcher(spec RunSpec) assetFetcher {
+	return func(dir string) error { return orasFetch(dir, spec.Notice, spec.Progress) }
 }

--- a/internal/runtime/bootfetch_test.go
+++ b/internal/runtime/bootfetch_test.go
@@ -33,7 +33,7 @@ func TestOrasFetchWithoutOrasExplainsItself(t *testing.T) {
 	t.Cleanup(func() { lookPath = orig })
 	lookPath = func(string) (string, error) { return "", errors.New("not found") }
 
-	err := orasFetch(t.TempDir())
+	err := orasFetch(t.TempDir(), nil, nil)
 	if err == nil {
 		t.Fatal("expected an error when oras is not installed")
 	}
@@ -64,7 +64,7 @@ func TestOrasFetchCreatesTheDirectoryItWasGiven(t *testing.T) {
 	lookPath = func(string) (string, error) { return stub, nil }
 
 	dir := filepath.Join(t.TempDir(), "not", "yet", "there")
-	if err := orasFetch(dir); err != nil {
+	if err := orasFetch(dir, nil, nil); err != nil {
 		t.Fatal(err)
 	}
 	if info, err := os.Stat(dir); err != nil || !info.IsDir() {
@@ -85,7 +85,7 @@ func TestOrasFetchReportsFailure(t *testing.T) {
 	t.Cleanup(func() { lookPath = orig })
 	lookPath = func(string) (string, error) { return stub, nil }
 
-	err := orasFetch(t.TempDir())
+	err := orasFetch(t.TempDir(), nil, nil)
 	if err == nil {
 		t.Fatal("expected a failing oras to be reported")
 	}

--- a/internal/runtime/hull.go
+++ b/internal/runtime/hull.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"os"
+	"io"
 	"os/exec"
 	"strconv"
 	"strings"
@@ -174,21 +174,33 @@ func hypervisorOrDefault(hv string) string { return orDefault(hv, "vz") }
 // driving that is one implementation instead of two that have to agree, and it
 // means a genericBoot profile works on a clean machine with no manual step.
 //
-// Output goes to stderr: this is progress, and brig's stdout belongs to the
-// workload.
-func (h *hull) pullAssets(dir string) error {
+// This is the one long operation brig starts on a first run, and it gets one
+// line each end rather than a stream: hull's own download progress goes to
+// Progress, which is empty unless somebody asked for it, and the two notices
+// say that a minute of silence is a download rather than a hang (#24).
+func (h *hull) pullAssets(dir string, notice, progress io.Writer) error {
+	noticef(notice, "downloading the kernel and initrd this profile boots (once)...")
 	cmd := exec.Command(h.bin, "assets", "pull")
 	// Pin hull to the directory brig resolved. That directory came from hull
 	// itself via assetDir, so this is not brig overriding a choice -- it is
 	// brig making sure the place it checked and the place hull writes are the
 	// same one, even if something changed between the two calls.
 	cmd.Env = mergeEnv(telemetryEnv(false), []string{"HULL_BOOT_ASSETS=" + dir})
-	cmd.Stdout = os.Stderr
-	cmd.Stderr = os.Stderr
+	said := narrate(progress)
+	cmd.Stdout, cmd.Stderr = said, said
 	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("%s assets pull: %w", h.bin, err)
+		return said.explain(fmt.Errorf("%s assets pull: %w", h.bin, err))
 	}
+	noticef(notice, "kernel and initrd downloaded")
 	return nil
+}
+
+// assetFetcher binds the boot-asset download to one run's writers, so a fetch
+// that happens deep inside runArgs still narrates where that run's output
+// goes. The alternative is another two parameters threaded through runArgs,
+// which has enough of them.
+func (h *hull) assetFetcher(spec RunSpec) assetFetcher {
+	return func(dir string) error { return h.pullAssets(dir, spec.Notice, spec.Progress) }
 }
 
 // assetDir asks hull where its boot assets live.
@@ -301,7 +313,7 @@ func (h *hull) Run(spec RunSpec) error {
 		}
 		gatewaySock, gatewayCidr = sock, cidr
 	}
-	args, envVals, err := runArgs(spec, hv, net, gatewaySock, gatewayCidr, h.assetDir, h.pullAssets)
+	args, envVals, err := runArgs(spec, hv, net, gatewaySock, gatewayCidr, h.assetDir, h.assetFetcher(spec))
 	if err != nil {
 		return err
 	}
@@ -311,8 +323,16 @@ func (h *hull) Run(spec RunSpec) error {
 	// is counted only once an answer is already on file. See telemetryEnvFor.
 	cmd.Env = mergeEnv(h.telemetryEnvFor(spec.Counted, false), envVals)
 	cmd.Stdout = nil // the instance id is not interesting; failures explain themselves
-	cmd.Stderr = os.Stderr
-	return cmd.Run()
+	// Held rather than passed through. What hull says on its way up is a pull
+	// progress bar and a boot message, which is noise on a boot that works and
+	// the only evidence there is on one that does not, so it is quoted back on
+	// the error and otherwise dropped. See narration.
+	said := narrate(spec.Progress)
+	cmd.Stderr = said
+	if err := cmd.Run(); err != nil {
+		return said.explain(fmt.Errorf("%s run: %w", h.bin, err))
+	}
+	return nil
 }
 
 // supports rejects a spec the chosen backend cannot honour, before anything

--- a/internal/runtime/hull.go
+++ b/internal/runtime/hull.go
@@ -177,7 +177,7 @@ func hypervisorOrDefault(hv string) string { return orDefault(hv, "vz") }
 // This is the one long operation brig starts on a first run, and it gets one
 // line each end rather than a stream: hull's own download progress goes to
 // Progress, which is empty unless somebody asked for it, and the two notices
-// say that a minute of silence is a download rather than a hang (#24).
+// say that a minute of silence is a download rather than a hang.
 func (h *hull) pullAssets(dir string, notice, progress io.Writer) error {
 	noticef(notice, "downloading the kernel and initrd this profile boots (once)...")
 	cmd := exec.Command(h.bin, "assets", "pull")

--- a/internal/runtime/narrate.go
+++ b/internal/runtime/narrate.go
@@ -23,7 +23,7 @@ const narrationLimit = 64 << 10
 // wanted to read it. It is held instead: streamed live only when the caller
 // asked to see it, and otherwise quoted back on the error, where it is the
 // evidence for why a boot failed. Dropping it altogether would make a broken
-// boot unreportable, which is the one outcome worse than the noise (#24).
+// boot unreportable.
 //
 // It is deliberately not an io.Writer somebody can hand around: a narration
 // belongs to one child process, and explain is the other half of it.

--- a/internal/runtime/narrate.go
+++ b/internal/runtime/narrate.go
@@ -1,0 +1,100 @@
+package runtime
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"strings"
+)
+
+// narrationLimit is how much of a child process's output brig keeps while it
+// runs.
+//
+// An image pull writes a progress bar per layer and can print megabytes of it,
+// so what is held has to be bounded -- and it is the END that is kept. A tool
+// that printed progress and then died says why on its last few lines; the
+// first 64K of a progress bar is the half that explains nothing.
+const narrationLimit = 64 << 10
+
+// narration is where a child process's own output goes.
+//
+// brig used to hand the runtime its own stderr, so every pull progress bar and
+// boot message landed in the middle of brig's output whether or not anyone
+// wanted to read it. It is held instead: streamed live only when the caller
+// asked to see it, and otherwise quoted back on the error, where it is the
+// evidence for why a boot failed. Dropping it altogether would make a broken
+// boot unreportable, which is the one outcome worse than the noise (#24).
+//
+// It is deliberately not an io.Writer somebody can hand around: a narration
+// belongs to one child process, and explain is the other half of it.
+type narration struct {
+	live io.Writer
+	buf  bytes.Buffer
+}
+
+// narrate collects a child's output, streaming it to live as well when live is
+// non-nil. A nil live is the ordinary case: hold it, and say nothing unless
+// something goes wrong.
+func narrate(live io.Writer) *narration { return &narration{live: live} }
+
+func (n *narration) Write(p []byte) (int, error) {
+	if n.live != nil {
+		// Best effort. A terminal that has gone away is not a reason to fail
+		// the boot that was writing to it.
+		_, _ = n.live.Write(p)
+	}
+	n.buf.Write(p)
+	// Trimmed in blocks rather than on every write, so a chatty child costs one
+	// copy per 64K written instead of one per line.
+	if n.buf.Len() > 2*narrationLimit {
+		kept := append([]byte(nil), n.buf.Bytes()[n.buf.Len()-narrationLimit:]...)
+		n.buf.Reset()
+		n.buf.Write(kept)
+	}
+	return len(p), nil
+}
+
+// explain attaches what the child said to the error it died with, and returns
+// the error unchanged when it said nothing.
+//
+// Only when the output was not already streamed: a caller that asked to see it
+// live has seen it, and quoting the same lines again at the bottom of the
+// message reads like a second failure rather than the same one.
+func (n *narration) explain(err error) error {
+	if err == nil || n.live != nil {
+		return err
+	}
+	said := lastLines(strings.TrimRight(n.buf.String(), "\n"), 10)
+	if strings.TrimSpace(said) == "" {
+		return err
+	}
+	return fmt.Errorf("%w\n%s", err, indent(said))
+}
+
+// lastLines is the final n lines of s, which is where a tool that ran for a
+// while and then died says why. firstLines beside it is for a command that
+// fails immediately and prints one line about it.
+func lastLines(s string, n int) string {
+	lines := strings.Split(s, "\n")
+	if len(lines) > n {
+		lines = lines[len(lines)-n:]
+	}
+	return strings.Join(lines, "\n")
+}
+
+// indent puts the child's words under brig's, so a multi-line quotation reads
+// as a quotation rather than as more of brig's own sentence.
+func indent(s string) string { return "  " + strings.ReplaceAll(s, "\n", "\n  ") }
+
+// noticef writes one of brig's own lines about a long operation: that it has
+// started, and that it is done.
+//
+// It carries brig's prefix because it is brig's voice rather than the tool's --
+// the tool's own words go to Progress. A nil writer is silence, which is what a
+// caller that wants neither hands in.
+func noticef(w io.Writer, format string, a ...any) {
+	if w == nil {
+		return
+	}
+	fmt.Fprintf(w, "brig: "+format+"\n", a...)
+}

--- a/internal/runtime/narrate_test.go
+++ b/internal/runtime/narrate_test.go
@@ -1,0 +1,101 @@
+package runtime
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// stubRuntimeBin writes an executable that says something on stderr and exits
+// with the status given, so a test drives a real exec.Command through the
+// adapter rather than asserting on a flag somewhere above it.
+func stubRuntimeBin(t *testing.T, said string, status int) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "hull")
+	script := fmt.Sprintf("#!/bin/sh\ncat <<'SAID' >&2\n%s\nSAID\nexit %d\n", said, status)
+	if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+// The single most important behaviour in #24: the runtime's output is captured
+// rather than passed through, so a boot that fails must still quote what the
+// runtime said. Losing it would make a broken boot unreportable.
+func TestRunQuotesWhatTheRuntimeSaidWhenItFails(t *testing.T) {
+	h := &hull{bin: stubRuntimeBin(t, "pulling ghcr.io/x\nError: no space left on device", 1)}
+
+	err := h.Run(RunSpec{Name: "brig-x", Image: "img", Hypervisor: "vz"})
+	if err == nil {
+		t.Fatal("a runtime that exited non-zero must fail the boot")
+	}
+	if !strings.Contains(err.Error(), "no space left on device") {
+		t.Errorf("the failure does not carry what the runtime said: %v", err)
+	}
+}
+
+// A boot that works says nothing at all: what the runtime printed on its way
+// up is held and then dropped, which is the whole point of holding it.
+func TestRunSaysNothingWhenItWorks(t *testing.T) {
+	h := &hull{bin: stubRuntimeBin(t, "pulling ghcr.io/x", 0)}
+
+	if err := h.Run(RunSpec{Name: "brig-x", Image: "img", Hypervisor: "vz"}); err != nil {
+		t.Fatalf("boot: %v", err)
+	}
+}
+
+// Under --verbose the caller hands the runtime a writer, and the output goes
+// there as it happens rather than being held for a failure that may not come.
+func TestRunStreamsTheRuntimeOutputWhenItIsAskedFor(t *testing.T) {
+	h := &hull{bin: stubRuntimeBin(t, "pulling ghcr.io/x", 0)}
+
+	var progress bytes.Buffer
+	spec := RunSpec{Name: "brig-x", Image: "img", Hypervisor: "vz", Progress: &progress}
+	if err := h.Run(spec); err != nil {
+		t.Fatalf("boot: %v", err)
+	}
+	if !strings.Contains(progress.String(), "pulling ghcr.io/x") {
+		t.Errorf("the runtime's output did not reach the writer: %q", progress.String())
+	}
+}
+
+// Streamed output is not quoted back on the error as well: the reader watched
+// it happen, and repeating it at the bottom reads like a second failure.
+func TestRunDoesNotQuoteOutputItAlreadyPrinted(t *testing.T) {
+	h := &hull{bin: stubRuntimeBin(t, "Error: no space left on device", 1)}
+
+	var progress bytes.Buffer
+	spec := RunSpec{Name: "brig-x", Image: "img", Hypervisor: "vz", Progress: &progress}
+	err := h.Run(spec)
+	if err == nil {
+		t.Fatal("a runtime that exited non-zero must fail the boot")
+	}
+	if strings.Contains(err.Error(), "no space left on device") {
+		t.Errorf("the failure repeated output that was already on screen: %v", err)
+	}
+	if !strings.Contains(progress.String(), "no space left on device") {
+		t.Errorf("the runtime's output did not reach the writer: %q", progress.String())
+	}
+}
+
+// What is held is bounded, and it is the END that is kept: a tool that printed
+// a progress bar and then died says why on its last lines.
+func TestNarrationKeepsTheEndOfALongStream(t *testing.T) {
+	n := narrate(nil)
+	for i := 0; i < 4000; i++ {
+		fmt.Fprintf(n, "%s\n", strings.Repeat("x", 100))
+	}
+	fmt.Fprintln(n, "Error: the last word")
+
+	got := n.explain(errors.New("boom")).Error()
+	if !strings.Contains(got, "Error: the last word") {
+		t.Errorf("the end of the stream was dropped: %q", got)
+	}
+	if len(got) > 4*narrationLimit {
+		t.Errorf("the whole stream was held: %d bytes", len(got))
+	}
+}

--- a/internal/runtime/narrate_test.go
+++ b/internal/runtime/narrate_test.go
@@ -23,9 +23,9 @@ func stubRuntimeBin(t *testing.T, said string, status int) string {
 	return path
 }
 
-// The single most important behaviour in #24: the runtime's output is captured
-// rather than passed through, so a boot that fails must still quote what the
-// runtime said. Losing it would make a broken boot unreportable.
+// The runtime's output is captured rather than passed through, so a boot that
+// fails must still quote what the runtime said. Losing it would make a broken
+// boot unreportable.
 func TestRunQuotesWhatTheRuntimeSaidWhenItFails(t *testing.T) {
 	h := &hull{bin: stubRuntimeBin(t, "pulling ghcr.io/x\nError: no space left on device", 1)}
 

--- a/internal/runtime/nerdctl.go
+++ b/internal/runtime/nerdctl.go
@@ -193,8 +193,15 @@ func (n *nerdctl) Run(spec RunSpec) error {
 	}
 	cmd := exec.Command(n.bin, args...)
 	cmd.Env = mergeEnv(telemetryEnv(spec.Counted), envVals)
-	cmd.Stderr = os.Stderr
-	return cmd.Run()
+	// Held rather than passed through, for the reason the hull adapter gives:
+	// the pull progress is noise on a boot that works and the only evidence
+	// there is on one that does not.
+	said := narrate(spec.Progress)
+	cmd.Stderr = said
+	if err := cmd.Run(); err != nil {
+		return said.explain(fmt.Errorf("%s run: %w", n.bin, err))
+	}
+	return nil
 }
 
 // runArgs is the one place the run command line is built, for the same reason
@@ -306,7 +313,7 @@ func (n *nerdctl) runArgs(spec RunSpec) (args, env []string, err error) {
 		}
 		// oras rather than hull: hull does not build on Linux, so there is
 		// nothing to ask. See bootfetch.go.
-		annotations, err := bootAnnotations(nil, orasFetch)
+		annotations, err := bootAnnotations(nil, orasFetcher(spec))
 		if err != nil {
 			return nil, nil, err
 		}

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -114,7 +114,7 @@ type RunSpec struct {
 	// nil holds it instead. It is captured and quoted back on the error if the
 	// boot fails, where it is the evidence, and dropped if it does not -- see
 	// narration. That is the default because the output is worth reading in
-	// exactly two situations, and a boot that worked is neither of them (#24).
+	// exactly two situations, and a boot that worked is neither of them.
 	Progress io.Writer
 	// Notice is where a long operation says, in one line, that it has started
 	// and that it is done.

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -108,6 +108,22 @@ type RunSpec struct {
 	// Counted marks an operation that is a user action rather than brig's own
 	// plumbing, so telemetry counts one command once. See telemetryEnv.
 	Counted bool
+	// Progress is where the runtime's own output goes: the image pull, the
+	// boot messages, whatever the binary underneath writes on its way up.
+	//
+	// nil holds it instead. It is captured and quoted back on the error if the
+	// boot fails, where it is the evidence, and dropped if it does not -- see
+	// narration. That is the default because the output is worth reading in
+	// exactly two situations, and a boot that worked is neither of them (#24).
+	Progress io.Writer
+	// Notice is where a long operation says, in one line, that it has started
+	// and that it is done.
+	//
+	// Separate from Progress because the two answer different questions. The
+	// stream is detail and waits to be asked for; a download that takes a
+	// minute has to say so whether or not anyone asked, or the terminal looks
+	// hung. nil is silence.
+	Notice io.Writer
 }
 
 // ExecSpec is a request to run something inside a sandbox.

--- a/internal/wrap/alert_test.go
+++ b/internal/wrap/alert_test.go
@@ -1,0 +1,216 @@
+package wrap
+
+import (
+	"bufio"
+	"bytes"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/brig-sh/brig/internal/creds"
+	"github.com/brig-sh/brig/internal/verify"
+)
+
+// Every way verification can go wrong reaches the reader under -q.
+//
+// Table-driven on purpose: this is the whole of the change, and the cases are
+// the outcomes the decision tables can actually produce -- the mode being off,
+// a runtime that cannot pin what it checked, an image nobody claimed to
+// publish, a machine with no cosign, a signature that failed, and a local copy
+// that is not the digest that verified. A run that asked for silence still
+// hears all of them.
+func TestVerificationProblemsSurviveQuiet(t *testing.T) {
+	const ours = "ghcr.io/brig-sh/claude-code:arm64"
+	other := "sha256:2222222222222222222222222222222222222222222222222222222222222222"
+
+	for _, tc := range []struct {
+		name  string
+		build func(t *testing.T) *Config
+		want  string
+	}{
+		{
+			name: "checking is off",
+			build: func(t *testing.T) *Config {
+				c := verifyConfig(t, ours, verify.Off)
+				return c
+			},
+			want: "BRIG_VERIFY=off",
+		},
+		{
+			name: "the runtime cannot boot what was checked",
+			build: func(t *testing.T) *Config {
+				return verifyConfig(t, ours, verify.Warn)
+			},
+			want: "cannot boot by digest",
+		},
+		{
+			name: "nothing on the machine can check",
+			build: func(t *testing.T) *Config {
+				return verifyConfig(t, ours, verify.Warn)
+			},
+			want: "cosign is not installed",
+		},
+		{
+			name: "the image is nobody's we know",
+			build: func(t *testing.T) *Config {
+				c := digestConfig(t, "docker.io/someone/else:latest", verify.Warn,
+					fakeCosign(t, testDigest, false), testDigest)
+				return c
+			},
+			want: "is not published by brig-sh, so there is no signature of ours to check",
+		},
+		{
+			name: "the signature failed",
+			build: func(t *testing.T) *Config {
+				return digestConfig(t, ours, verify.Warn, fakeCosign(t, testDigest, true), testDigest)
+			},
+			want: "DID NOT VERIFY",
+		},
+		{
+			name: "the copy on disk is not what verified",
+			build: func(t *testing.T) *Config {
+				return digestConfig(t, ours, verify.Warn, fakeCosign(t, testDigest, false), other)
+			},
+			want: "NOT the sha256:",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			c := tc.build(t)
+			c.Verbosity = Quiet
+			said := &bytes.Buffer{}
+			c.Err = said
+
+			// The answer does not matter: a refusal and a boot both have to have
+			// said what was wrong before they get here.
+			_ = c.verifyImage()
+
+			if said.Len() == 0 {
+				t.Fatalf("-q silenced a verification problem entirely")
+			}
+			if !strings.Contains(said.String(), tc.want) {
+				t.Errorf("-q said %q, want it to mention %q", said.String(), tc.want)
+			}
+		})
+	}
+}
+
+// The boot assets are the other half of the same claim -- the kernel is the
+// more privileged of the two -- so they are not quieter than the image.
+func TestBootAssetProblemsSurviveQuiet(t *testing.T) {
+	c := verifyConfig(t, "ghcr.io/brig-sh/claude-code:arm64", verify.Warn)
+	c.Profile.GenericBoot = true
+	c.Verbosity = Quiet
+	said := &bytes.Buffer{}
+	c.Err = said
+
+	if err := c.verifyBootAssets(); err != nil {
+		t.Fatalf("warn mode must not refuse: %v", err)
+	}
+	if said.Len() == 0 {
+		t.Error("-q silenced a boot-asset verification problem")
+	}
+}
+
+// And there is nobody to ask is the same class: it is the check declining to
+// proceed, not a note about one.
+func TestNobodyToAskSurvivesQuiet(t *testing.T) {
+	c, said, _ := levelled(Quiet)
+	c.NoTerminal = true
+
+	if c.confirm("Boot it anyway?") {
+		t.Fatal("a run with nobody to ask must answer no")
+	}
+	if !strings.Contains(said.String(), "nobody to ask") {
+		t.Errorf("-q silenced the refusal: %q", said.String())
+	}
+}
+
+// The scoping, which is what keeps the level meaningful. An ordinary warning is
+// still a warning: a level that collects "important" collects everything within
+// a release, and then -q prints what it was added to suppress.
+func TestAnOrdinaryWarningIsStillSuppressedByQuiet(t *testing.T) {
+	c, said, _ := levelled(Quiet)
+	c.warnf("the imported credential expired 24m ago")
+	if said.Len() != 0 {
+		t.Errorf("-q printed an ordinary warning: %q", said.String())
+	}
+}
+
+// A site added to the verify path later must not reach for warnf, which -q
+// would silence. The behavioural cases above cover the outcomes a test can
+// drive; this covers the ones it cannot, and the ones nobody has written yet.
+//
+// Source-level because that is the only way to catch the site that does not
+// exist. sayVerified is the one exception and it is named rather than pattern-
+// matched: it reports that verification HELD, which is the one thing on this
+// path a script does not need and -q is right to drop.
+func TestVerifySitesDoNotReachForTheWarningLevel(t *testing.T) {
+	f, err := os.Open("verify.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = f.Close() }()
+
+	allowed := map[string]bool{"sayVerified": true}
+	fn, line := "", 0
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line++
+		text := scanner.Text()
+		if name, ok := funcName(text); ok {
+			fn = name
+		}
+		if strings.Contains(text, "c.warnf(") && !allowed[fn] {
+			t.Errorf("verify.go:%d: %s uses warnf, which -q silences. "+
+				"A verification problem is an alertf: it has to reach a caller "+
+				"that asked for silence. See alertf.", line, fn)
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		t.Fatal(err)
+	}
+	// The allowlist must not outlive what it names, or it silently widens.
+	if fn == "" {
+		t.Fatal("no functions were found in verify.go; the scan proves nothing")
+	}
+}
+
+// funcName reads a method declaration on Config, for the scan above.
+func funcName(line string) (string, bool) {
+	const prefix = "func (c *Config) "
+	if !strings.HasPrefix(line, prefix) {
+		return "", false
+	}
+	name, _, ok := strings.Cut(strings.TrimPrefix(line, prefix), "(")
+	return name, ok
+}
+
+// BRIG_VERIFY=off is stated exactly once, whether or not the envelope carried
+// it, and at every level.
+//
+// Both halves are needed and neither is redundant: the VERIFY row says it on a
+// run that printed the block, and the standalone line says it on one that did
+// not -- a cold `brig sh`, and every run below --verbose. Saying it twice is
+// how a reader learns to skip it, and saying it neither way is how a sandbox
+// boots unchecked in silence.
+func TestCheckingOffIsStatedExactlyOnce(t *testing.T) {
+	for _, level := range []Verbosity{Quiet, Normal, Verbose} {
+		for _, withEnvelope := range []bool{false, true} {
+			c := verifyConfig(t, "ghcr.io/brig-sh/claude-code:arm64", verify.Off)
+			c.Verbosity = level
+			said := &bytes.Buffer{}
+			c.Err = said
+			if withEnvelope {
+				c.PrintPreRunEnvelope(creds.Set{})
+			}
+
+			if err := c.verifyImage(); err != nil {
+				t.Fatalf("level %d: off must not refuse: %v", level, err)
+			}
+			if got := strings.Count(said.String(), "BRIG_VERIFY=off"); got != 1 {
+				t.Errorf("level %d, envelope %v: BRIG_VERIFY=off stated %d times, want 1:\n%s",
+					level, withEnvelope, got, said.String())
+			}
+		}
+	}
+}

--- a/internal/wrap/config.go
+++ b/internal/wrap/config.go
@@ -16,6 +16,31 @@ import (
 	"github.com/brig-sh/brig/internal/verify"
 )
 
+// Verbosity is how much a run says about itself.
+//
+// The rule it encodes is the one #24 sets: by default, print what the user has
+// to act on. A warning is an action and stays; brig's own narration and the
+// runtime's own output are not, and wait to be asked for. Below the default is
+// the form a script reads, where the output is identifiers and the errors that
+// stopped them, and nothing in between.
+//
+// Ordered rather than a set of modes, so every print site asks the same
+// question -- is this worth saying at the level we are at -- with one
+// comparison instead of a switch that has to be kept exhaustive.
+type Verbosity int
+
+const (
+	// Quiet is identifiers and errors only, for a script. An error is never
+	// printed at this level; it is returned, and the caller prints it.
+	Quiet Verbosity = iota - 1
+	// Normal is the default: warnings, the execution envelope, and one line
+	// each end of a long operation. It is the zero value, so a Config built by
+	// hand is at the level a person reads rather than silent.
+	Normal
+	// Verbose adds brig's own progress and the runtime's own output.
+	Verbose
+)
+
 // NamePrefix is what every brig sandbox name begins with. It is how brig picks
 // its own sandboxes out of a runtime that may be running other things, so it is
 // the one part of the name that is not the caller's to drop -- see the BRIG_NAME
@@ -163,6 +188,12 @@ type Config struct {
 	// why it went unnoticed for as long as the CLI was the only caller.
 	Progress io.Writer
 
+	// Verbosity decides how much of the above is written. See the type: Err
+	// carries warnings and goes quiet only under -q, and Progress carries
+	// narration and stays empty until --verbose asks for it. Out is not
+	// levelled -- it is the report `brig info` was asked for by name.
+	Verbosity Verbosity
+
 	env Env
 }
 
@@ -192,6 +223,11 @@ type Options struct {
 	// Network is the posture asked for on the command line, and beats both the
 	// setting and the profile. Empty means nothing was asked for.
 	Network string
+	// Verbosity is how much this invocation was asked to say: --verbose and
+	// -q, which are read left of the verb. The zero value is the default
+	// level, so a caller with no opinion -- brigd, and every test that builds
+	// Options by hand -- gets what a person reads.
+	Verbosity Verbosity
 }
 
 // Load resolves the configuration for one invocation.
@@ -366,6 +402,7 @@ func Load(t profile.Profile, o Options, rt runtime.Runtime) (*Config, error) {
 		Out:            os.Stdout,
 		Err:            os.Stderr,
 		Progress:       os.Stderr,
+		Verbosity:      o.Verbosity,
 		env:            env,
 	}
 	if strictErr != nil {

--- a/internal/wrap/config.go
+++ b/internal/wrap/config.go
@@ -18,8 +18,8 @@ import (
 
 // Verbosity is how much a run says about itself.
 //
-// The rule it encodes is the one #24 sets: by default, print what the user has
-// to act on. A warning is an action and stays; brig's own narration and the
+// The rule it encodes: by default, print what the user has to act on. A
+// warning is an action and stays; brig's own narration and the
 // runtime's own output are not, and wait to be asked for. Below the default is
 // the form a script reads, where the output is identifiers and the errors that
 // stopped them, and nothing in between.

--- a/internal/wrap/config.go
+++ b/internal/wrap/config.go
@@ -129,7 +129,20 @@ type Config struct {
 	// runtime so the object that boots is the object that verified; empty means
 	// boot the tag as given, which is every hull run and any path that could not
 	// resolve a digest.
-	BootDigest  string
+	BootDigest string
+	// envelopeShown records that the execution envelope has been printed for
+	// this run, so the VERIFY row's fact is not then repeated as a standalone
+	// line. Set by PrintPreRunEnvelope, read by verifyImage.
+	envelopeShown bool
+	// verified is what actually checked out during this run's verification
+	// step, in the order it was checked: "image", "boot assets". Empty when
+	// nothing was positively verified -- BRIG_VERIFY=off, an image nobody
+	// claimed to publish, a machine with no cosign -- each of which says so on
+	// its own, at warning level, where it belongs.
+	//
+	// Collected rather than reported as it happens because the run says it in
+	// one line for the whole step. See sayVerified.
+	verified    []string
 	AllowRefs   bool
 	AllowDenied bool
 	// AllowExpired forwards the host credential even when its own expiry says it

--- a/internal/wrap/envelope.go
+++ b/internal/wrap/envelope.go
@@ -123,9 +123,9 @@ func (c *Config) isolationLine() string {
 // this row is written there is no outcome to report. sayVerified prints the
 // other half when the checks have run.
 //
-// The pair is what makes a quiet run readable. #24 put the per-check success
-// lines behind --verbose, on the rule that a check which passed is not an
-// action; without this row a default run saying nothing about verification
+// The pair is what makes a quiet run readable. The per-check success lines are
+// behind --verbose, on the rule that a check which passed is not an action;
+// without this row a default run saying nothing about verification
 // would be indistinguishable from one where nothing was checked, which is the
 // one reading that must never be available by accident. The row says what the
 // policy is, the line afterwards says it held, and everything that did not hold

--- a/internal/wrap/envelope.go
+++ b/internal/wrap/envelope.go
@@ -8,6 +8,7 @@ import (
 	"github.com/brig-sh/brig/internal/creds"
 	"github.com/brig-sh/brig/internal/profile"
 	"github.com/brig-sh/brig/internal/runtime"
+	"github.com/brig-sh/brig/internal/verify"
 )
 
 // envelopeRow is one line of the execution envelope: a label and the value
@@ -78,9 +79,12 @@ func (c *Config) envelope(set creds.Set) []envelopeRow {
 	}
 	rows = append(rows,
 		// The pull policy, the same detail the full report prints beside the
-		// image. Whether the signature verified is a separate fact that the
-		// verify-mode row will carry, so it is deliberately not folded in here.
+		// image. Whether the signature verified is a separate fact, and the row
+		// below carries the half of it that is knowable here.
 		envelopeRow{"IMAGE", fmt.Sprintf("%s (pull %s)", c.Image, c.Pull)},
+		// Directly under the image, because it is the same subject: that row
+		// names what boots and this one names whether anything checks it first.
+		envelopeRow{"VERIFY", c.verifyLine()},
 		envelopeRow{"CREDENTIALS", c.credentialLine(set)},
 		// The posture, said out loud. It decides what the agent can reach, and
 		// until it appeared here the only way to know was to remember which
@@ -108,6 +112,38 @@ func (c *Config) isolationLine() string {
 			" (no runtime, so brig cannot tell what a sandbox here would stand on)"
 	}
 	return c.Runtime.Isolation(c.hypervisor()).Line()
+}
+
+// verifyLine is the VERIFY row: whether the guest image and the kernel it boots
+// are checked before they run, and whose policy says so.
+//
+// The mode rather than the outcome, and that is forced rather than chosen. The
+// envelope is printed before the sandbox boots, which is the whole point of it,
+// and verification happens inside EnsureRunning afterwards -- so at the moment
+// this row is written there is no outcome to report. sayVerified prints the
+// other half when the checks have run.
+//
+// The pair is what makes a quiet run readable. #24 put the per-check success
+// lines behind --verbose, on the rule that a check which passed is not an
+// action; without this row a default run saying nothing about verification
+// would be indistinguishable from one where nothing was checked, which is the
+// one reading that must never be available by accident. The row says what the
+// policy is, the line afterwards says it held, and everything that did not hold
+// still prints unasked.
+//
+// The full report reads this too, so the block and `brig info` cannot come to
+// describe the same policy differently. See reportVerify.
+func (c *Config) verifyLine() string {
+	switch {
+	case c.Verify == verify.Off:
+		return "off (BRIG_VERIFY=off), so nothing is checked before it boots"
+	case c.VerifyPolicy.Replaced():
+		return fmt.Sprintf("%s, against a replaced trust policy "+
+			"(BRIG_VERIFY_REGISTRY, BRIG_VERIFY_IDENTITY or BRIG_VERIFY_ISSUER is set, "+
+			"so this is not brig's own check)", c.Verify)
+	default:
+		return fmt.Sprintf("%s, against brig's own trust policy", c.Verify)
+	}
 }
 
 // credentialLine is the CREDENTIALS row: every credential this run hands the
@@ -182,7 +218,12 @@ func (c *Config) renderEnvelope(w io.Writer, set creds.Set) {
 // sandbox, to stderr. Stderr rather than stdout so it never lands in the
 // agent's own output or in the sandbox name a scripted create captures; the
 // block is a notice, not the command's result. --quiet suppresses it entirely.
-func (c *Config) PrintPreRunEnvelope(set creds.Set) { c.renderEnvelope(c.Err, set) }
+func (c *Config) PrintPreRunEnvelope(set creds.Set) {
+	// Recorded so the checks below do not say a second time what the VERIFY row
+	// has just said. See verifyImage.
+	c.envelopeShown = true
+	c.renderEnvelope(c.Err, set)
+}
 
 // Info is `brig info`: the envelope, then everything `brig env` has always
 // printed, both to stdout because here the report is the point. `brig env` is

--- a/internal/wrap/run.go
+++ b/internal/wrap/run.go
@@ -277,6 +277,10 @@ func (c *Config) EnsureRunning(set creds.Set) error {
 	if err := c.verifyBootAssets(); err != nil {
 		return &VerifyRefusedError{Err: err}
 	}
+	// Both checks are in, so the run can state the outcome in one line. Here
+	// rather than inside either check, because there is one answer for the step
+	// and two checks that reach it. See sayVerified.
+	c.sayVerified()
 
 	// The share below is a path, and the runtime resolves it again on its own
 	// time -- after the image pull, after the VM starts. PrepareWorkspace

--- a/internal/wrap/run.go
+++ b/internal/wrap/run.go
@@ -335,6 +335,12 @@ func (c *Config) EnsureRunning(set creds.Set) error {
 		// read it, so the backend this spec boots is the one that was checked.
 		Hypervisor: hypervisor,
 		Counted:    true,
+		// Where the runtime's own words go. Empty unless --verbose asked for
+		// them, which is what tells the adapter to hold them for the failure
+		// instead; the one line each end of a long download is separate and
+		// stays in the default output. See runtimeOutput and runtimeNotice.
+		Progress: c.runtimeOutput(),
+		Notice:   c.runtimeNotice(),
 	}
 	if err := c.Runtime.Run(spec); err != nil {
 		return fmt.Errorf("could not start the sandbox: %w", err)

--- a/internal/wrap/status.go
+++ b/internal/wrap/status.go
@@ -1,7 +1,6 @@
 package wrap
 
 import (
-	"github.com/brig-sh/brig/internal/verify"
 	"strings"
 
 	"github.com/brig-sh/brig/internal/creds"
@@ -295,15 +294,11 @@ var nowMilli = defaultNowMilli
 // returned before any output when off, and a replaced policy printed the same
 // success line as the shipped one. A reader who has to notice an absence to
 // learn either of those is not being told.
+//
+// The sentence comes from verifyLine, which the VERIFY row also reads. Two
+// copies of it is two things to change, and the one that goes stale is a
+// report about a check rather than the check itself -- the worse half to get
+// wrong, because nothing fails to make it visible.
 func (c *Config) reportVerify() {
-	switch {
-	case c.Verify == verify.Off:
-		c.sayf("image verification: off (BRIG_VERIFY=off), so nothing is checked before it boots")
-	case c.VerifyPolicy.Replaced():
-		c.sayf("image verification: %s, against a replaced trust policy "+
-			"(BRIG_VERIFY_REGISTRY, BRIG_VERIFY_IDENTITY or BRIG_VERIFY_ISSUER is set, "+
-			"so this is not brig's own check)", c.Verify)
-	default:
-		c.sayf("image verification: %s, against brig's own trust policy", c.Verify)
-	}
+	c.sayf("image verification: %s", c.verifyLine())
 }

--- a/internal/wrap/verbosity_test.go
+++ b/internal/wrap/verbosity_test.go
@@ -1,0 +1,104 @@
+package wrap
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+// levelled builds a Config whose three writers a test can read back, at the
+// level given. Nothing here boots anything: what is under test is which of the
+// print helpers writes at which level.
+func levelled(v Verbosity) (*Config, *bytes.Buffer, *bytes.Buffer) {
+	out, progress := &bytes.Buffer{}, &bytes.Buffer{}
+	return &Config{Out: out, Err: out, Progress: progress, Verbosity: v}, out, progress
+}
+
+// The rule the issue sets: by default, print what the user has to act on. A
+// warning is an action, so it stays in the default output.
+func TestWarningsStayInTheDefaultOutput(t *testing.T) {
+	c, said, _ := levelled(Normal)
+	c.warnf("the host's credential has expired")
+	if !strings.Contains(said.String(), "expired") {
+		t.Errorf("a warning was dropped from the default output: %q", said.String())
+	}
+}
+
+// -q is identifiers and errors only, so a warning is not printed there: an
+// error is returned rather than warned about, and everything between the two
+// is what a script did not ask for.
+func TestQuietDropsWarnings(t *testing.T) {
+	c, said, _ := levelled(Quiet)
+	c.warnf("the host's credential has expired")
+	if said.Len() != 0 {
+		t.Errorf("-q printed a warning: %q", said.String())
+	}
+}
+
+// brig's own narration -- the line saying a boot has started -- is not an
+// action, so it waits to be asked for.
+func TestProgressNarrationWaitsForVerbose(t *testing.T) {
+	c, _, progress := levelled(Normal)
+	c.progressf("starting sandbox %s...", "brig-claude-code")
+	if progress.Len() != 0 {
+		t.Errorf("the default output narrated a boot: %q", progress.String())
+	}
+
+	c, _, progress = levelled(Verbose)
+	c.progressf("starting sandbox %s...", "brig-claude-code")
+	if !strings.Contains(progress.String(), "starting sandbox") {
+		t.Errorf("--verbose did not print the narration: %q", progress.String())
+	}
+}
+
+// The report `brig info` prints is the answer to the command rather than
+// narration about one, so it is not levelled: asking for it by name is the
+// whole of the request.
+func TestTheReportIsNotLevelled(t *testing.T) {
+	for _, v := range []Verbosity{Quiet, Normal, Verbose} {
+		c, said, _ := levelled(v)
+		c.sayf("image %s (pull %s)", "img", "missing")
+		if !strings.Contains(said.String(), "image img") {
+			t.Errorf("verbosity %d dropped a line of the report: %q", v, said.String())
+		}
+	}
+}
+
+// What the runtime says is handed a writer only when somebody asked to see it.
+// Otherwise the runtime holds it and quotes it back if the boot fails, which is
+// what a nil writer asks for.
+func TestTheRuntimeGetsAWriterOnlyUnderVerbose(t *testing.T) {
+	for _, tc := range []struct {
+		level Verbosity
+		want  bool
+	}{{Quiet, false}, {Normal, false}, {Verbose, true}} {
+		c, _, _ := levelled(tc.level)
+		if got := c.runtimeOutput() != nil; got != tc.want {
+			t.Errorf("verbosity %d: runtime writer %v, want %v", tc.level, got, tc.want)
+		}
+	}
+}
+
+// One long operation gets one line whether or not anyone asked for detail: a
+// download that takes a minute has to say so, or the terminal looks hung. Only
+// -q, which is reading a script's output, drops it.
+func TestALongOperationAnnouncesItselfByDefault(t *testing.T) {
+	for _, tc := range []struct {
+		level Verbosity
+		want  bool
+	}{{Quiet, false}, {Normal, true}, {Verbose, true}} {
+		c, _, _ := levelled(tc.level)
+		if got := c.runtimeNotice() != nil; got != tc.want {
+			t.Errorf("verbosity %d: notice writer %v, want %v", tc.level, got, tc.want)
+		}
+	}
+}
+
+// Normal is the zero value, so a Config built by hand -- every one in these
+// tests, and brigd's -- is at the level a person reads rather than silent.
+func TestNormalIsTheZeroValue(t *testing.T) {
+	var v Verbosity
+	if v != Normal {
+		t.Errorf("the zero Verbosity is %d, want Normal", v)
+	}
+}

--- a/internal/wrap/verbosity_test.go
+++ b/internal/wrap/verbosity_test.go
@@ -4,6 +4,9 @@ import (
 	"bytes"
 	"strings"
 	"testing"
+
+	"github.com/brig-sh/brig/internal/creds"
+	"github.com/brig-sh/brig/internal/verify"
 )
 
 // levelled builds a Config whose three writers a test can read back, at the
@@ -100,5 +103,147 @@ func TestNormalIsTheZeroValue(t *testing.T) {
 	var v Verbosity
 	if v != Normal {
 		t.Errorf("the zero Verbosity is %d, want Normal", v)
+	}
+}
+
+// The VERIFY row names the policy this run boots under, for every mode.
+//
+// It is the half of verification that is knowable when the envelope is
+// printed: the block goes out before the sandbox boots, which is the point of
+// it, and the checks happen afterwards inside EnsureRunning. See verifyLine.
+func TestTheEnvelopeNamesTheVerifyMode(t *testing.T) {
+	for _, mode := range []verify.Mode{verify.Require, verify.Warn, verify.Off} {
+		c := testConfig(t, t.TempDir(), t.TempDir())
+		c.Verify = mode
+		block := &bytes.Buffer{}
+		c.renderEnvelope(block, creds.Set{})
+
+		got := block.String()
+		if !strings.Contains(got, "VERIFY ") {
+			t.Errorf("%s: the envelope has no VERIFY row:\n%s", mode, got)
+			continue
+		}
+		if !strings.Contains(got, string(mode)) {
+			t.Errorf("%s: the VERIFY row does not name the mode:\n%s", mode, got)
+		}
+	}
+}
+
+// A replaced trust policy is the state the row most has to carry: the check
+// still runs and still reports success, and it is no longer brig's check.
+func TestTheVerifyRowSaysWhenThePolicyIsNotBrigsOwn(t *testing.T) {
+	c := testConfig(t, t.TempDir(), t.TempDir())
+	c.Verify = verify.Warn
+	c.VerifyPolicy = verify.Policy{Registry: "ghcr.io/someone-else"}
+	if !c.VerifyPolicy.Replaced() {
+		t.Fatal("the fixture policy does not read as replaced; the test proves nothing")
+	}
+
+	if got := c.verifyLine(); !strings.Contains(got, "replaced trust policy") {
+		t.Errorf("the VERIFY row does not say the policy is not brig's: %q", got)
+	}
+}
+
+// The outcome, which the row cannot carry. A default run states that
+// verification held, in one line, so that a quiet run is not asking the reader
+// to infer it from an absence.
+func TestADefaultRunSaysVerificationHeld(t *testing.T) {
+	c, said, _ := levelled(Normal)
+	c.verified = []string{"image"}
+	c.sayVerified()
+	if !strings.Contains(said.String(), "image verified") {
+		t.Errorf("a default run said nothing about verification holding: %q", said.String())
+	}
+}
+
+// One line for the whole step, however many checks reached it: a reader wants
+// to know that what boots verified, not to audit the checks.
+func TestTheOutcomeIsOneLineForEveryCheck(t *testing.T) {
+	c, said, _ := levelled(Normal)
+	c.verified = []string{"image", "boot assets"}
+	c.sayVerified()
+	if got := strings.Count(said.String(), "\n"); got != 1 {
+		t.Errorf("the outcome took %d lines, want 1: %q", got, said.String())
+	}
+	if !strings.Contains(said.String(), "image and boot assets verified") {
+		t.Errorf("the outcome does not name both checks: %q", said.String())
+	}
+}
+
+// And nothing is said when nothing was positively checked. BRIG_VERIFY=off, an
+// image nobody claimed to publish and a machine with no cosign each say so
+// themselves, in the default output; "verified" beside any of them is false.
+func TestNothingIsSaidWhenNothingVerified(t *testing.T) {
+	c, said, _ := levelled(Normal)
+	c.sayVerified()
+	if said.Len() != 0 {
+		t.Errorf("a run that verified nothing claimed it had: %q", said.String())
+	}
+}
+
+// -q takes the outcome with everything else between an identifier and an
+// error; --verbose keeps it and adds the per-check detail it summarises.
+func TestTheOutcomeFollowsTheLevel(t *testing.T) {
+	c, said, _ := levelled(Quiet)
+	c.verified = []string{"image"}
+	c.sayVerified()
+	if said.Len() != 0 {
+		t.Errorf("-q printed the verification outcome: %q", said.String())
+	}
+
+	c, said, progress := levelled(Verbose)
+	c.verified = []string{"image"}
+	c.progressf("image ghcr.io/x: signature verified")
+	c.sayVerified()
+	if !strings.Contains(said.String(), "image verified") {
+		t.Errorf("--verbose dropped the outcome: %q", said.String())
+	}
+	if !strings.Contains(progress.String(), "signature verified") {
+		t.Errorf("--verbose dropped the per-check detail: %q", progress.String())
+	}
+}
+
+// `brig info` does not boot, so it has no outcome to report: the row appears
+// and the line does not. That asymmetry is the report being honest about what
+// it knows rather than a gap in it -- the command answers what a run WOULD
+// trust, and whether a signature holds is not established until something
+// checks it.
+func TestInfoShowsTheModeAndNoOutcome(t *testing.T) {
+	c := testConfig(t, t.TempDir(), t.TempDir())
+	c.Verify = verify.Require
+	report, said := &bytes.Buffer{}, &bytes.Buffer{}
+	c.Out, c.Err = report, said
+
+	c.Info(creds.Set{})
+
+	if !strings.Contains(report.String(), "VERIFY ") {
+		t.Errorf("brig info has no VERIFY row:\n%s", report.String())
+	}
+	if !strings.Contains(report.String(), "image verification: require") {
+		t.Errorf("brig info dropped the verification line from the report:\n%s", report.String())
+	}
+	for _, w := range []*bytes.Buffer{report, said} {
+		if strings.Contains(w.String(), "image verified") {
+			t.Errorf("brig info claimed an outcome it never established:\n%s", w.String())
+		}
+	}
+}
+
+// The envelope is `brig info`'s output whatever level a run asks for. It is the
+// answer to a command asked by name, which is the same reason the report it
+// heads is not levelled -- see sayf. Only a RUN decides whether to print it,
+// and cmd/brig makes that decision; the block itself never goes quiet.
+func TestInfoPrintsTheEnvelopeAtEveryLevel(t *testing.T) {
+	for _, level := range []Verbosity{Quiet, Normal, Verbose} {
+		c := testConfig(t, t.TempDir(), t.TempDir())
+		c.Verbosity = level
+		report := &bytes.Buffer{}
+		c.Out = report
+
+		c.Info(creds.Set{})
+
+		if !strings.Contains(report.String(), "SANDBOX ") {
+			t.Errorf("level %d: brig info dropped the envelope:\n%s", level, report.String())
+		}
 	}
 }

--- a/internal/wrap/verify.go
+++ b/internal/wrap/verify.go
@@ -50,13 +50,29 @@ func (c *Config) verifyImage() error {
 		// state no command mentioned: the check returned here, before any
 		// output, so a sandbox booted unchecked and nothing on screen said so.
 		// The quietest path was the one that most needed a line.
-		c.warnf("BRIG_VERIFY=off, so the guest image is not checked before it boots")
+		//
+		// Unless the envelope has already said it. The VERIFY row carries the
+		// mode, so on a run that printed the block this line is the same fact a
+		// second time, four lines apart -- and a fact stated twice is one a
+		// reader starts skipping. Said exactly once at every level: by the row
+		// when there is one, by this line when there is not, which is every
+		// default run, every -q run and every cold `brig sh`.
+		if !c.envelopeShown {
+			c.alertf("BRIG_VERIFY=off, so the guest image is not checked before it boots")
+		}
 		return nil
 	}
 	if c.Runtime.PinsDigest() {
 		return c.verifyDigest()
 	}
-	c.warnf("this %s cannot boot by digest (hull 0.1.0-rc23 or newer can), so the tag "+
+	// An alert rather than a warning, on the same rule as "could not check": it
+	// is a caveat on the claim, not a note beside it. What verified and what
+	// boots are not provably the same bytes here -- under the default pull
+	// policy they need not be, which is the limitation docs/security.md
+	// records -- so a reader told nothing would believe a digest was pinned
+	// when none was. The upgrade advice in it is incidental; the substance is
+	// that brig's guarantee is weaker on this host than it otherwise is.
+	c.alertf("this %s cannot boot by digest (hull 0.1.0-rc23 or newer can), so the tag "+
 		"is verified and booted rather than a pinned digest", c.Runtime.Kind())
 	return c.verifyTag()
 }
@@ -70,9 +86,12 @@ func (c *Config) verifyTag() error {
 
 	switch res.Outcome {
 	case verify.Verified:
-		// A signature that checked out is nothing to act on, so it narrates
-		// rather than warns: the default output carries the refusals and the
-		// gaps, and no news here is the good news. See Verbosity.
+		// The per-check detail narrates rather than warns: a signature that
+		// checked out is nothing to act on, and one line per check on every
+		// boot is the noise #24 is about. What the default run gets instead is
+		// one summary line for the whole step, which is what recording it here
+		// is for. See sayVerified.
+		c.verified = append(c.verified, "image")
 		c.progressf("%s", res.Message())
 		return nil
 
@@ -80,11 +99,11 @@ func (c *Config) verifyTag() error {
 		if c.Verify == verify.Require {
 			return fmt.Errorf("%s (BRIG_VERIFY=require)", res.Message())
 		}
-		c.warnf("%s", res.Message())
+		c.alertf("%s", res.Message())
 		return nil
 
 	default:
-		c.warnf("%s", res.Message())
+		c.alertf("%s", res.Message())
 		if c.Verify == verify.Require {
 			return errors.New("refusing to boot an image that failed verification")
 		}
@@ -135,10 +154,11 @@ func (c *Config) verifyDigest() error {
 		// nothing to act on and narrates; an image nobody claimed to publish is
 		// a gap in what was checked, and that stays on screen.
 		if res.Outcome == verify.Verified {
+			c.verified = append(c.verified, "image")
 			c.progressf("%s", res.Message())
 			return nil
 		}
-		c.warnf("%s", res.Message())
+		c.alertf("%s", res.Message())
 		return nil
 
 	case verify.NoTooling:
@@ -149,7 +169,7 @@ func (c *Config) verifyDigest() error {
 		if c.Verify == verify.Require {
 			return fmt.Errorf("%s (BRIG_VERIFY=require)", res.Message())
 		}
-		c.warnf("%s", res.Message())
+		c.alertf("%s", res.Message())
 		return nil
 
 	case verify.Unresolved:
@@ -160,7 +180,7 @@ func (c *Config) verifyDigest() error {
 		// would let anyone who can make the registry unreachable, a captive
 		// portal or a sinkhole, turn the default mode into "unchecked". Nothing
 		// is pinned either way: a yes boots the cached tag.
-		c.warnf("%s", res.Message())
+		c.alertf("%s", res.Message())
 		if c.Verify == verify.Require {
 			return errors.New("refusing to boot an image that could not be verified " +
 				"(BRIG_VERIFY=require)")
@@ -176,11 +196,11 @@ func (c *Config) verifyDigest() error {
 		// Boot the resolved digest whatever we decide below: the object on disk
 		// is the one we are refusing to trust, so a "yes" must not boot it.
 		c.BootDigest = res.Digest
-		c.warnf("%s", res.Message())
+		c.alertf("%s", res.Message())
 		if !res.Ours {
-			// A third party's copy differing from the registry is a warning, the
-			// same weight as NotOurs -- unless Require, which trusts nothing it
-			// cannot positively verify.
+			// A third party's copy differing from the registry is said and
+			// booted, the same weight as NotOurs -- unless Require, which
+			// trusts nothing it cannot positively verify.
 			if c.Verify == verify.Require {
 				return errors.New("refusing under BRIG_VERIFY=require: the local image " +
 					"is not the digest the registry serves")
@@ -200,7 +220,7 @@ func (c *Config) verifyDigest() error {
 
 	default: // verify.Failed
 		c.BootDigest = res.Digest
-		c.warnf("%s", res.Message())
+		c.alertf("%s", res.Message())
 		if c.Verify == verify.Require {
 			return errors.New("refusing to boot an image that failed verification")
 		}
@@ -218,6 +238,35 @@ func (c *Config) verifyDigest() error {
 	}
 }
 
+// sayVerified is the one line a default run prints about verification that
+// held.
+//
+// It is the other half of the VERIFY row. The row names the policy before the
+// sandbox boots, because that is all that is knowable then; this names the
+// result after the checks have run. Without it a quiet run says nothing about
+// verification at all, and "nothing was said" would have to be read as "it
+// verified" -- an inference on an absence, about the one subject where a reader
+// must never have to make one.
+//
+// A warning rather than narration, unlike the per-check lines it summarises.
+// Those are detail about how the answer was reached and wait for --verbose;
+// this is the answer, and the default run is where it belongs. -q drops it with
+// everything else between an identifier and an error.
+//
+// One line for the whole step, not one per check. The image and the kernel are
+// two checks under one policy, and a reader wants to know that what boots
+// verified rather than to audit the checks -- which is also why nothing is said
+// when nothing was positively checked. BRIG_VERIFY=off, an image nobody
+// claimed to publish and a machine with no cosign have each already said so
+// themselves, in the default output, and a run that added "verified" beside
+// them would be false.
+func (c *Config) sayVerified() {
+	if len(c.verified) == 0 {
+		return
+	}
+	c.warnf("%s verified", strings.Join(c.verified, " and "))
+}
+
 // confirm asks a yes/no question, defaulting to no.
 //
 // Without a terminal there is nobody to ask, and assuming yes would turn the
@@ -232,7 +281,7 @@ func (c *Config) verifyDigest() error {
 // front of nobody while the client waits.
 func (c *Config) confirm(question string) bool {
 	if c.NoTerminal || !IsTerminal(os.Stdin) {
-		c.warnf("not a terminal, so there is nobody to ask: refusing. " +
+		c.alertf("not a terminal, so there is nobody to ask: refusing. " +
 			"Set BRIG_VERIFY=off to boot it regardless.")
 		return false
 	}
@@ -283,7 +332,9 @@ func (c *Config) verifyBootAssets() error {
 	switch res.Outcome {
 	case verify.Verified:
 		// Narration for the same reason the image's success line is: the kernel
-		// verified, and there is nothing here for anybody to do about it.
+		// verified, and there is nothing here for anybody to do about it. It
+		// joins the summary the run prints for the whole step.
+		c.verified = append(c.verified, "boot assets")
 		c.progressf("boot assets %s: signature verified", ref)
 		return nil
 
@@ -295,18 +346,18 @@ func (c *Config) verifyBootAssets() error {
 			return fmt.Errorf("refusing to boot: the boot assets at %s are not published "+
 				"by brig, so their signature cannot be checked (BRIG_VERIFY=require)", ref)
 		}
-		c.warnf("boot assets %s are not published by brig, so nothing was checked "+
+		c.alertf("boot assets %s are not published by brig, so nothing was checked "+
 			"about the kernel this sandbox boots", ref)
 		return nil
 
 	case verify.NoTooling, verify.Unresolved:
-		// Could not check, rather than failed. It follows the image's rule: a
-		// warning by default, a refusal under require.
+		// Could not check, rather than failed. It follows the image's rule: said
+		// out loud at every level by default, a refusal under require.
 		if c.Verify == verify.Require {
 			return fmt.Errorf("refusing to boot: the boot assets at %s could not be "+
 				"verified (%s) (BRIG_VERIFY=require)", ref, res.Message())
 		}
-		c.warnf("the boot assets at %s could not be verified: %s", ref, res.Message())
+		c.alertf("the boot assets at %s could not be verified: %s", ref, res.Message())
 		return nil
 
 	default:

--- a/internal/wrap/verify.go
+++ b/internal/wrap/verify.go
@@ -88,7 +88,7 @@ func (c *Config) verifyTag() error {
 	case verify.Verified:
 		// The per-check detail narrates rather than warns: a signature that
 		// checked out is nothing to act on, and one line per check on every
-		// boot is the noise #24 is about. What the default run gets instead is
+		// boot is noise. What the default run gets instead is
 		// one summary line for the whole step, which is what recording it here
 		// is for. See sayVerified.
 		c.verified = append(c.verified, "image")

--- a/internal/wrap/verify.go
+++ b/internal/wrap/verify.go
@@ -70,7 +70,10 @@ func (c *Config) verifyTag() error {
 
 	switch res.Outcome {
 	case verify.Verified:
-		c.warnf("%s", res.Message())
+		// A signature that checked out is nothing to act on, so it narrates
+		// rather than warns: the default output carries the refusals and the
+		// gaps, and no news here is the good news. See Verbosity.
+		c.progressf("%s", res.Message())
 		return nil
 
 	case verify.NotOurs, verify.NoTooling:
@@ -127,6 +130,13 @@ func (c *Config) verifyDigest() error {
 		c.BootDigest = res.Digest
 		if res.Outcome == verify.NotOurs && c.Verify == verify.Require {
 			return fmt.Errorf("%s (BRIG_VERIFY=require)", res.Message())
+		}
+		// The two outcomes part company here. A signature that checked out is
+		// nothing to act on and narrates; an image nobody claimed to publish is
+		// a gap in what was checked, and that stays on screen.
+		if res.Outcome == verify.Verified {
+			c.progressf("%s", res.Message())
+			return nil
 		}
 		c.warnf("%s", res.Message())
 		return nil
@@ -272,7 +282,9 @@ func (c *Config) verifyBootAssets() error {
 
 	switch res.Outcome {
 	case verify.Verified:
-		c.warnf("boot assets %s: signature verified", ref)
+		// Narration for the same reason the image's success line is: the kernel
+		// verified, and there is nothing here for anybody to do about it.
+		c.progressf("boot assets %s: signature verified", ref)
 		return nil
 
 	case verify.NotOurs:

--- a/internal/wrap/verify_test.go
+++ b/internal/wrap/verify_test.go
@@ -116,8 +116,8 @@ const testDigest = "sha256:11111111111111111111111111111111111111111111111111111
 // The digest brig resolved and verified is the digest it records to boot, and
 // the line names it.
 //
-// The line is narration rather than a warning since #24 -- a signature that
-// checked out is nothing to act on -- so it is read off Progress, and the run
+// The line is narration rather than a warning -- a signature that checked out
+// is nothing to act on -- so it is read off Progress, and the run
 // asks for the detail the way --verbose does.
 func TestVerifyDigestPinsAndReportsTheDigest(t *testing.T) {
 	cosign := fakeCosign(t, testDigest, false)

--- a/internal/wrap/verify_test.go
+++ b/internal/wrap/verify_test.go
@@ -24,7 +24,14 @@ type verifyRuntime struct {
 	local string
 }
 
-func (v verifyRuntime) Kind() string                       { return "hull" }
+func (v verifyRuntime) Kind() string { return "hull" }
+
+// Answered because the envelope asks it: the VERIFY row sits in the same block
+// as the ISOLATION row, so a test that prints the block needs both.
+func (v verifyRuntime) Isolation(string) runtime.Isolation {
+	return runtime.Isolation{Boundary: runtime.BoundaryVM, Detail: "hull, vz backend"}
+}
+
 func (v verifyRuntime) PinsDigest() bool                   { return v.pins }
 func (v verifyRuntime) LocalDigest(string) (string, error) { return v.local, nil }
 

--- a/internal/wrap/verify_test.go
+++ b/internal/wrap/verify_test.go
@@ -108,17 +108,37 @@ const testDigest = "sha256:11111111111111111111111111111111111111111111111111111
 
 // The digest brig resolved and verified is the digest it records to boot, and
 // the line names it.
+//
+// The line is narration rather than a warning since #24 -- a signature that
+// checked out is nothing to act on -- so it is read off Progress, and the run
+// asks for the detail the way --verbose does.
 func TestVerifyDigestPinsAndReportsTheDigest(t *testing.T) {
 	cosign := fakeCosign(t, testDigest, false)
 	c := digestConfig(t, "ghcr.io/brig-sh/claude-code:arm64", verify.Warn, cosign, testDigest)
+	progress := &bytes.Buffer{}
+	c.Progress, c.Verbosity = progress, Verbose
 	if err := c.verifyImage(); err != nil {
 		t.Fatalf("a verified image was refused: %v", err)
 	}
 	if c.BootDigest != testDigest {
 		t.Errorf("BootDigest = %q, want the resolved digest so EnsureRunning boots it", c.BootDigest)
 	}
-	if said := c.Err.(*bytes.Buffer).String(); !strings.Contains(said, testDigest) {
+	if said := progress.String(); !strings.Contains(said, testDigest) {
 		t.Errorf("the message did not name the digest: %q", said)
+	}
+}
+
+// And the default run says nothing about it. A verification that succeeded is
+// not an action, so the absence of a line is the report: everything this switch
+// prints in the default output is a refusal or a gap in what was checked.
+func TestAVerifiedImageIsSilentByDefault(t *testing.T) {
+	cosign := fakeCosign(t, testDigest, false)
+	c := digestConfig(t, "ghcr.io/brig-sh/claude-code:arm64", verify.Warn, cosign, testDigest)
+	if err := c.verifyImage(); err != nil {
+		t.Fatalf("a verified image was refused: %v", err)
+	}
+	if said := c.Err.(*bytes.Buffer).String(); said != "" {
+		t.Errorf("a default run narrated a successful verification: %q", said)
 	}
 }
 

--- a/internal/wrap/workspace.go
+++ b/internal/wrap/workspace.go
@@ -16,26 +16,72 @@ import (
 // markerFile identifies the workspace from inside the guest. See Marker.
 const markerFile = ".brig-workspace"
 
+// warnf says something the reader has to act on: an expired credential, an
+// image that did not verify, a share that went stale.
+//
+// It stays in the default output, because a warning is an action -- that is the
+// half of #24's rule that keeps things on screen rather than taking them off.
+// Only -q drops it, and -q is a script asking for identifiers and errors and
+// nothing between the two.
 func (c *Config) warnf(format string, a ...any) {
+	if c.Verbosity < Normal {
+		return
+	}
 	fmt.Fprintf(c.Err, "brig: "+format+"\n", a...)
 }
 
+// sayf writes one line of the report `brig info` prints.
+//
+// Deliberately not levelled, unlike the two below it. This is the answer to the
+// command rather than narration about one: somebody typed the verb whose whole
+// output this is, and a report that went quiet because it was not asked for
+// twice would be a command that does nothing.
 func (c *Config) sayf(format string, a ...any) {
 	fmt.Fprintf(c.Out, "brig: "+format+"\n", a...)
 }
 
 // progressf narrates what the run is doing. See Config.Progress for why this
-// is not warnf.
+// is not warnf, and Verbosity for why it waits: a line saying a boot has
+// started is not something anybody acts on, so it is printed for the reader who
+// asked for detail and to nobody else.
 //
 // A nil Progress is silence rather than a panic, unlike Out and Err: losing a
 // line of narration costs the reader nothing, and every test that builds a
 // Config by hand would otherwise have to declare where its progress goes to
 // ask a question about something else.
 func (c *Config) progressf(format string, a ...any) {
-	if c.Progress == nil {
+	if c.Progress == nil || c.Verbosity < Verbose {
 		return
 	}
 	fmt.Fprintf(c.Progress, "brig: "+format+"\n", a...)
+}
+
+// runtimeOutput is where the runtime's own output goes: the writer a run
+// narrates to when --verbose asked for it, and nil otherwise.
+//
+// nil is not "throw it away". It is what tells the runtime adapter to hold the
+// output and quote it back if the boot fails, which is the one situation a
+// reader who wanted none of the detail still needs all of it. See
+// runtime.RunSpec.Progress.
+func (c *Config) runtimeOutput() io.Writer {
+	if c.Verbosity < Verbose {
+		return nil
+	}
+	return c.Progress
+}
+
+// runtimeNotice is where a long operation says, in one line, that it has
+// started and that it is done.
+//
+// It sits at the default level rather than behind --verbose, which is the whole
+// of #24's sixth item: a first run downloads a kernel, and a minute of silence
+// with nothing on screen reads as a hang. The stream behind that line is
+// runtimeOutput's, and it stays behind --verbose.
+func (c *Config) runtimeNotice() io.Writer {
+	if c.Verbosity < Normal {
+		return nil
+	}
+	return c.Progress
 }
 
 // Marker identifies this workspace by path and inode.

--- a/internal/wrap/workspace.go
+++ b/internal/wrap/workspace.go
@@ -30,6 +30,28 @@ func (c *Config) warnf(format string, a ...any) {
 	fmt.Fprintf(c.Err, "brig: "+format+"\n", a...)
 }
 
+// alertf says something about verification that has to reach the reader
+// whatever level was asked for.
+//
+// It outranks warnf, and the rank is the whole point. -q hides warnings because
+// a script asked for identifiers and errors, and that is a fair trade for an
+// expired credential or a stale share: the run still works, the fact keeps, and
+// the next interactive run says it again. It is not a fair trade for "nothing
+// checked the image this sandbox boots". Verification is the claim brig exists
+// to make, and a run that skipped the check, could not make it, or made it and
+// did not like the answer has to say so even to a caller that asked for
+// silence -- because the caller asking for silence is exactly the unattended
+// one where an unchecked image matters most.
+//
+// Only verification belongs here, and that scoping is not fussiness. A level
+// that means "important" collects everything within a release, and then -q is
+// back to printing what it was added to suppress. Everything else brig warns
+// about stays a warning: the credential expiry, the workspace notices, the
+// deprecations.
+func (c *Config) alertf(format string, a ...any) {
+	fmt.Fprintf(c.Err, "brig: "+format+"\n", a...)
+}
+
 // sayf writes one line of the report `brig info` prints.
 //
 // Deliberately not levelled, unlike the two below it. This is the answer to the

--- a/internal/wrap/workspace.go
+++ b/internal/wrap/workspace.go
@@ -19,9 +19,8 @@ const markerFile = ".brig-workspace"
 // warnf says something the reader has to act on: an expired credential, an
 // image that did not verify, a share that went stale.
 //
-// It stays in the default output, because a warning is an action -- that is the
-// half of #24's rule that keeps things on screen rather than taking them off.
-// Only -q drops it, and -q is a script asking for identifiers and errors and
+// It stays in the default output, because a warning is an action. Only -q
+// drops it, and -q is a script asking for identifiers and errors and
 // nothing between the two.
 func (c *Config) warnf(format string, a ...any) {
 	if c.Verbosity < Normal {
@@ -95,9 +94,9 @@ func (c *Config) runtimeOutput() io.Writer {
 // runtimeNotice is where a long operation says, in one line, that it has
 // started and that it is done.
 //
-// It sits at the default level rather than behind --verbose, which is the whole
-// of #24's sixth item: a first run downloads a kernel, and a minute of silence
-// with nothing on screen reads as a hang. The stream behind that line is
+// It sits at the default level rather than behind --verbose: a first run
+// downloads a kernel, and a minute of silence with nothing on screen reads as a
+// hang. The stream behind that line is
 // runtimeOutput's, and it stays behind --verbose.
 func (c *Config) runtimeNotice() io.Writer {
 	if c.Verbosity < Normal {

--- a/script/smoke.sh
+++ b/script/smoke.sh
@@ -45,6 +45,15 @@ case "$verb" in
       printf '%s stopped\n' "$(cat "$STUB_STATE.stopped")"
     ;;
   run)
+    # What a real runtime says on its way up: a pull, then a boot. brig holds
+    # this rather than passing it through, so the cases below can ask where it
+    # ended up. STUB_RUN_FAIL turns the boot into the one that has to stay
+    # reportable however quiet brig is.
+    printf 'pulling ghcr.io/brig-sh/claude-code-stock:latest\n' >&2
+    if [ -n "${STUB_RUN_FAIL:-}" ]; then
+      printf 'FATAL: no space left on device\n' >&2
+      exit 1
+    fi
     # Remember the instance name and the shared directory the way a real
     # runtime binds them at boot.
     #
@@ -1411,10 +1420,21 @@ export BRIG_COSIGN_BIN="$WORK/bin/cosign"
 fresh() { "$WORK/brig" stop claude > /dev/null 2>&1; }
 
 fresh
+# A signature that checks out is narration, not a warning: there is nothing for
+# anyone to act on, so #24 moved it behind --verbose. The default run below
+# asserts the other half -- that the line is gone from the output a person gets
+# without asking for detail -- and everything else this section checks is a
+# refusal or a gap, which stays on screen either way.
+out="$(BRIG_VERIFY=warn "$WORK/brig" --verbose run claude -p hi 2>&1)"
+case "$out" in
+  *"signature verified"*) ok "a signature that checks out is reported under --verbose" ;;
+  *) bad "a signature that checks out is reported under --verbose -- got: $out" ;;
+esac
+fresh
 out="$(BRIG_VERIFY=warn "$WORK/brig" run claude -p hi 2>&1)"
 case "$out" in
-  *"signature verified"*) ok "a signature that checks out is reported" ;;
-  *) bad "a signature that checks out is reported -- got: $out" ;;
+  *"signature verified"*) bad "a default run reported a signature that checked out -- got: $out" ;;
+  *) ok "a default run says nothing about a signature that checks out" ;;
 esac
 grep 'argv: run ' "$STUB_LOG" | tail -1 | grep -q '@sha256:' \
   && ok "the verified digest is what hull was told to boot" \
@@ -1525,6 +1545,110 @@ retired '<agent>@<label>' run claude --name retn -d
 retired '<agent>@<label>' run claude -n retn -d
 # Last of the group: it removes what the others were acting on.
 retired 'brig rm --all' reset
+
+echo "== what a run says =="
+# #24: by default, print what the user has to act on. brig's own progress and
+# the runtime's own output wait for --verbose; -q is identifiers and errors.
+"$WORK/brig" rm --all > /dev/null 2>&1
+: > "$STUB_LOG"
+CLAUDE_CODE_OAUTH_TOKEN=env-token-secret \
+  "$WORK/brig" run claude -d > "$WORK/say.out" 2> "$WORK/say.err"
+grep -q '^SANDBOX ' "$WORK/say.err" \
+  && ok "a default run prints the envelope" \
+  || bad "a default run prints the envelope -- got: $(cat "$WORK/say.err")"
+grep -q 'starting sandbox' "$WORK/say.err" \
+  && bad "a default run narrated the boot -- got: $(cat "$WORK/say.err")" \
+  || ok "a default run does not narrate the boot"
+grep -q 'pulling ghcr.io' "$WORK/say.err" \
+  && bad "a default run passed the runtime's output through -- got: $(cat "$WORK/say.err")" \
+  || ok "a default run holds the runtime's output"
+
+# --verbose asks for both, and gets both.
+"$WORK/brig" rm --all > /dev/null 2>&1
+CLAUDE_CODE_OAUTH_TOKEN=env-token-secret \
+  "$WORK/brig" --verbose run claude -d > /dev/null 2> "$WORK/verbose.err"
+grep -q 'starting sandbox' "$WORK/verbose.err" \
+  && ok "--verbose narrates the boot" \
+  || bad "--verbose narrates the boot -- got: $(cat "$WORK/verbose.err")"
+grep -q 'pulling ghcr.io' "$WORK/verbose.err" \
+  && ok "--verbose prints the runtime's own output" \
+  || bad "--verbose prints the runtime's own output -- got: $(cat "$WORK/verbose.err")"
+
+# The one that matters most: a boot that fails still says what the runtime said,
+# with nothing asked for. Hold the output and lose it and a broken boot becomes
+# unreportable.
+"$WORK/brig" rm --all > /dev/null 2>&1
+CLAUDE_CODE_OAUTH_TOKEN=env-token-secret STUB_RUN_FAIL=1 \
+  "$WORK/brig" run claude -d > /dev/null 2> "$WORK/failed.err"
+rc=$?
+[ "$rc" != 0 ] && ok "a boot the runtime refused fails the run" \
+  || bad "a boot the runtime refused exited 0"
+grep -q 'no space left on device' "$WORK/failed.err" \
+  && ok "a failed boot quotes what the runtime said" \
+  || bad "a failed boot quotes what the runtime said -- got: $(cat "$WORK/failed.err")"
+
+# -q is identifiers and errors only: the envelope goes, and so do the warnings
+# that stand in the default output.
+"$WORK/brig" rm --all > /dev/null 2>&1
+: > "$STUB_LOG"
+CLAUDE_CODE_OAUTH_TOKEN=env-token-secret GH_TOKEN='op://vault/item/field' \
+  "$WORK/brig" -q run claude -d > "$WORK/q.out" 2> "$WORK/q.err"
+grep -q '^SANDBOX ' "$WORK/q.err" \
+  && bad "brig -q printed the envelope" || ok "brig -q drops the envelope"
+grep -q 'unresolved secret reference' "$WORK/q.err" \
+  && bad "brig -q printed a warning -- got: $(cat "$WORK/q.err")" \
+  || ok "brig -q drops brig's warnings"
+# The other half of "identifiers and errors only": an error is not something -q
+# takes away, and neither is the evidence under it. A boot that fails has to be
+# reportable at every level brig has.
+"$WORK/brig" rm --all > /dev/null 2>&1
+CLAUDE_CODE_OAUTH_TOKEN=env-token-secret STUB_RUN_FAIL=1 \
+  "$WORK/brig" -q run claude -d > /dev/null 2> "$WORK/qfail.err"
+rc=$?
+[ "$rc" != 0 ] && ok "brig -q still fails a boot the runtime refused" \
+  || bad "brig -q exited 0 on a boot the runtime refused"
+grep -q 'no space left on device' "$WORK/qfail.err" \
+  && ok "brig -q still quotes what the runtime said" \
+  || bad "brig -q still quotes what the runtime said -- got: $(cat "$WORK/qfail.err")"
+
+# The same flag after the verb, which is where it used to live. It keeps
+# working for this release and names the position it moved to.
+"$WORK/brig" rm --all > /dev/null 2>&1
+CLAUDE_CODE_OAUTH_TOKEN=env-token-secret \
+  "$WORK/brig" run claude -q -d > /dev/null 2> "$WORK/runq.err"
+grep -q '^SANDBOX ' "$WORK/runq.err" \
+  && bad "run -q printed the envelope" || ok "-q after the verb still means quiet"
+grep -q 'is now `brig -q <verb> <ref>`' "$WORK/runq.err" \
+  && ok "-q after the verb names the global position" \
+  || bad "-q after the verb names the global position -- got: $(cat "$WORK/runq.err")"
+
+# -v is not brig's. It is Claude Code's version flag, codex's verbose flag and
+# Docker's volume flag, so brig claims neither reading: left of the verb it is
+# an unknown token, and right of the ref it is the agent's word.
+"$WORK/brig" -v run claude > "$WORK/dashv.out" 2>&1
+rc=$?
+[ "$rc" = 2 ] && ok "-v before the command is a usage error" \
+  || bad "-v before the command is a usage error -- rc $rc: $(cat "$WORK/dashv.out")"
+CLAUDE_CODE_OAUTH_TOKEN=env-token-secret \
+  "$WORK/brig" run claude -v > /dev/null 2> "$WORK/agentv.err"
+rc=$?
+# Not a usage error: right of the ref the vocabulary is the agent's, and brig
+# hands the token over rather than reading it. Any other status is the run
+# itself, which the cases above assert.
+[ "$rc" != 2 ] && ok "-v after the ref is not brig's to refuse" \
+  || bad "-v after the ref was refused: $(cat "$WORK/agentv.err")"
+grep -q -- "-v is one of brig's own flags" "$WORK/agentv.err" \
+  && bad "brig claimed -v as its own -- got: $(cat "$WORK/agentv.err")" \
+  || ok "brig claims no reading of -v"
+
+# And the global -q reaches ls as the meaning ls already had: refs alone.
+"$WORK/brig" -q ls > "$WORK/globalq.out" 2>&1
+[ "$(cat "$WORK/globalq.out")" = claude-code ] \
+  && ok "brig -q ls prints the refs alone" \
+  || bad "brig -q ls prints the refs alone -- got: $(cat "$WORK/globalq.out")"
+"$WORK/brig" ls -q > "$WORK/lsq.out" 2>&1
+[ "$(cat "$WORK/lsq.out")" = claude-code ] \
+  && ok "ls -q is unchanged" || bad "ls -q is unchanged -- got: $(cat "$WORK/lsq.out")"
 
 [ "$fail" = 0 ] && echo PASS || echo FAILURES
 exit "$fail"

--- a/script/smoke.sh
+++ b/script/smoke.sh
@@ -214,9 +214,9 @@ echo "== envelope =="
 # stdout or a scripted create's sandbox name. It names the boundary before the
 # boot noise.
 #
-# Behind --verbose since #24: nine rows of boundary before the agent says
-# anything is machinery, and `brig info` is the command whose whole output it
-# is. So the assertions below read a --verbose run, and the first pair pins the
+# Behind --verbose: nine rows of boundary before the agent says anything is
+# machinery, and `brig info` is the command whose whole output it is. So the
+# assertions below read a --verbose run, and the first pair pins the
 # default: the block is absent, and what a quiet run still says about the
 # boundary is the verification line.
 grep -q '^SANDBOX ' "$WORK/run.err" \
@@ -1434,7 +1434,7 @@ fresh() { "$WORK/brig" stop claude > /dev/null 2>&1; }
 
 fresh
 # A signature that checks out is narration, not a warning: there is nothing for
-# anyone to act on, so #24 moved it behind --verbose. The default run below
+# anyone to act on, so it sits behind --verbose. The default run below
 # asserts the other half -- that the line is gone from the output a person gets
 # without asking for detail -- and everything else this section checks is a
 # refusal or a gap, which stays on screen either way.
@@ -1637,8 +1637,8 @@ retired '<agent>@<label>' run claude -n retn -d
 retired 'brig rm --all' reset
 
 echo "== what a run says =="
-# #24: by default, print what the user has to act on. brig's own progress and
-# the runtime's own output wait for --verbose; -q is identifiers and errors.
+# By default, print what the user has to act on. brig's own progress and the
+# runtime's own output wait for --verbose; -q is identifiers and errors.
 "$WORK/brig" rm --all > /dev/null 2>&1
 : > "$STUB_LOG"
 CLAUDE_CODE_OAUTH_TOKEN=env-token-secret \

--- a/script/smoke.sh
+++ b/script/smoke.sh
@@ -213,31 +213,44 @@ echo "== envelope =="
 # The block is a notice, printed to stderr so it never pollutes the agent's
 # stdout or a scripted create's sandbox name. It names the boundary before the
 # boot noise.
-grep -q '^SANDBOX .*brig-claude-code' "$WORK/run.err" \
-  && ok "run prints the execution envelope" \
-  || bad "run prints the execution envelope: $(cat "$WORK/run.err")"
-grep -q '^WORKSPACE ' "$WORK/run.err" \
+#
+# Behind --verbose since #24: nine rows of boundary before the agent says
+# anything is machinery, and `brig info` is the command whose whole output it
+# is. So the assertions below read a --verbose run, and the first pair pins the
+# default: the block is absent, and what a quiet run still says about the
+# boundary is the verification line.
+grep -q '^SANDBOX ' "$WORK/run.err" \
+  && bad "a default run printed the envelope -- got: $(cat "$WORK/run.err")" \
+  || ok "a default run does not print the envelope"
+: > "$STUB_LOG"
+CLAUDE_CODE_OAUTH_TOKEN=env-token-secret GH_TOKEN=gh-secret \
+  "$WORK/brig" --verbose run claude -p hi > /dev/null 2> "$WORK/env.err"
+grep -q '^SANDBOX .*brig-claude-code' "$WORK/env.err" \
+  && ok "--verbose prints the execution envelope" \
+  || bad "--verbose prints the execution envelope: $(cat "$WORK/env.err")"
+grep -q '^WORKSPACE ' "$WORK/env.err" \
   && ok "the envelope names the workspace" || bad "the envelope names the workspace"
 # What the sandbox stands on, not only what drives it. The stub is a hull
 # stand-in and BRIG_HYPERVISOR is pinned to vz above, so the row names that
 # backend; which containerd shim maps to which boundary is settled in the
 # runtime package's own tests, there being no containerd here to ask.
-grep -q '^ISOLATION .*microVM (hull, vz backend)' "$WORK/run.err" \
+grep -q '^ISOLATION .*microVM (hull, vz backend)' "$WORK/env.err" \
   && ok "the envelope names the isolation boundary" \
-  || bad "the envelope names the isolation boundary -- got: $(grep '^ISOLATION' "$WORK/run.err")"
+  || bad "the envelope names the isolation boundary -- got: $(grep '^ISOLATION' "$WORK/env.err")"
 # A value must never reach the block, the same promise argv keeps. Scan the
 # whole envelope output rather than a fixed list of rows, so a row added later
 # is covered without touching this check.
-grep -q 'env-token-secret\|gh-secret\|host-token' "$WORK/run.err" \
+grep -q 'env-token-secret\|gh-secret\|host-token' "$WORK/env.err" \
   && bad "the envelope printed a credential value" \
   || ok "the envelope names credentials, never values"
 
-# --quiet drops the block and changes nothing else about the run.
+# -q prints no envelope either, which is no longer -q's doing -- the default
+# prints none. Kept as the guard that asking for less never yields more.
 : > "$STUB_LOG"
 CLAUDE_CODE_OAUTH_TOKEN=env-token-secret GH_TOKEN=gh-secret \
   "$WORK/brig" run claude --quiet -p hi > /dev/null 2> "$WORK/quiet.err"
 grep -q '^SANDBOX ' "$WORK/quiet.err" \
-  && bad "--quiet still printed the envelope" || ok "--quiet suppresses the envelope"
+  && bad "--quiet printed the envelope" || ok "--quiet prints no envelope"
 
 echo "== workspace =="
 [ -f "$WS/.claude.json" ] && ok "onboarding is seeded" || bad "onboarding is seeded"
@@ -266,7 +279,7 @@ PROJ="$WORK/myproject"
 mkdir -p "$PROJ"
 : > "$STUB_LOG"
 CLAUDE_CODE_OAUTH_TOKEN=env-token-secret \
-  "$WORK/brig" run claude "$PROJ" -p hi > "$WORK/proj.out" 2> "$WORK/proj.err"
+  "$WORK/brig" --verbose run claude "$PROJ" -p hi > "$WORK/proj.out" 2> "$WORK/proj.err"
 rc=$?
 [ "$rc" = 0 ] && ok "a run with a project exits 0" \
   || bad "a run with a project exits 0 -- got $rc: $(cat "$WORK/proj.err")"
@@ -443,7 +456,7 @@ echo "== network =="
 # check that the resolved value actually travels.
 "$WORK/brig" rm --all > /dev/null 2>&1
 : > "$STUB_LOG"
-"$WORK/brig" run claude --offline -d > "$WORK/off.out" 2>&1
+"$WORK/brig" --verbose run claude --offline -d > "$WORK/off.out" 2>&1
 grep -q -- '--net none' "$STUB_LOG" \
   && ok "--offline reaches the runtime as --net none" \
   || bad "--offline reaches the runtime as --net none -- got: $(grep '^argv: run' "$STUB_LOG")"
@@ -453,7 +466,7 @@ grep -q '^NETWORK .*offline' "$WORK/off.out" \
 
 "$WORK/brig" rm --all > /dev/null 2>&1
 : > "$STUB_LOG"
-"$WORK/brig" run claude -d > "$WORK/on.out" 2>&1
+"$WORK/brig" --verbose run claude -d > "$WORK/on.out" 2>&1
 grep -q -- '--net shared' "$STUB_LOG" \
   && ok "a default run still asks for the shared network" \
   || bad "a default run still asks for the shared network -- got: $(grep '^argv: run' "$STUB_LOG")"
@@ -467,7 +480,7 @@ grep -q '^NETWORK .*shared' "$WORK/on.out" \
 # other is a real-runtime fact, recorded in docs/manual-tests.
 "$WORK/brig" rm --all > /dev/null 2>&1
 : > "$STUB_LOG"
-"$WORK/brig" run claude --network isolated -d > "$WORK/iso.out" 2>&1
+"$WORK/brig" --verbose run claude --network isolated -d > "$WORK/iso.out" 2>&1
 grep -q -- '--net isolated' "$STUB_LOG" \
   && ok "--network isolated reaches the runtime" \
   || bad "--network isolated reaches the runtime -- got: $(grep '^argv: run' "$STUB_LOG")"
@@ -534,9 +547,9 @@ grep -q 'is now `brig info`' "$WORK/info.err" \
 # has to be the envelope the run prints. Compare the rows themselves rather than
 # one grep each: a row that drifts between the preview and the run makes the
 # preview a claim about a boundary nobody is going to use.
-"$WORK/brig" run claude -d > "$WORK/runenv.out" 2>&1
+"$WORK/brig" --verbose run claude -d > "$WORK/runenv.out" 2>&1
 "$WORK/brig" rm --all > /dev/null 2>&1
-envelope_rows() { grep -E '^(SESSION|PROFILE|SANDBOX|ISOLATION|WORKSPACE|IMAGE|CREDENTIALS) ' "$1"; }
+envelope_rows() { grep -E '^(SESSION|PROFILE|SANDBOX|ISOLATION|WORKSPACE|IMAGE|VERIFY|CREDENTIALS) ' "$1"; }
 envelope_rows "$WORK/info.out" > "$WORK/rows.info"
 envelope_rows "$WORK/runenv.out" > "$WORK/rows.run"
 [ -s "$WORK/rows.info" ] \
@@ -727,7 +740,7 @@ grep -q 'CLAUDE_CODE_OAUTH_TOKEN' "$STUB_LOG" \
 
 echo "== lifecycle verbs =="
 : > "$STUB_LOG"
-out="$("$WORK/brig" run claude -d 2>"$WORK/detach.err")"
+out="$("$WORK/brig" --verbose run claude -d 2>"$WORK/detach.err")"
 [ "$out" = brig-claude-code ] && ok "run -d prints the sandbox name" \
   || bad "run -d prints the sandbox name -- got '$out'"
 # The envelope is on stderr, so the scriptable name on stdout stays clean.
@@ -1433,12 +1446,89 @@ esac
 fresh
 out="$(BRIG_VERIFY=warn "$WORK/brig" run claude -p hi 2>&1)"
 case "$out" in
-  *"signature verified"*) bad "a default run reported a signature that checked out -- got: $out" ;;
-  *) ok "a default run says nothing about a signature that checks out" ;;
+  *"signature verified"*) bad "a default run reported the per-check detail -- got: $out" ;;
+  *) ok "a default run holds back the per-check detail" ;;
 esac
 grep 'argv: run ' "$STUB_LOG" | tail -1 | grep -q '@sha256:' \
   && ok "the verified digest is what hull was told to boot" \
   || bad "hull was told to boot the tag, not the verified digest: $(grep 'argv: run ' "$STUB_LOG" | tail -1)"
+
+# What the default run gets instead of the detail is the outcome, in one line.
+# One line for the whole step, not one per check: the shipped profiles boot a
+# downloaded kernel as well as an image, so both checks reach the same summary.
+case "$out" in
+  *"brig: image and boot assets verified"*) ok "a default run says verification held" ;;
+  *) bad "a default run says verification held -- got: $out" ;;
+esac
+# The policy that outcome held under is the envelope's VERIFY row, which
+# --verbose carries. Stating neither would leave "it verified" to be inferred
+# from an absence, on the one subject where a reader must never have to.
+fresh
+out="$(BRIG_VERIFY=warn "$WORK/brig" --verbose run claude -p hi 2>&1)"
+case "$out" in
+  *"VERIFY       warn"*) ok "the envelope names the verify mode" ;;
+  *) bad "the envelope names the verify mode -- got: $out" ;;
+esac
+
+# -q takes the outcome with everything else between an identifier and an error.
+fresh
+out="$(BRIG_VERIFY=warn "$WORK/brig" -q run claude -p hi 2>&1)"
+case "$out" in
+  *" verified"*) bad "brig -q printed the verification outcome -- got: $out" ;;
+  *) ok "brig -q drops the verification outcome" ;;
+esac
+
+# But a verification PROBLEM is never suppressed, -q included. It is the one
+# claim brig exists to make, and the caller that asked for silence is the
+# unattended one where an unchecked image matters most.
+fresh
+out="$(BRIG_VERIFY=off "$WORK/brig" -q run claude -p hi 2>&1)"
+case "$out" in
+  *"BRIG_VERIFY=off"*) ok "brig -q still says nothing checked the image" ;;
+  *) bad "brig -q hid that the image was never checked -- got: $out" ;;
+esac
+# An older hull cannot boot the bytes it checked, which is a caveat on the
+# claim rather than a note beside it, so it survives -q too.
+fresh
+out="$(STUB_HULL_VERSION=0.1.0-rc21 BRIG_VERIFY=warn "$WORK/brig" -q run claude -p hi 2>&1)"
+case "$out" in
+  *"cannot boot by digest"*) ok "brig -q still says the boot is not pinned to what verified" ;;
+  *) bad "brig -q hid that the boot is not pinned -- got: $out" ;;
+esac
+# And an ordinary warning is still an ordinary warning: the level means
+# verification, not "important", or -q is back to printing what it suppresses.
+fresh
+out="$(GH_TOKEN='op://vault/item/field' "$WORK/brig" -q run claude -p hi 2>&1)"
+case "$out" in
+  *"unresolved secret reference"*) bad "brig -q printed an ordinary warning -- got: $out" ;;
+  *) ok "brig -q still drops an ordinary warning" ;;
+esac
+
+# And nothing is claimed when nothing was checked. Off says so itself, in the
+# default output, and a run that added "verified" beside it would be false.
+fresh
+out="$(BRIG_VERIFY=off "$WORK/brig" run claude -p hi 2>&1)"
+case "$out" in
+  *" verified"*) bad "BRIG_VERIFY=off claimed something verified -- got: $out" ;;
+  *) ok "BRIG_VERIFY=off claims no verification" ;;
+esac
+# Exactly once, whichever half says it. The default run has no envelope, so
+# the standalone line carries the fact; a --verbose run has the VERIFY row, so
+# the standalone line stands down. A fact stated twice is one a reader skips.
+count=$(printf '%s\n' "$out" | grep -c 'BRIG_VERIFY=off')
+[ "$count" = 1 ] \
+  && ok "BRIG_VERIFY=off is stated exactly once by default" \
+  || bad "BRIG_VERIFY=off stated $count times by default -- got: $out"
+fresh
+out="$(BRIG_VERIFY=off "$WORK/brig" --verbose run claude -p hi 2>&1)"
+case "$out" in
+  *"VERIFY       off"*) ok "the envelope names the mode when checking is off" ;;
+  *) bad "the envelope names the mode when checking is off -- got: $out" ;;
+esac
+count=$(printf '%s\n' "$out" | grep -c 'BRIG_VERIFY=off')
+[ "$count" = 1 ] \
+  && ok "BRIG_VERIFY=off is stated exactly once under --verbose" \
+  || bad "BRIG_VERIFY=off stated $count times under --verbose -- got: $out"
 
 fresh
 out="$(STUB_HULL_VERSION=0.1.0-rc21 BRIG_VERIFY=warn "$WORK/brig" run claude -p hi 2>&1)"
@@ -1554,8 +1644,8 @@ echo "== what a run says =="
 CLAUDE_CODE_OAUTH_TOKEN=env-token-secret \
   "$WORK/brig" run claude -d > "$WORK/say.out" 2> "$WORK/say.err"
 grep -q '^SANDBOX ' "$WORK/say.err" \
-  && ok "a default run prints the envelope" \
-  || bad "a default run prints the envelope -- got: $(cat "$WORK/say.err")"
+  && bad "a default run printed the envelope -- got: $(cat "$WORK/say.err")" \
+  || ok "a default run prints no envelope"
 grep -q 'starting sandbox' "$WORK/say.err" \
   && bad "a default run narrated the boot -- got: $(cat "$WORK/say.err")" \
   || ok "a default run does not narrate the boot"
@@ -1573,6 +1663,9 @@ grep -q 'starting sandbox' "$WORK/verbose.err" \
 grep -q 'pulling ghcr.io' "$WORK/verbose.err" \
   && ok "--verbose prints the runtime's own output" \
   || bad "--verbose prints the runtime's own output -- got: $(cat "$WORK/verbose.err")"
+grep -q '^SANDBOX ' "$WORK/verbose.err" \
+  && ok "--verbose prints the envelope" \
+  || bad "--verbose prints the envelope -- got: $(cat "$WORK/verbose.err")"
 
 # The one that matters most: a boot that fails still says what the runtime said,
 # with nothing asked for. Hold the output and lose it and a broken boot becomes


### PR DESCRIPTION
## Summary

A default `brig run` printed brig's progress, the runtime's output and brig's warnings
together, so an expired credential sat in the same column as a pull progress bar.

Three levels now. A default run prints warnings and identifiers. `--verbose` adds the
execution envelope, brig's progress and the runtime's output. `-q` drops ordinary
warnings. Verification prints at every level, including `-q`.

| | envelope | verification problems | other warnings | progress, runtime output | identifiers, errors |
| --- | --- | --- | --- | --- | --- |
| `-q` | no | **yes** | no | no | yes |
| default | no | yes | yes | no | yes |
| `--verbose` | yes | yes | yes | yes | yes |

## Related issues

Fixes #24. Part of #47. Branches from `main`; no stacking.

## Changes

**`wrap.Verbosity`** is `Quiet(-1)/Normal(0)/Verbose(1)`. `Normal` is the zero value, so a
hand-built `Config` is unchanged. `warnf` requires `>= Normal`, `progressf` requires
`>= Verbose`, `alertf` has no level check.

**The runtime's output is captured, not passed through.** `RunSpec.Progress` decides:
`nil` buffers it and prints it with the error if the boot fails, discards it if the boot
succeeds; a non-nil writer streams it live. Capped at 64K, keeping the tail.
`Replace` is untouched — it execs the runtime over this process, so there is nothing to
capture and nothing buffered in front of an interactive agent.

**`--verbose` and `-q` take the global position** that #108 established closed and empty.
`--verbose` has no short form: `-v` is Claude Code's version flag, codex's verbose flag and
Docker's volume flag.

**`-q` moved from the run line.** `brig run claude -q` works today, so both positions are
accepted this release; the run-line spelling prints a notice and v0.3 drops it.
`brig ls -q` is unchanged.

**Verification is above the level `-q` can silence.** It used `warnf`, so `-q` suppressed
it and a run that booted an unchecked image told a script nothing. `alertf` covers
`BRIG_VERIFY=off`, every signature refusal, gap, mismatch, `NotOurs`, `NoTooling`,
`Unresolved`, both boot-asset failures, the no-terminal refusal, and `cannot boot by
digest`. Credential expiry, workspace notices and deprecations stay at `warnf`.

**A `VERIFY` envelope row and a result line.** Moving the per-check success lines behind
`--verbose` left a default run silent about verification. `PrintPreRunEnvelope` runs before
`EnsureRunning`, so the mode is known at envelope time and the outcome is not: the row
carries the mode under `--verbose`, and `sayVerified` prints the result at default level.
Nothing is printed when nothing was positively checked.

**The envelope moves behind `--verbose`.** Nine rows, and the largest part of a default
run. This reverses part of #10 and part of #24's own text, on a decision taken during
review. `brig info` prints it without booting and is unaffected at every level.

## Behaviour change worth flagging

A successful run can now print nothing. On a warm sandbox, `brig run -d` prints only the
sandbox name and `brig sh` prints nothing at all — verification does not re-run, and the
envelope is behind `--verbose`. That follows the table, and it is the first time brig is
silent on success.

## Testing

`script/smoke.sh`: 253 → 284 passing assertions, FAIL set identical to `c06f9bc`.

The 16 failures predate this branch. They are the stub `stat -f` defect fixed by #128; with
that branch applied I measured this one at **288 ok / 0 FAIL**.

Unit tests cover: the levels; each verification outcome a fake cosign can drive, all at
`Quiet`; an ordinary warning still suppressed by `-q`; the envelope's presence per verb and
level; `brig info` at every level. A source scan of `verify.go` fails on any `c.warnf`
outside `sayVerified`, so a verification site added later cannot land at the suppressible
level.

## Manual testing

```bash
make build
export BRIG=./brig
```

**The three levels.** Any profile; `ubuntu` needs no credentials.

```bash
$BRIG run -d ubuntu              # warnings, then the sandbox name
$BRIG --verbose run -d ubuntu    # envelope, brig's progress, the runtime's output
$BRIG -q run -d ubuntu           # the sandbox name
```

**`-q` drops ordinary warnings but not verification.**

```bash
GH_TOKEN='op://x/y' $BRIG run -d ubuntu      # warns about the unresolved reference
GH_TOKEN='op://x/y' $BRIG -q run -d ubuntu   # silent
BRIG_VERIFY=off $BRIG -q run -d ubuntu       # still reports that nothing was checked
```

**Flag positions.**

```bash
$BRIG -v run ubuntu          # refused, naming -v
$BRIG --verbose run ubuntu   # accepted
$BRIG -q run ubuntu          # accepted
$BRIG run ubuntu -q          # works, prints a notice naming the global position
$BRIG ls -q                  # refs only, unchanged
```

**A failed boot still reports what the runtime said.** Point `BRIG_RUNTIME_BIN` at a script
that writes to stderr and exits non-zero:

```bash
$BRIG run -d ubuntu          # brig's error, then the runtime's last lines, indented
$BRIG -q run -d ubuntu       # same: an error is not suppressed
```

On a successful boot the same output is discarded. Check both directions.

**Verification, on a profile with a signed image and cosign installed.**

```bash
$BRIG run -d claude              # "image and boot assets verified"
$BRIG -q run -d claude           # no result line
$BRIG --verbose run -d claude    # VERIFY row, result line, per-check detail
BRIG_VERIFY=off $BRIG run -d claude   # reported once, not twice
```

**`brig info` is unaffected.**

```bash
$BRIG info claude                # full envelope including the VERIFY row
$BRIG -q info claude             # same
```

It does not boot, so it shows the mode and no result line.

## Checklist

- [x] `make all` passes (vet, test, build)
- [x] `script/smoke.sh` passes
- [x] I have added or updated tests covering the change
- [x] I have run `go test ./... -race`, if the change touches concurrency, subprocesses or the daemon
- [ ] I have exercised the change against a real runtime (`brig run <agent>`), if it touches the run, exec or credential path
- [x] I have updated the affected docs (README, `docs/security.md`, `docs/profiles.md`, `docs/brigd.md`)

`script/smoke.sh` is ticked on CI, where it runs clean; the local failures are the #128 stub
defect described above.

Real runtime: not booted. Verified against the stub runtime, which covers the whole path
except the VM.

Docs: README and `docs/quickstart.md` updated for the flags and the new default output.

## Credentials and the sandbox boundary

No new mount, no new forwarded variable, no new host path reachable from the guest.

This changes what is printed about the boundary, in both directions. A default run no longer
prints the envelope, which named the sandbox, workspace, image, credentials and network.
Against that, verification is now unsuppressible: `-q` previously silenced every signature
refusal and `BRIG_VERIFY=off`, so a script could boot an unchecked image and see nothing.
`brig info` remains the full report and is unchanged.

Credential values are not printed at any level, as before.

## LLM usage

Authored with assistance from Claude Code (Opus 5). Verification was re-run independently of
the agent that wrote the change: `gofmt`, `make all`, each commit built and tested in
isolation, and every command in the Manual testing section exercised against the built
binary. The level table and the failed-boot behaviour were checked in both directions.
