### PR TITLE
fix(cli): class a verbless bad ref as a usage error, not failure

### DIFF
--- a/cmd/brig/lifecycle_test.go
+++ b/cmd/brig/lifecycle_test.go
@@ -174,6 +174,14 @@ func TestARefShapedTokenIsDiagnosedAsARef(t *testing.T) {
 		if verbless.Error() != verbed.Error() {
 			t.Errorf("brig %s said\n  %v\nbut brig run %s said\n  %v", ref, verbless, ref, verbed)
 		}
+		// The message being equal is not enough: a bare ParseRef failure falls
+		// through to exit 1 while the verbed form's usage error exits 2, so the
+		// two read alike and a script still tells them apart. Pin the class too,
+		// including nosuch@refactor, which already reaches exit 3 both ways.
+		if exitCode(verbless) != exitCode(verbed) {
+			t.Errorf("brig %s exits %d, brig run %s exits %d",
+				ref, exitCode(verbless), ref, exitCode(verbed))
+		}
 		if strings.Contains(verbless.Error(), "unknown command") {
 			t.Errorf("brig %s was reported as an unknown command: %v", ref, verbless)
 		}

--- a/cmd/brig/main.go
+++ b/cmd/brig/main.go
@@ -328,8 +328,14 @@ func run(args []string) error {
 		// vocabulary of commands would send the reader looking for a verb they
 		// did not type, past a diagnosis that already names what is wrong with
 		// the ref.
+		//
+		// Classed as a usage error, the same way split wraps the identical
+		// ParseRef failure on the verbed line: nothing ran, so this is a token
+		// in the wrong place rather than a run that started and failed. The
+		// message is refErr's own, untouched, so the two spellings still read
+		// the same word for word -- only the exit code joins them.
 		if refErr != nil {
-			return refErr
+			return usagef("%s", refErr)
 		}
 		// An agent brig does not have falls through to the run line rather
 		// than being reported here, which is where the verbed form reports it


### PR DESCRIPTION
`brig claude@BAD` exited 1. `brig run claude@BAD` exited 2. Same mistake, same message, two exit codes.

Nothing runs in either case, so 2 is the right class, and it is what `split` already gives the verbed form. The verbless branch returned the `ParseRef` error bare, which falls through `exitCode` to 1. It is now wrapped in `usagef`. The message is unchanged, so the two spellings still read the same word for word.

`nosuch@refactor` is untouched. It falls through to the run line and exits 3 both ways.

`TestARefShapedTokenIsDiagnosedAsARef` compared only the message strings, which were already equal, so it never caught this. It now compares the exit code as well, over every token in the table.

Tested with `go vet ./...`, `go test -race ./...` and `./script/smoke.sh`.

Fixes: #127