### PR TITLE
feat(cli): add brig logs <ref> to read a sandbox's log

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ separate Linux re-implementation of it.
 | `brig rm <ref>` | stop and remove the sandbox. The workspace is untouched |
 | `brig rm --all` | stop and remove every brig sandbox. Workspaces are untouched |
 | `brig ls [-q]` | every brig sandbox, running or merely holding its name, with its ref and workspace. `-q` prints the refs alone, for a script |
+| `brig logs <ref>` | stream the sandbox's log; `--gateway` reads the gateway's |
 | `brig info <ref>` | the boundary a run would trust -- sandbox, workspace, image, credentials **by name only** -- and whether the guest will be authenticated |
 | `brig agent ls` | the agents, their images, and what each one refuses to forward |
 | `brig agent show <agent>` | print one agent's spec. `--json` for JSON instead of YAML |

--- a/cmd/brig/logs.go
+++ b/cmd/brig/logs.go
@@ -103,7 +103,7 @@ func logsCmd(args []string) error {
 	if err != nil {
 		return err
 	}
-	return streamLogs(rt, name, o, os.Stdout)
+	return logsFor(rt, name, ref, o, os.Stdout)
 }
 
 // resolveSandbox turns a ref into the runtime it runs on and the sandbox name
@@ -136,6 +136,28 @@ func resolveSandbox(ref string) (*wrap.Config, runtime.Runtime, string, error) {
 		return nil, nil, "", err
 	}
 	return cfg, rt, cfg.VMName, nil
+}
+
+// logsFor confirms the runtime has the sandbox before streaming its log.
+//
+// There is nothing to read from a sandbox that is not there, which the exit
+// table calls a not-found (3) rather than a log stream that started and failed
+// (1). So the runtime is asked before the stream is opened, and the ref the
+// reader typed -- not the sandbox name -- is what the not-found names. A List
+// that itself fails comes back as is (exit 4, the runtime unavailable), not as
+// absence: the two are different facts. See sandboxPresent.
+//
+// Split from logsCmd so a test can drive it with a runtime double, the way
+// streamLogs is split for the same reason.
+func logsFor(rt runtime.Runtime, name, ref string, o logsOptions, out io.Writer) error {
+	present, err := sandboxPresent(rt, name)
+	if err != nil {
+		return err
+	}
+	if !present {
+		return noSandboxf(ref)
+	}
+	return streamLogs(rt, name, o, out)
 }
 
 // streamLogs hands the runtime the log request, filtering terminal control

--- a/cmd/brig/logs.go
+++ b/cmd/brig/logs.go
@@ -1,0 +1,313 @@
+package main
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/brig-sh/brig/internal/profile"
+	"github.com/brig-sh/brig/internal/runtime"
+	"github.com/brig-sh/brig/internal/session"
+	"github.com/brig-sh/brig/internal/wrap"
+)
+
+// logsOptions is what `brig logs` was asked for.
+type logsOptions struct {
+	follow bool
+	// tail is how many trailing lines to show, or -1 for all -- the default,
+	// and what both runtimes read as "all".
+	tail int
+	raw  bool
+}
+
+// logsCmd streams a sandbox's log, the one thing no brig command pointed at
+// before: after `brig run -d`, or a boot that never became ready, brig's only
+// advice was to leave brig for `hull logs <sandbox>` or `nerdctl logs
+// <sandbox>` -- which asks the reader for the sandbox name, which is not the
+// ref, and which runtime is underneath, both of which brig has and they do not.
+//
+// It parses its own flags rather than going through the run line, because
+// --gateway takes no ref: the gateway is one per host, and the run line's
+// parser requires a ref to resolve a profile at all.
+func logsCmd(args []string) error {
+	o := logsOptions{tail: -1}
+	var gateway bool
+	ref := ""
+	for i := 0; i < len(args); i++ {
+		a := args[i]
+		switch {
+		case a == "--follow":
+			o.follow = true
+		case a == "--raw":
+			o.raw = true
+		case a == "--gateway":
+			gateway = true
+		case a == "--tail":
+			i++
+			if i >= len(args) {
+				return usagef("--tail needs a number, for example `--tail 100`")
+			}
+			n, err := strconv.Atoi(args[i])
+			if err != nil {
+				return usagef("--tail needs a number, not %q", args[i])
+			}
+			o.tail = n
+		case strings.HasPrefix(a, "--tail="):
+			raw := a[len("--tail="):]
+			n, err := strconv.Atoi(raw)
+			if err != nil {
+				return usagef("--tail needs a number, not %q", raw)
+			}
+			o.tail = n
+		case strings.HasPrefix(a, "-"):
+			return usagef("unknown flag %q for `brig logs`", a)
+		default:
+			if ref != "" {
+				return usagef("unexpected argument %q; `brig logs` takes one ref", a)
+			}
+			ref = a
+		}
+	}
+
+	// The gateway log is per host, so it takes no ref -- and naming one is a
+	// mistake to say, not a session to go and resolve.
+	if gateway {
+		if ref != "" {
+			return usagef("`brig logs --gateway` names no session; the gateway is per host, "+
+				"not per sandbox. Drop %q", ref)
+		}
+		return gatewayLogs(os.Stdout, o)
+	}
+	if ref == "" {
+		return usagef("brig logs needs a ref, for example `brig logs claude`. " +
+			"`brig logs --gateway` reads the host's gateway log instead")
+	}
+
+	// Resolved the way every other ref'd verb resolves: the ref names the agent
+	// and the session, the profile picks the runtime, and Load derives the
+	// sandbox name from the two.
+	r, err := session.ParseRef(ref)
+	if err != nil {
+		// Classed as a usage error, the same way split classes the identical
+		// ParseRef failure on the run line: nothing ran, so this is a token in
+		// the wrong place rather than a run that started and failed.
+		return usagef("%s", err)
+	}
+	t, ok := profile.Lookup(r.Agent)
+	if !ok {
+		return notFoundf("unknown profile %q. `brig agent ls` lists them", r.Agent)
+	}
+	rt, err := runtime.DetectFor(runtime.Preference{Bin: t.RuntimeBin})
+	if err != nil {
+		return err
+	}
+	cfg, err := wrap.Load(t, wrap.Options{Name: r.Label, Verbosity: verbosity}, rt)
+	if err != nil {
+		return err
+	}
+	return streamLogs(rt, cfg.VMName, o, os.Stdout)
+}
+
+// streamLogs hands the runtime the log request, filtering terminal control
+// sequences on the way out unless the raw bytes were asked for.
+//
+// A function of its own, taking the runtime rather than reaching for it, so a
+// test can hand it a double and assert that --follow and --tail reach the
+// adapter with the values the line carried.
+func streamLogs(rt runtime.Runtime, name string, o logsOptions, out io.Writer) error {
+	return rt.Logs(runtime.LogsSpec{
+		Name:   name,
+		Follow: o.follow,
+		Tail:   o.tail,
+		Out:    filtered(out, o.raw),
+		Err:    filtered(os.Stderr, o.raw),
+	})
+}
+
+// gatewayLogs prints the shared gateway's own log. brig starts that gateway for
+// the hvi backend and writes its output to a file beside the socket; a network
+// failure at boot lands there and nothing pointed at it until now.
+func gatewayLogs(out io.Writer, o logsOptions) error {
+	path, err := runtime.GatewayLogPath()
+	if err != nil {
+		return err
+	}
+	return streamGatewayFile(filtered(out, o.raw), path, o.follow, o.tail)
+}
+
+// gatewayFollowPoll is how often --follow re-reads the gateway log for bytes
+// appended since. It is a file brig does not own the writer of, so there is
+// nothing to wait on but the file itself.
+const gatewayFollowPoll = 500 * time.Millisecond
+
+// streamGatewayFile writes the gateway log to out, tailing it under --follow.
+//
+// A missing file is not a fault to fail loudly over: the gateway log appears
+// only once a sandbox has needed the host network gateway, so on a machine that
+// has booted only vz sandboxes there is simply nothing yet.
+func streamGatewayFile(out io.Writer, path string, follow bool, tail int) error {
+	f, err := os.Open(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return notFoundf("no gateway log at %s yet -- it appears once a sandbox "+
+				"first needs the host network gateway", path)
+		}
+		return err
+	}
+	defer func() { _ = f.Close() }()
+
+	data, err := io.ReadAll(f)
+	if err != nil {
+		return err
+	}
+	if tail >= 0 {
+		data = lastLines(data, tail)
+	}
+	if _, err := out.Write(data); err != nil {
+		return err
+	}
+	if !follow {
+		return nil
+	}
+	// Interrupting this leaves the gateway running: it serves every sandbox on
+	// the host, and reading its log is not owning it. Ctrl-C reaches this
+	// process and ends it, which is the whole of what stopping should do.
+	for {
+		time.Sleep(gatewayFollowPoll)
+		more, err := io.ReadAll(f)
+		if err != nil {
+			return err
+		}
+		if len(more) > 0 {
+			if _, err := out.Write(more); err != nil {
+				return err
+			}
+		}
+	}
+}
+
+// lastLines keeps only the final n lines of data, for --tail on a file the
+// runtime is not the one reading. n <= 0 keeps nothing; fewer lines than asked
+// keeps them all.
+func lastLines(data []byte, n int) []byte {
+	if n <= 0 {
+		return nil
+	}
+	lines := bytes.SplitAfter(data, []byte("\n"))
+	// SplitAfter leaves a trailing empty piece after a final newline; it is not
+	// a line, so it does not count toward n.
+	if len(lines) > 0 && len(lines[len(lines)-1]) == 0 {
+		lines = lines[:len(lines)-1]
+	}
+	if len(lines) <= n {
+		return data
+	}
+	return bytes.Join(lines[len(lines)-n:], nil)
+}
+
+// filtered wraps a writer to strip terminal control sequences, or hands it back
+// untouched when the raw bytes were asked for.
+func filtered(out io.Writer, raw bool) io.Writer {
+	if raw {
+		return out
+	}
+	return &controlFilter{w: out}
+}
+
+// filterState is where the control-sequence filter is in a sequence it has
+// started to recognise. Held on the writer rather than reset per Write so a
+// sequence split across two writes -- which streaming makes ordinary -- is
+// still filtered whole.
+type filterState int
+
+const (
+	fText    filterState = iota // ordinary text
+	fEsc                        // just saw ESC
+	fCSI                        // in ESC [ ... , waiting for the final byte
+	fOSC                        // in ESC ] ... , waiting for BEL or ST
+	fOSCEsc                     // in an OSC and saw ESC, waiting for the \ of ST
+	fCharset                    // ESC ( or ) , which consumes one more byte
+)
+
+// controlFilter strips terminal control sequences from a log as it passes
+// through. brig sits in the middle of this stream -- unlike `brig run`, which
+// hands the terminal straight to the agent -- which is what makes filtering
+// possible here at all. A runtime replays into its log whatever a program
+// wrote, cursor moves and colour and title-setting included, and a log meant to
+// be read back is text, not a terminal to drive. --raw skips this.
+//
+// Newline, tab and carriage return are kept: they are the layout of the text,
+// not control of a terminal. Every other C0 control and DEL is dropped.
+type controlFilter struct {
+	w  io.Writer
+	st filterState
+}
+
+func (f *controlFilter) Write(p []byte) (int, error) {
+	out := make([]byte, 0, len(p))
+	for _, b := range p {
+		switch f.st {
+		case fText:
+			switch {
+			case b == 0x1b:
+				f.st = fEsc
+			case b == '\n' || b == '\t' || b == '\r':
+				out = append(out, b)
+			case b < 0x20 || b == 0x7f:
+				// A C0 control or DEL with no place in read-back text.
+			default:
+				out = append(out, b)
+			}
+		case fEsc:
+			switch b {
+			case '[':
+				f.st = fCSI
+			case ']':
+				f.st = fOSC
+			case '(', ')':
+				f.st = fCharset
+			default:
+				// A lone ESC-something, e.g. ESC c reset: drop the pair.
+				f.st = fText
+			}
+		case fCSI:
+			// The final byte of a CSI is in 0x40-0x7e; the bytes before it are
+			// parameters and intermediates.
+			if b >= 0x40 && b <= 0x7e {
+				f.st = fText
+			}
+		case fOSC:
+			switch b {
+			case 0x07: // BEL terminates an OSC
+				f.st = fText
+			case 0x1b: // ESC may begin the ST that terminates it
+				f.st = fOSCEsc
+			}
+		case fOSCEsc:
+			// ESC \ is the string terminator; anything else was ESC inside the
+			// OSC body, and either way the sequence is over as far as text goes.
+			f.st = fText
+		case fCharset:
+			f.st = fText
+		}
+	}
+	if _, err := f.w.Write(out); err != nil {
+		return 0, err
+	}
+	// The whole input was consumed, sequences included, so report it fully
+	// written: a short count with no error is what makes io.Copy report
+	// ErrShortWrite, and this writer drops bytes by design.
+	return len(p), nil
+}
+
+// stripControl runs a complete byte slice through the filter, for a caller --
+// a test above all -- that has all the bytes at once.
+func stripControl(in []byte) []byte {
+	var buf bytes.Buffer
+	f := &controlFilter{w: &buf}
+	_, _ = f.Write(in)
+	return buf.Bytes()
+}

--- a/cmd/brig/logs.go
+++ b/cmd/brig/logs.go
@@ -30,8 +30,9 @@ type logsOptions struct {
 // ref, and which runtime is underneath, both of which brig has and they do not.
 //
 // It parses its own flags rather than going through the run line, because
-// --gateway takes no ref: the gateway is one per host, and the run line's
-// parser requires a ref to resolve a profile at all.
+// --gateway takes an optional ref: the shared gateway is one per host and is
+// named by no session, while the run line's parser requires a ref to resolve a
+// profile at all.
 func logsCmd(args []string) error {
 	o := logsOptions{tail: -1}
 	var gateway bool
@@ -72,43 +73,69 @@ func logsCmd(args []string) error {
 		}
 	}
 
-	// The gateway log is per host, so it takes no ref -- and naming one is a
-	// mistake to say, not a session to go and resolve.
+	// Which gateway is asked for is the ref: bare --gateway is the shared one,
+	// which serves the host and is named by no session, and a ref is that
+	// sandbox's own. An isolated sandbox has a gateway to itself, so the ref is
+	// the only thing that can pick between the two.
 	if gateway {
-		if ref != "" {
-			return usagef("`brig logs --gateway` names no session; the gateway is per host, "+
-				"not per sandbox. Drop %q", ref)
+		if ref == "" {
+			return gatewayLogs(os.Stdout, o)
 		}
-		return gatewayLogs(os.Stdout, o)
+		cfg, _, name, err := resolveSandbox(ref)
+		if err != nil {
+			return err
+		}
+		// A sandbox on the shared gateway has no gateway log of its own, and
+		// that is a fact this run already resolved rather than a guess to
+		// offer among others.
+		if cfg.Network != "isolated" {
+			return notFoundf("%s is on the shared gateway, which has no log of its own "+
+				"per sandbox. `brig logs --gateway` reads the shared gateway's log", ref)
+		}
+		return isolatedGatewayLogs(os.Stdout, o, ref, name)
 	}
 	if ref == "" {
 		return usagef("brig logs needs a ref, for example `brig logs claude`. " +
-			"`brig logs --gateway` reads the host's gateway log instead")
+			"`brig logs --gateway` reads the shared gateway's log instead")
 	}
 
-	// Resolved the way every other ref'd verb resolves: the ref names the agent
-	// and the session, the profile picks the runtime, and Load derives the
-	// sandbox name from the two.
+	_, rt, name, err := resolveSandbox(ref)
+	if err != nil {
+		return err
+	}
+	return streamLogs(rt, name, o, os.Stdout)
+}
+
+// resolveSandbox turns a ref into the runtime it runs on and the sandbox name
+// it is known by there, the way every other ref'd verb resolves one: the ref
+// names the agent and the session, the profile picks the runtime, and Load
+// derives the sandbox name from the two.
+//
+// Both gateway and sandbox logs go through this. The gateway path wants only
+// the name -- an isolated gateway's socket is named after the sandbox -- but it
+// has to arrive at that name by exactly the same route, or `brig logs <ref>`
+// and `brig logs --gateway <ref>` could disagree about which sandbox a ref is.
+func resolveSandbox(ref string) (*wrap.Config, runtime.Runtime, string, error) {
 	r, err := session.ParseRef(ref)
 	if err != nil {
 		// Classed as a usage error, the same way split classes the identical
 		// ParseRef failure on the run line: nothing ran, so this is a token in
 		// the wrong place rather than a run that started and failed.
-		return usagef("%s", err)
+		return nil, nil, "", usagef("%s", err)
 	}
 	t, ok := profile.Lookup(r.Agent)
 	if !ok {
-		return notFoundf("unknown profile %q. `brig agent ls` lists them", r.Agent)
+		return nil, nil, "", notFoundf("unknown profile %q. `brig agent ls` lists them", r.Agent)
 	}
 	rt, err := runtime.DetectFor(runtime.Preference{Bin: t.RuntimeBin})
 	if err != nil {
-		return err
+		return nil, nil, "", err
 	}
 	cfg, err := wrap.Load(t, wrap.Options{Name: r.Label, Verbosity: verbosity}, rt)
 	if err != nil {
-		return err
+		return nil, nil, "", err
 	}
-	return streamLogs(rt, cfg.VMName, o, os.Stdout)
+	return cfg, rt, cfg.VMName, nil
 }
 
 // streamLogs hands the runtime the log request, filtering terminal control
@@ -130,12 +157,41 @@ func streamLogs(rt runtime.Runtime, name string, o logsOptions, out io.Writer) e
 // gatewayLogs prints the shared gateway's own log. brig starts that gateway for
 // the hvi backend and writes its output to a file beside the socket; a network
 // failure at boot lands there and nothing pointed at it until now.
+//
+// That gateway is per host: it serves every sandbox that asked for the shared
+// network, so no ref names it. An isolated sandbox has one to itself, and
+// isolatedGatewayLogs is that one's log.
 func gatewayLogs(out io.Writer, o logsOptions) error {
 	path, err := runtime.GatewayLogPath()
 	if err != nil {
 		return err
 	}
-	return streamGatewayFile(filtered(out, o.raw), path, o.follow, o.tail)
+	missing := notFoundf("no gateway log at %s yet -- it appears once a sandbox "+
+		"first needs the host network gateway", path)
+	return streamGatewayFile(filtered(out, o.raw), path, o.follow, o.tail, missing)
+}
+
+// isolatedGatewayLogs prints the log of the gateway serving one sandbox alone.
+//
+// This is the log the feature is most for. An isolated gateway that fails to
+// start takes its sandbox's network with it, and its output is the only account
+// of why -- the boot error names the file, and nothing could read it.
+//
+// It lives only as long as its gateway: the log is removed along with the pid
+// and spec records once the gateway is confirmed stopped, which is what keeps
+// ~/.brig from growing a file for every sandbox ever isolated. A gateway that
+// never came up was never confirmed stopped, so the failure this is for leaves
+// its log in place. Absent means the gateway is not running, and the message
+// says so rather than implying the log was somewhere else.
+func isolatedGatewayLogs(out io.Writer, o logsOptions, ref, name string) error {
+	path, err := runtime.IsolatedGatewayLogPath(name)
+	if err != nil {
+		return err
+	}
+	missing := notFoundf("no gateway log at %s: the gateway serving %s is not running, "+
+		"and its log is removed with it. A gateway that failed to start leaves its log "+
+		"behind, so this is a sandbox that is stopped or has not run yet", path, ref)
+	return streamGatewayFile(filtered(out, o.raw), path, o.follow, o.tail, missing)
 }
 
 // gatewayFollowPoll is how often --follow re-reads the gateway log for bytes
@@ -145,15 +201,15 @@ const gatewayFollowPoll = 500 * time.Millisecond
 
 // streamGatewayFile writes the gateway log to out, tailing it under --follow.
 //
-// A missing file is not a fault to fail loudly over: the gateway log appears
-// only once a sandbox has needed the host network gateway, so on a machine that
-// has booted only vz sandboxes there is simply nothing yet.
-func streamGatewayFile(out io.Writer, path string, follow bool, tail int) error {
+// A missing file is not a fault to fail loudly over, but why it is missing
+// differs by gateway -- the shared one's log has not appeared yet, an isolated
+// one's has been removed -- so the caller supplies that error and this returns
+// it. Both are not-found, so a script can tell either from a failure.
+func streamGatewayFile(out io.Writer, path string, follow bool, tail int, missing error) error {
 	f, err := os.Open(path)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return notFoundf("no gateway log at %s yet -- it appears once a sandbox "+
-				"first needs the host network gateway", path)
+			return missing
 		}
 		return err
 	}
@@ -172,9 +228,10 @@ func streamGatewayFile(out io.Writer, path string, follow bool, tail int) error 
 	if !follow {
 		return nil
 	}
-	// Interrupting this leaves the gateway running: it serves every sandbox on
-	// the host, and reading its log is not owning it. Ctrl-C reaches this
-	// process and ends it, which is the whole of what stopping should do.
+	// Interrupting this leaves the gateway running: it serves sandboxes -- every
+	// shared one on the host, or the single isolated one -- and reading its log
+	// is not owning it. Ctrl-C reaches this process and ends it, which is the
+	// whole of what stopping should do.
 	for {
 		time.Sleep(gatewayFollowPoll)
 		more, err := io.ReadAll(f)

--- a/cmd/brig/logs_test.go
+++ b/cmd/brig/logs_test.go
@@ -1,0 +1,214 @@
+package main
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/brig-sh/brig/internal/runtime"
+)
+
+// logRuntime records the one request `brig logs` makes of the runtime. The
+// interface is embedded rather than implemented, the repo's pattern: a call to
+// any other method is a call `brig logs` has no business making, and the nil
+// panic says that louder than a stub returning nothing.
+type logRuntime struct {
+	runtime.Runtime
+	spec runtime.LogsSpec
+	err  error
+}
+
+func (r *logRuntime) Logs(spec runtime.LogsSpec) error {
+	r.spec = spec
+	return r.err
+}
+
+// The filter is the part most likely to be wrong, so it gets a table of its
+// own: what a runtime replays into a log versus what a reader should see.
+func TestStripControl(t *testing.T) {
+	cases := []struct {
+		name     string
+		in, want string
+	}{
+		{"plain text is untouched", "hello world\n", "hello world\n"},
+		{"newline tab and return survive", "a\tb\r\nc\n", "a\tb\r\nc\n"},
+		{"a CSI colour sequence goes", "a\x1b[31mred\x1b[0m", "ared"},
+		{"a cursor move goes", "before\x1b[2Kafter", "beforeafter"},
+		{"an OSC title ends at BEL", "x\x1b]0;my title\x07y", "xy"},
+		{"an OSC title ends at ST", "x\x1b]0;my title\x1b\\y", "xy"},
+		{"a charset selection goes", "a\x1b(Bb", "ab"},
+		{"a bare escape pair goes", "a\x1bcb", "ab"},
+		{"stray control bytes are dropped", "a\x00\x07b", "ab"},
+		{"DEL is dropped", "a\x7fb", "ab"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := string(stripControl([]byte(c.in))); got != c.want {
+				t.Errorf("stripControl(%q) = %q, want %q", c.in, got, c.want)
+			}
+		})
+	}
+}
+
+// A sequence split across two writes -- which streaming makes ordinary -- is
+// still filtered whole: the state rides on the writer, not on one Write.
+func TestControlFilterAcrossWrites(t *testing.T) {
+	var buf bytes.Buffer
+	f := &controlFilter{w: &buf}
+	if _, err := f.Write([]byte("a\x1b[")); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := f.Write([]byte("31mb")); err != nil {
+		t.Fatal(err)
+	}
+	if got := buf.String(); got != "ab" {
+		t.Errorf("a split escape was not filtered whole: got %q, want %q", got, "ab")
+	}
+}
+
+// The whole input must read as written even though bytes were dropped, or
+// io.Copy from a runtime's pipe reports ErrShortWrite.
+func TestControlFilterReportsFullWrite(t *testing.T) {
+	in := []byte("a\x1b[31mb")
+	n, err := (&controlFilter{w: io.Discard}).Write(in)
+	if err != nil || n != len(in) {
+		t.Errorf("Write(%q) = %d, %v; want %d, nil", in, n, err, len(in))
+	}
+}
+
+// --follow and --tail reach the adapter with the values the line carried, and
+// the sandbox name resolved for it.
+func TestStreamLogsPassesFollowAndTail(t *testing.T) {
+	rt := &logRuntime{}
+	if err := streamLogs(rt, "brig-claude-code", logsOptions{follow: true, tail: 100}, io.Discard); err != nil {
+		t.Fatal(err)
+	}
+	if rt.spec.Name != "brig-claude-code" {
+		t.Errorf("the adapter got name %q, want %q", rt.spec.Name, "brig-claude-code")
+	}
+	if !rt.spec.Follow {
+		t.Error("--follow did not reach the adapter")
+	}
+	if rt.spec.Tail != 100 {
+		t.Errorf("the adapter got tail %d, want 100", rt.spec.Tail)
+	}
+}
+
+// By default the writer handed to the adapter filters control sequences; --raw
+// hands the bytes through untouched.
+func TestStreamLogsFiltersUnlessRaw(t *testing.T) {
+	dirty := []byte("a\x1b[31mb")
+
+	var filteredBuf bytes.Buffer
+	rt := &logRuntime{}
+	if err := streamLogs(rt, "brig-x", logsOptions{tail: -1}, &filteredBuf); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := rt.spec.Out.Write(dirty); err != nil {
+		t.Fatal(err)
+	}
+	if got := filteredBuf.String(); got != "ab" {
+		t.Errorf("the default writer did not filter: got %q, want %q", got, "ab")
+	}
+
+	var rawBuf bytes.Buffer
+	rt = &logRuntime{}
+	if err := streamLogs(rt, "brig-x", logsOptions{tail: -1, raw: true}, &rawBuf); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := rt.spec.Out.Write(dirty); err != nil {
+		t.Fatal(err)
+	}
+	if got := rawBuf.Bytes(); !bytes.Equal(got, dirty) {
+		t.Errorf("--raw filtered the bytes: got %q, want %q", got, dirty)
+	}
+}
+
+// --gateway reads the log named for the socket, filtering it like any other
+// log. The path is asked of the runtime package rather than spelled here, so
+// the test follows the writer's rule for where the log goes instead of pinning
+// a second one.
+func TestGatewayLogsReadsTheFile(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("BRIG_GATEWAY_SOCK", filepath.Join(dir, "gateway-test.sock"))
+	path, err := runtime.GatewayLogPath()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte("gateway up\x1b[0m\nlistening\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	var buf bytes.Buffer
+	if err := gatewayLogs(&buf, logsOptions{tail: -1}); err != nil {
+		t.Fatal(err)
+	}
+	if got, want := buf.String(), "gateway up\nlistening\n"; got != want {
+		t.Errorf("the gateway log was not read filtered: got %q, want %q", got, want)
+	}
+}
+
+// A gateway log that does not exist yet is not a fault: it appears only once a
+// sandbox has needed the host gateway, and the reader is told that, not handed
+// a bare open error. It is a not-found, so a script can tell it from a failure.
+func TestGatewayLogsMissing(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("BRIG_GATEWAY_SOCK", filepath.Join(dir, "gateway-test.sock"))
+
+	err := gatewayLogs(io.Discard, logsOptions{tail: -1})
+	if err == nil {
+		t.Fatal("a missing gateway log was reported as success")
+	}
+	if _, ok := err.(*notFoundError); !ok {
+		t.Errorf("a missing gateway log is not a not-found error: %T: %v", err, err)
+	}
+}
+
+func TestLastLines(t *testing.T) {
+	data := []byte("one\ntwo\nthree\n")
+	cases := []struct {
+		n    int
+		want string
+	}{
+		{0, ""},
+		{1, "three\n"},
+		{2, "two\nthree\n"},
+		{5, "one\ntwo\nthree\n"},
+	}
+	for _, c := range cases {
+		if got := string(lastLines(data, c.n)); got != c.want {
+			t.Errorf("lastLines(_, %d) = %q, want %q", c.n, got, c.want)
+		}
+	}
+}
+
+// logsCmd's own guards, before any runtime or profile is touched.
+func TestLogsCmdArgErrors(t *testing.T) {
+	cases := []struct {
+		name string
+		args []string
+	}{
+		{"no ref and no gateway", nil},
+		{"a ref that does not parse", []string{"claude@@x"}},
+		{"a gateway with a ref", []string{"--gateway", "claude"}},
+		{"an unknown flag", []string{"--nope", "claude"}},
+		{"tail without a number", []string{"--tail", "claude"}},
+		{"a second ref", []string{"claude", "extra"}},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			err := logsCmd(c.args)
+			if err == nil {
+				t.Fatalf("logsCmd(%q) returned no error", c.args)
+			}
+			// Every one of these is a mistake on the line, so every one is the
+			// usage class -- the ref that does not parse included, which is the
+			// class run already gives it.
+			if exitCode(err) != exitUsage {
+				t.Errorf("logsCmd(%q) exits %d, want %d: %v", c.args, exitCode(err), exitUsage, err)
+			}
+		})
+	}
+}

--- a/cmd/brig/logs_test.go
+++ b/cmd/brig/logs_test.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/brig-sh/brig/internal/runtime"
@@ -166,6 +167,84 @@ func TestGatewayLogsMissing(t *testing.T) {
 	}
 }
 
+// A ref reads the log of the gateway serving that sandbox alone, not the shared
+// one. The path is asked of the runtime package for the sandbox name, the same
+// way the shared test does, so both follow the writer's rule for where a log
+// goes rather than pinning one of their own.
+func TestIsolatedGatewayLogsReadsTheFile(t *testing.T) {
+	t.Setenv("BRIG_GATEWAY_DIR", shortGatewayDir(t))
+	path, err := runtime.IsolatedGatewayLogPath("brig-claude-code")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte("isolated gateway up\x1b[0m\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	// The shared log holds something else, so reading it instead would be
+	// visible rather than an empty pass.
+	shared, err := runtime.GatewayLogPath()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(shared, []byte("shared gateway up\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	var buf bytes.Buffer
+	if err := isolatedGatewayLogs(&buf, logsOptions{tail: -1}, "claude@code", "brig-claude-code"); err != nil {
+		t.Fatal(err)
+	}
+	if got, want := buf.String(), "isolated gateway up\n"; got != want {
+		t.Errorf("the isolated gateway log was not read filtered: got %q, want %q", got, want)
+	}
+
+	// And bare --gateway still reads the shared one, with an isolated log
+	// sitting beside it.
+	buf.Reset()
+	if err := gatewayLogs(&buf, logsOptions{tail: -1}); err != nil {
+		t.Fatal(err)
+	}
+	if got, want := buf.String(), "shared gateway up\n"; got != want {
+		t.Errorf("bare --gateway did not read the shared log: got %q, want %q", got, want)
+	}
+}
+
+// An isolated gateway's log is removed with the gateway, so an absent one means
+// the sandbox's gateway is not running. The message says that and names the ref
+// the reader typed -- not the sandbox name, which they did not -- and it is a
+// not-found, like the shared one, so a script can tell it from a failure.
+func TestIsolatedGatewayLogsMissing(t *testing.T) {
+	t.Setenv("BRIG_GATEWAY_DIR", shortGatewayDir(t))
+
+	err := isolatedGatewayLogs(io.Discard, logsOptions{tail: -1}, "claude@code", "brig-claude-code")
+	if err == nil {
+		t.Fatal("a missing isolated gateway log was reported as success")
+	}
+	if _, ok := err.(*notFoundError); !ok {
+		t.Fatalf("a missing isolated gateway log is not a not-found error: %T: %v", err, err)
+	}
+	if got := err.Error(); !strings.Contains(got, "claude@code") || !strings.Contains(got, "not running") {
+		t.Errorf("the message does not name the ref and say the gateway is not running: %q", got)
+	}
+}
+
+// --gateway with a ref is no longer refused on the line. It names a sandbox
+// whose gateway log is wanted, so whatever it goes on to fail at, it is not the
+// usage error that used to reject the ref outright.
+func TestGatewayWithRefIsNotAUsageError(t *testing.T) {
+	t.Setenv("BRIG_GATEWAY_DIR", t.TempDir())
+	// A profile that does not exist stops the resolution at its first step, so
+	// this touches no runtime: what is asserted is only that the ref got that
+	// far, which the old parse-time refusal did not allow.
+	err := logsCmd([]string{"--gateway", "no-such-profile-here"})
+	if err == nil {
+		t.Fatal("`brig logs --gateway <ref>` returned no error for an unknown profile")
+	}
+	if exitCode(err) == exitUsage {
+		t.Errorf("`brig logs --gateway <ref>` is still a usage error: %v", err)
+	}
+}
+
 func TestLastLines(t *testing.T) {
 	data := []byte("one\ntwo\nthree\n")
 	cases := []struct {
@@ -192,7 +271,7 @@ func TestLogsCmdArgErrors(t *testing.T) {
 	}{
 		{"no ref and no gateway", nil},
 		{"a ref that does not parse", []string{"claude@@x"}},
-		{"a gateway with a ref", []string{"--gateway", "claude"}},
+		{"a ref that does not parse, with --gateway", []string{"--gateway", "claude@@x"}},
 		{"an unknown flag", []string{"--nope", "claude"}},
 		{"tail without a number", []string{"--tail", "claude"}},
 		{"a second ref", []string{"claude", "extra"}},
@@ -211,4 +290,19 @@ func TestLogsCmdArgErrors(t *testing.T) {
 			}
 		})
 	}
+}
+
+// shortGatewayDir is a gateway directory a unix socket path fits in. t.TempDir
+// carries the test's name, and on macOS that overflows the 103 bytes a socket
+// path has, so isolatedSocket refuses the directory before any log is read.
+// os.MkdirTemp under the default location stays short, the same way the
+// runtime package's own gateway tests make theirs.
+func shortGatewayDir(t *testing.T) string {
+	t.Helper()
+	dir, err := os.MkdirTemp("", "gw")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.RemoveAll(dir) })
+	return dir
 }

--- a/cmd/brig/main.go
+++ b/cmd/brig/main.go
@@ -554,9 +554,16 @@ func dispatch(args []string) error {
 	// keychain prompt that reading the host login may bring up.
 	switch verb {
 	case "stop":
+		// Deliberately not gated on the sandbox existing: stopping one that was
+		// never running is the end state stop asks for, not a failure. See
+		// Config.Stop. rm and logs below are the opposite -- there is nothing to
+		// remove and nothing to read -- which is why only they check first.
 		return cfg.Stop()
 	case "rm":
-		return cfg.Remove()
+		// The slug, not the name as typed: ParseRef refuses a label that is not
+		// already its own slug, so naming RawName here would print a ref brig
+		// would then turn away. The index is keyed by the slug too.
+		return removeSandbox(cfg, session.Ref{Agent: profileName, Label: cfg.Slug}.String())
 	}
 
 	set, err := cfg.BuildEnv()
@@ -1876,6 +1883,61 @@ func takeAll(args []string) (rest []string, all bool) {
 		rest = append(rest, a)
 	}
 	return rest, all
+}
+
+// removeSandbox is `brig rm <ref>`: be rid of the one sandbox the ref names.
+//
+// It asks the runtime whether that sandbox is there before handing over, so the
+// case the runtime used to answer with its own "instance not found" -- there is
+// nothing to remove -- is reported as a not-found (exit 3), the code the README
+// gives a name that resolves to nothing, rather than as a removal that ran and
+// failed (exit 1). A List that itself fails is a runtime that could not be asked
+// (exit 4), a different fact the exit table keeps apart, so it comes back
+// untouched rather than being read as absence.
+func removeSandbox(cfg *wrap.Config, ref string) error {
+	present, err := sandboxPresent(cfg.Runtime, cfg.VMName)
+	if err != nil {
+		return err
+	}
+	if !present {
+		// Not pruned here. Nothing was removed, so nothing about the index has
+		// been settled: the entry goes when a removal actually happens, in
+		// Remove, or when ls prunes against a listing of what the runtime
+		// really holds. Dropping it on the strength of one absence would put
+		// this path in the business of deciding a sandbox is gone, which is a
+		// judgement the verb that removes it is better placed to make. A stale
+		// entry for a sandbox that is truly gone costs nothing until then.
+		return noSandboxf(ref)
+	}
+	return cfg.Remove()
+}
+
+// sandboxPresent reports whether the runtime has a sandbox of this name at all,
+// running or stopped.
+//
+// It is how rm and logs tell "there is nothing here" -- a not-found, exit 3 --
+// from a runtime that could not be asked -- its own error, exit 4. The two are
+// different facts and the README's exit table keeps them apart, so a List that
+// fails is returned as is rather than folded into absence.
+func sandboxPresent(rt runtime.Runtime, name string) (bool, error) {
+	list, err := rt.List()
+	if err != nil {
+		return false, err
+	}
+	for _, inst := range list {
+		if inst.Name == name {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// noSandboxf is the not-found a ref'd verb gives when the runtime has no sandbox
+// for the ref. It names the ref the reader typed -- the word `brig ls` prints
+// and the one they will reach for next -- rather than the sandbox name they
+// never chose.
+func noSandboxf(ref string) error {
+	return notFoundf("no sandbox for %s. `brig ls` lists them", ref)
 }
 
 // removeAll stops and removes every sandbox brig started. Workspaces are left

--- a/cmd/brig/main.go
+++ b/cmd/brig/main.go
@@ -50,6 +50,8 @@ usage:
   brig rm   <ref>                                stop and remove the sandbox
   brig rm   --all                                stop and remove every brig sandbox
   brig ls   [-q]                                 list sandboxes; -q prints the refs
+  brig logs <ref> [--follow] [--tail N] [--raw]  stream the sandbox's log
+  brig logs --gateway                            the shared gateway's log
   brig info <ref>                                print the execution envelope and the
                                                  full environment, by name -- fails
                                                  if a declared secret is missing
@@ -295,6 +297,8 @@ func dispatch(args []string) error {
 		return doctorCmd(os.Stdout, rest)
 	case "completion":
 		return completionCmd(os.Stdout, rest)
+	case "logs":
+		return logsCmd(rest)
 	// Deprecated spellings, absent from the usage text.
 	//
 	// The three grammars this release settles are all here: a plural noun that

--- a/cmd/brig/main.go
+++ b/cmd/brig/main.go
@@ -51,7 +51,9 @@ usage:
   brig rm   --all                                stop and remove every brig sandbox
   brig ls   [-q]                                 list sandboxes; -q prints the refs
   brig logs <ref> [--follow] [--tail N] [--raw]  stream the sandbox's log
-  brig logs --gateway                            the shared gateway's log
+  brig logs --gateway [<ref>]                    the gateway's log: the shared
+                                                 one, or with a ref the gateway
+                                                 serving that sandbox alone
   brig info <ref>                                print the execution envelope and the
                                                  full environment, by name -- fails
                                                  if a declared secret is missing

--- a/cmd/brig/notfound_test.go
+++ b/cmd/brig/notfound_test.go
@@ -1,0 +1,197 @@
+package main
+
+import (
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/brig-sh/brig/internal/runtime"
+	"github.com/brig-sh/brig/internal/wrap"
+)
+
+// listRuntime answers what rm and logs ask before they act: whether a sandbox
+// of a given name exists, and -- once they know it does -- the removal or the
+// log stream. The interface is embedded rather than implemented, the repo's
+// pattern: a call to any other method is one these verbs have no business
+// making, and the nil panic says that louder than a stub returning nothing.
+type listRuntime struct {
+	runtime.Runtime
+	instances []runtime.Instance
+	listErr   error
+	lists     int
+	stopped   bool
+	removed   bool
+	logged    bool
+}
+
+func (r *listRuntime) List() ([]runtime.Instance, error) {
+	r.lists++
+	return r.instances, r.listErr
+}
+
+func (r *listRuntime) Stop(string) error           { r.stopped = true; return nil }
+func (r *listRuntime) Remove(string) error         { r.removed = true; return nil }
+func (r *listRuntime) Logs(runtime.LogsSpec) error { r.logged = true; return nil }
+
+// present is a runtime that has brig-claude-code, absent one that has nothing.
+func present() *listRuntime {
+	return &listRuntime{instances: []runtime.Instance{{Name: "brig-claude-code", State: "running"}}}
+}
+func absent() *listRuntime { return &listRuntime{} }
+
+// With no sandbox for the ref, rm is a name that resolves to nothing: exit 3,
+// naming the ref the reader typed rather than the sandbox name they never chose.
+// It used to hand back the runtime's own "instance not found" and exit 1.
+func TestRemoveSandboxOnMissingIsNotFound(t *testing.T) {
+	t.Setenv("BRIG_STATE_DIR", t.TempDir())
+	rt := absent()
+	cfg := &wrap.Config{VMName: "brig-claude-code", Runtime: rt}
+
+	err := removeSandbox(cfg, "claude")
+	if err == nil {
+		t.Fatal("rm of a missing sandbox was reported as success")
+	}
+	if _, ok := err.(*notFoundError); !ok {
+		t.Errorf("rm of a missing sandbox is not a not-found error: %T: %v", err, err)
+	}
+	if exitCode(err) != exitNotFound {
+		t.Errorf("rm of a missing sandbox exits %d, want %d", exitCode(err), exitNotFound)
+	}
+	if !strings.Contains(err.Error(), "claude") {
+		t.Errorf("the error does not name the ref: %v", err)
+	}
+	if rt.removed {
+		t.Error("rm reached the runtime's Remove for a sandbox that is not there")
+	}
+}
+
+// A sandbox that is there is removed as before: the check is a gate, not a
+// detour.
+func TestRemoveSandboxProceedsWhenPresent(t *testing.T) {
+	t.Setenv("BRIG_STATE_DIR", t.TempDir())
+	rt := present()
+	cfg := &wrap.Config{VMName: "brig-claude-code", Runtime: rt}
+
+	if err := removeSandbox(cfg, "claude"); err != nil {
+		t.Fatalf("rm of a present sandbox failed: %v", err)
+	}
+	if !rt.removed {
+		t.Error("rm did not reach the runtime's Remove for a sandbox that is there")
+	}
+}
+
+// A List that fails is a runtime that could not be asked, not a sandbox that is
+// gone: the error comes back as is, so exitCode reads it as the runtime class
+// rather than not-found. Turning "could not ask" into "not there" would erase a
+// fact the README's exit table keeps apart.
+func TestRemoveSandboxPropagatesAListError(t *testing.T) {
+	t.Setenv("BRIG_STATE_DIR", t.TempDir())
+	boom := errors.New("cannot connect to the daemon")
+	rt := &listRuntime{listErr: boom}
+	cfg := &wrap.Config{VMName: "brig-claude-code", Runtime: rt}
+
+	err := removeSandbox(cfg, "claude")
+	if !errors.Is(err, boom) {
+		t.Fatalf("a List error was not returned as is: %v", err)
+	}
+	if _, ok := err.(*notFoundError); ok {
+		t.Error("a List error was misreported as not-found")
+	}
+	if rt.removed {
+		t.Error("rm removed a sandbox after failing to list them")
+	}
+}
+
+// The missing path does not prune. "Not in the list" is not always "gone":
+// hull.List falls back to a plain ps on a hull without ps -a, and that listing
+// carries only the running instances, so a stopped sandbox reads as absent
+// while it is still in hull's store. Its index entry stays until a removal
+// actually happens, or until ls prunes against a full listing.
+func TestRemoveSandboxKeepsTheIndexOnMissing(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("BRIG_STATE_DIR", dir)
+	sessions := filepath.Join(dir, "sessions.json")
+	if err := os.WriteFile(sessions,
+		[]byte(`{"claude@refactor":{"home":"/ws","sandbox":"brig-claude-code"}}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	err := removeSandbox(&wrap.Config{VMName: "brig-claude-code", Runtime: absent()}, "claude@refactor")
+	if exitCode(err) != exitNotFound {
+		t.Fatalf("rm of a missing sandbox exits %d, want %d: %v", exitCode(err), exitNotFound, err)
+	}
+	blob, readErr := os.ReadFile(sessions)
+	if readErr != nil {
+		t.Fatal(readErr)
+	}
+	if !strings.Contains(string(blob), "brig-claude-code") {
+		t.Errorf("the index entry was pruned on a listing that may not have been complete: %s", blob)
+	}
+}
+
+// logs mirrors rm: nothing to read from a sandbox that is not there is a
+// not-found (exit 3) naming the ref, not a log stream that started and failed.
+func TestLogsForOnMissingIsNotFound(t *testing.T) {
+	rt := absent()
+	err := logsFor(rt, "brig-claude-code", "claude", logsOptions{tail: -1}, io.Discard)
+	if err == nil {
+		t.Fatal("logs of a missing sandbox was reported as success")
+	}
+	if _, ok := err.(*notFoundError); !ok {
+		t.Errorf("logs of a missing sandbox is not a not-found error: %T: %v", err, err)
+	}
+	if exitCode(err) != exitNotFound {
+		t.Errorf("logs of a missing sandbox exits %d, want %d", exitCode(err), exitNotFound)
+	}
+	if !strings.Contains(err.Error(), "claude") {
+		t.Errorf("the error does not name the ref: %v", err)
+	}
+	if rt.logged {
+		t.Error("logs streamed from a sandbox that is not there")
+	}
+}
+
+// A sandbox that is there streams as before.
+func TestLogsForProceedsWhenPresent(t *testing.T) {
+	rt := present()
+	if err := logsFor(rt, "brig-claude-code", "claude", logsOptions{tail: -1}, io.Discard); err != nil {
+		t.Fatalf("logs of a present sandbox failed: %v", err)
+	}
+	if !rt.logged {
+		t.Error("logs did not stream from a sandbox that is there")
+	}
+}
+
+// A List that fails comes back as is here too, never as not-found.
+func TestLogsForPropagatesAListError(t *testing.T) {
+	boom := errors.New("cannot connect to the daemon")
+	rt := &listRuntime{listErr: boom}
+	err := logsFor(rt, "brig-claude-code", "claude", logsOptions{tail: -1}, io.Discard)
+	if !errors.Is(err, boom) {
+		t.Fatalf("a List error was not returned as is: %v", err)
+	}
+	if _, ok := err.(*notFoundError); ok {
+		t.Error("a List error was misreported as not-found")
+	}
+	if rt.logged {
+		t.Error("logs streamed after failing to list the sandboxes")
+	}
+}
+
+// stop is the verb this change must not widen: stopping a sandbox that is not
+// running is the end state stop asks for, not a failure, so it stays exit 0 and
+// never consults the list. Pinned with the same double, whose List would flag it
+// if stop grew the gate rm and logs have.
+func TestStopIsNotGatedOnTheSandboxExisting(t *testing.T) {
+	rt := absent()
+	cfg := &wrap.Config{VMName: "brig-claude-code", Runtime: rt}
+	if err := cfg.Stop(); err != nil {
+		t.Errorf("stop of a missing sandbox was reported as a failure: %v", err)
+	}
+	if rt.lists != 0 {
+		t.Errorf("stop consulted the sandbox list %d times; it must not gate on existence", rt.lists)
+	}
+}

--- a/docs/runtimes.md
+++ b/docs/runtimes.md
@@ -76,6 +76,7 @@ hull run --detach --name <name>
      [--gui [--gui-title <title>]]
      [--env <NAME>]... <image>
 hull exec [-t] [--cwd <dir>] [-u <user>] [--env <NAME>]... <name> -- <cmd>...
+hull logs [--follow] [--tail <n>] <name>
 hull stop <name>
 hull rm <name>
 hull network-gateway --socket <path> --qemu-socket <path>.qemu
@@ -93,8 +94,8 @@ routers and by vmnet on macOS, and 100.64.0.0/10 by Tailscale. The sibling
 `hull exec` is the whole exec path: the reachability probe, the captured read,
 the credential written over stdin and the terminal handover all build the same
 argv (`execArgs`), and the handover replaces the brig process with hull so the
-guest gets a real terminal. `hull logs <name>` appears in brig's error output
-as a suggestion and is never run.
+guest gets a real terminal. `hull logs <name>` is what `brig logs <ref>` runs,
+and it is also named in brig's error output when a sandbox will not come up.
 
 On Linux, from `internal/runtime/nerdctl.go`:
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -664,9 +664,12 @@ clipboard; DCS sequences are forwarded verbatim by `tmux` and `screen` to the
 *outer* terminal; and a cursor-position query makes the terminal type its
 reply onto your shell's standard input. An agent that has read a hostile
 README can do any of those. `hull exec` and `hull logs` do filter, because
-hull stays in the middle of that stream; brig deliberately does not stay. If
-this matters for your threat model, run brig inside a terminal you are willing
-to lose, or through `hull exec`.
+hull stays in the middle of that stream. `brig run` deliberately does not
+stay. `brig logs` does: it reads a log back rather than driving a terminal, so
+it filters control sequences by default, and `--raw` turns that off and hands
+you the bytes with the surface above intact. If this matters for your threat
+model, run brig inside a terminal you are willing to lose, or through
+`hull exec`.
 
 It does not protect the workspace from the agent. Everything in there is
 writable by design, since that is the work.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -11,21 +11,24 @@ thing to know when the wording does not match anything in brig.
 ## The sandbox never became ready
 
 ```
-brig: sandbox did not become ready; check 'hull logs brig-claude-code'
+brig: sandbox did not become ready; check 'brig logs claude (or the runtime's own, hull logs brig-claude-code)'
 ```
 
-On Linux the hint names `nerdctl logs` instead.
+On Linux the second half names `nerdctl logs` instead.
 
 The runtime reported the sandbox running, but the agent inside it never
 answered. Those are two different moments: the VM process starts, and a few
 seconds later the guest binds its listener. brig waits for the second one and
 gave up.
 
-Check the runtime's own logs, which is what the message points at:
+Read the log, which is what the message points at:
 
 ```bash
-hull logs brig-claude-code
+brig logs claude
 ```
+
+That is `hull logs` underneath, and the message names that spelling too, for
+a boot that never became a sandbox brig can address by ref.
 
 The guest's own errors are there, not in brig's output. If the guest is only
 slow rather than broken, give it longer with `BRIG_READY_TIMEOUT` (seconds,
@@ -39,8 +42,8 @@ BRIG_READY_TIMEOUT=60 brig run claude
 
 ```
 VMM started (PID 33351)
-brig: sandbox did not become ready; check '/opt/homebrew/bin/hull logs brig-claude-code'
-$ hull logs brig-claude-code
+brig: sandbox did not become ready; check 'brig logs claude (or the runtime's own, /opt/homebrew/bin/hull logs brig-claude-code)'
+$ brig logs claude
 dyld[33351]: missing symbol called
 ```
 

--- a/internal/runtime/gateway.go
+++ b/internal/runtime/gateway.go
@@ -131,6 +131,20 @@ func gatewaySocket() (string, error) {
 	return filepath.Join(dir, "gateway-"+socketTag(gatewaySubnet)+".sock"), nil
 }
 
+// GatewayLogPath is where the shared gateway's own output is written, beside
+// its socket. ensureGateway opens it, and `brig logs --gateway` points at it:
+// the gateway logs a boot's network failure to a file no command named until
+// now, so a network that never came up was invisible unless you already knew
+// the file was there. Derived from the socket by the same rule startGateway
+// uses, so the writer and the reader cannot drift onto two paths.
+func GatewayLogPath() (string, error) {
+	sock, err := gatewaySocket()
+	if err != nil {
+		return "", err
+	}
+	return gatewayLogPath(sock), nil
+}
+
 // socketTag turns a subnet into something that can sit in a filename.
 func socketTag(subnet string) string {
 	return strings.NewReplacer("/", "_", ".", "-").Replace(subnet)

--- a/internal/runtime/gateway.go
+++ b/internal/runtime/gateway.go
@@ -132,13 +132,30 @@ func gatewaySocket() (string, error) {
 }
 
 // GatewayLogPath is where the shared gateway's own output is written, beside
-// its socket. ensureGateway opens it, and `brig logs --gateway` points at it:
-// the gateway logs a boot's network failure to a file no command named until
-// now, so a network that never came up was invisible unless you already knew
-// the file was there. Derived from the socket by the same rule startGateway
-// uses, so the writer and the reader cannot drift onto two paths.
+// its socket, and IsolatedGatewayLogPath is the same for the gateway serving
+// one sandbox alone. ensureGateway and ensureIsolatedGateway open them, and
+// `brig logs --gateway` points at them: the gateway logs a boot's network
+// failure to a file no command named until now, so a network that never came up
+// was invisible unless you already knew the file was there. Both are derived
+// from the socket by the same rule startGateway uses, so the writer and the
+// reader cannot drift onto two paths.
+//
+// The shared log stays put; an isolated one does not. clearGatewayRecord
+// removes it with the gateway it belongs to, once that gateway is confirmed
+// stopped, which is what keeps ~/.brig from growing a file for every sandbox
+// ever isolated. So an isolated log is there while its gateway runs -- and
+// after one that failed to start, which is the case a reader most needs -- and
+// gone once the sandbox is stopped.
 func GatewayLogPath() (string, error) {
 	sock, err := gatewaySocket()
+	if err != nil {
+		return "", err
+	}
+	return gatewayLogPath(sock), nil
+}
+
+func IsolatedGatewayLogPath(name string) (string, error) {
+	sock, err := isolatedSocket(name)
 	if err != nil {
 		return "", err
 	}

--- a/internal/runtime/hull.go
+++ b/internal/runtime/hull.go
@@ -788,6 +788,25 @@ func firstLines(s string, n int) string {
 	return strings.Join(lines, "; ")
 }
 
+// Logs streams the instance's log. hull writes it to its own stdout, so the
+// stream is handed straight to spec.Out; --follow and --tail are the two flags
+// hull offers, and brig offers only what both runtimes share. The instance is
+// the positional. Not counted: reading a log is not the user action telemetry
+// attributes, the same reason ps and rm read false.
+func (h *hull) Logs(spec LogsSpec) error {
+	args := []string{"logs"}
+	if spec.Follow {
+		args = append(args, "--follow")
+	}
+	// hull's own default is -1 (all), so spec.Tail passes straight through.
+	args = append(args, "--tail", strconv.Itoa(spec.Tail), spec.Name)
+	cmd := exec.Command(h.bin, args...)
+	cmd.Env = mergeEnv(telemetryEnv(false))
+	cmd.Stdout = spec.Out
+	cmd.Stderr = spec.Err
+	return cmd.Run()
+}
+
 func (h *hull) LogsHint(name string) string {
 	return fmt.Sprintf("%s logs %s", h.bin, name)
 }

--- a/internal/runtime/nerdctl.go
+++ b/internal/runtime/nerdctl.go
@@ -483,6 +483,27 @@ func (n *nerdctl) quiet(verb, name string) error {
 	return cmd.Run()
 }
 
+// Logs streams the container's log. nerdctl documents --follow, --tail,
+// --since and --timestamps, but brig drives it against --follow and --tail
+// only, so the two runtimes offer brig the same thing and brig does not promise
+// what only one of them has. nerdctl has no negative tail -- its default is
+// already all -- so a -1 is passed as an absent flag rather than the literal.
+func (n *nerdctl) Logs(spec LogsSpec) error {
+	args := []string{"logs"}
+	if spec.Follow {
+		args = append(args, "--follow")
+	}
+	if spec.Tail >= 0 {
+		args = append(args, "--tail", strconv.Itoa(spec.Tail))
+	}
+	args = append(args, spec.Name)
+	cmd := exec.Command(n.bin, args...)
+	cmd.Env = mergeEnv(telemetryEnv(false))
+	cmd.Stdout = spec.Out
+	cmd.Stderr = spec.Err
+	return cmd.Run()
+}
+
 func (n *nerdctl) LogsHint(name string) string {
 	return fmt.Sprintf("%s logs %s", n.bin, name)
 }

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -188,6 +188,36 @@ type Rule struct {
 // that turns it on: rules with no default are rules nothing consults.
 func (e Egress) Filtered() bool { return e.Default != "" }
 
+// LogsSpec is a request to stream a sandbox's log.
+//
+// An options value rather than a parameter list, in the style of RunSpec and
+// ExecSpec: the flags brig hands the runtime -- follow, tail -- are a set that
+// grows, and threading them positionally is what makes an adapter and its
+// caller drift.
+type LogsSpec struct {
+	Name string
+	// Follow streams the log until the reader interrupts it. brig reads a log
+	// here and does not own the sandbox, so an interrupt that reaches the
+	// runtime must leave the sandbox running -- see the note on Logs.
+	Follow bool
+	// Tail is how many trailing lines to show, or -1 for all. -1 is both
+	// runtimes' own default; a container runtime with no notion of a negative
+	// count reads it as "all" rather than passing it through.
+	Tail int
+	// Out is where the log is written, as it arrives. The caller wraps it to
+	// filter the terminal control sequences a runtime may have captured, unless
+	// asked for the raw bytes.
+	Out io.Writer
+	// Err is where the runtime's own standard error goes, kept apart from Out
+	// rather than merged into it. On hull that stream carries the runtime's
+	// diagnostics and nothing else, so merging would write "instance not
+	// found" into a redirect that was meant to hold a log; on a container
+	// runtime it carries the guest's stderr, which a reader redirecting stdout
+	// expects to still see on the terminal. The caller wraps this one too, so
+	// the control-sequence filter covers both halves of the stream.
+	Err io.Writer
+}
+
 // Instance is one sandbox as the runtime sees it.
 type Instance struct {
 	Name  string
@@ -270,7 +300,14 @@ type Runtime interface {
 	// Stop stops a sandbox, and Remove clears the instance holding the name.
 	Stop(name string) error
 	Remove(name string) error
-	// LogsHint is the command to suggest when a sandbox will not come up.
+	// Logs streams a sandbox's log to spec.Out, following until interrupted
+	// when spec.Follow is set. This reads a log; it does not own the sandbox, so
+	// an interrupt reaching the runtime leaves the sandbox running.
+	Logs(spec LogsSpec) error
+	// LogsHint is the command to suggest when a sandbox will not come up. It is
+	// kept beside Logs rather than replaced by it: a boot that never became a
+	// sandbox brig can drive still has a runtime command worth naming, and it is
+	// the second half of the advice `brig logs` leads.
 	LogsHint(name string) string
 }
 

--- a/internal/wrap/run.go
+++ b/internal/wrap/run.go
@@ -382,8 +382,7 @@ func (c *Config) EnsureRunning(set creds.Set) error {
 	// to find out.
 	c.rememberSession()
 	if !c.waitReady() {
-		return fmt.Errorf("sandbox did not become ready; check '%s'",
-			c.Runtime.LogsHint(c.VMName))
+		return fmt.Errorf("sandbox did not become ready; check '%s'", c.logHint())
 	}
 	if c.Profile.IsGUI() {
 		focusWindow()
@@ -462,6 +461,25 @@ func majorVersion(v string) (int, bool) {
 		return 0, false
 	}
 	return n, true
+}
+
+// logHint is the advice a boot that will not come up, or a stop that will not
+// take, points the reader at: `brig logs` first, then the runtime's own
+// command. brig knows the two facts the runtime command asks of the user and
+// they do not -- the sandbox name, which is not the ref, and which runtime is
+// underneath -- so its own command leads, and the runtime's stays as the
+// fallback for a boot that never became a sandbox brig can name.
+//
+// The ref is recovered from the sandbox name through the session index, which
+// EnsureRunning has already written by the time a readiness wait can fail; a
+// session not in the index falls back to the bare agent, which is still a ref
+// every verb takes.
+func (c *Config) logHint() string {
+	ref := RefOfSandbox(c.VMName)
+	if ref == "" {
+		ref = c.Profile.Name
+	}
+	return fmt.Sprintf("brig logs %s (or the runtime's own, %s)", ref, c.Runtime.LogsHint(c.VMName))
 }
 
 // waitReady waits for the in-guest agent.
@@ -610,11 +628,11 @@ func (c *Config) Stop() error {
 		// Both, joined: what the stop said and why the end state could not be
 		// checked are two separate things to fix, and errors.Is finds either.
 		return fmt.Errorf("the sandbox %s would not stop, and whether it is still running "+
-			"could not be established (%s): %w", c.VMName, c.Runtime.LogsHint(c.VMName),
+			"could not be established (%s): %w", c.VMName, c.logHint(),
 			errors.Join(err, askErr))
 	}
 	return fmt.Errorf("the sandbox %s is still running and would not stop (%s): %w",
-		c.VMName, c.Runtime.LogsHint(c.VMName), err)
+		c.VMName, c.logHint(), err)
 }
 
 // Remove stops the sandbox and clears the instance holding its name. The

--- a/internal/wrap/run.go
+++ b/internal/wrap/run.go
@@ -648,6 +648,9 @@ func (c *Config) Stop() error {
 func (c *Config) Remove() error {
 	_ = c.Runtime.Stop(c.VMName)
 	err := c.Runtime.Remove(c.VMName)
+	// The index entries that name this sandbox: the workspace record and the
+	// slug claim. Both are idempotent. Removal is the only thing that clears
+	// them -- rm's not-found path leaves them alone, since it removed nothing.
 	ForgetSandbox(c.VMName)
 	ForgetSlugClaim(c.VMName)
 	return err

--- a/script/smoke.sh
+++ b/script/smoke.sh
@@ -815,6 +815,11 @@ echo "== logs =="
 # the ref resolves to, and the flags the line carried. The stub logs its argv
 # like every other verb, so this asserts what reached the runtime. --tail -1 is
 # the default brig passes, which both runtimes read as "all".
+#
+# A sandbox has to exist for there to be a log to read: logs asks the runtime's
+# list first and is a not-found otherwise, which the case below the lifecycle
+# section pins. The stop above left none, so boot one here.
+"$WORK/brig" run claude -d > /dev/null 2>&1
 : > "$STUB_LOG"
 "$WORK/brig" logs claude > /dev/null 2>&1
 grep -q '^argv: logs --tail -1 brig-claude-code' "$STUB_LOG" \
@@ -931,6 +936,26 @@ grep -q '^argv: rm brig-claude-code' "$STUB_LOG" \
 "$WORK/brig" rm --all > /dev/null 2>&1
 grep -q '^argv: rm brig-claude-code' "$STUB_LOG" \
   && ok "rm --all removes brig sandboxes" || bad "rm --all removes brig sandboxes"
+
+echo "== rm and logs with no sandbox =="
+# Nothing holds the name now, so rm and logs name a sandbox that resolves to
+# nothing: exit 3, the code the table gives a name that is not there, and a
+# message naming the ref rather than the runtime's own "instance not found".
+# They used to hand that error back and exit 1.
+out="$("$WORK/brig" rm claude 2>&1)"; rc=$?
+[ "$rc" = 3 ] && ok "rm of a missing sandbox exits 3" \
+  || bad "rm of a missing sandbox exits 3 -- got $rc: $out"
+case "$out" in
+  *"no sandbox for claude"*) ok "rm names the ref, not the sandbox" ;;
+  *) bad "rm names the ref -- got: $out" ;;
+esac
+out="$("$WORK/brig" logs claude 2>&1)"; rc=$?
+[ "$rc" = 3 ] && ok "logs of a missing sandbox exits 3" \
+  || bad "logs of a missing sandbox exits 3 -- got $rc: $out"
+case "$out" in
+  *"no sandbox for claude"*) ok "logs names the ref, not the sandbox" ;;
+  *) bad "logs names the ref -- got: $out" ;;
+esac
 
 echo "== remembered workspace =="
 # A session created with -w used to be restarted by the next verb that left the

--- a/script/smoke.sh
+++ b/script/smoke.sh
@@ -810,6 +810,22 @@ grep -q '^argv: stop brig-claude-code' "$STUB_LOG" \
 grep -q 'CLAUDE_CODE_OAUTH_TOKEN' "$STUB_LOG" \
   && bad "stop resolved credentials" || ok "stop resolves no credentials"
 
+echo "== logs =="
+# brig hands the runtime the log request built from the ref: the sandbox name
+# the ref resolves to, and the flags the line carried. The stub logs its argv
+# like every other verb, so this asserts what reached the runtime. --tail -1 is
+# the default brig passes, which both runtimes read as "all".
+: > "$STUB_LOG"
+"$WORK/brig" logs claude > /dev/null 2>&1
+grep -q '^argv: logs --tail -1 brig-claude-code' "$STUB_LOG" \
+  && ok "logs streams the sandbox log through the runtime" \
+  || bad "logs streams the sandbox log -- got: $(grep '^argv:' "$STUB_LOG")"
+: > "$STUB_LOG"
+"$WORK/brig" logs claude --follow > /dev/null 2>&1
+grep -q '^argv: logs --follow --tail -1 brig-claude-code' "$STUB_LOG" \
+  && ok "logs --follow passes --follow to the runtime" \
+  || bad "logs --follow passes --follow -- got: $(grep '^argv:' "$STUB_LOG")"
+
 echo "== lifecycle verbs =="
 : > "$STUB_LOG"
 out="$("$WORK/brig" --verbose run claude -d 2>"$WORK/detach.err")"
@@ -886,6 +902,7 @@ while read -r ref; do
   takes_ref "brig run"   run "$ref" -d
   takes_ref "brig sh"    sh "$ref" -- true
   takes_ref "brig info"  info "$ref"
+  takes_ref "brig logs"  logs "$ref"
   takes_ref "brig stop"  stop "$ref"
   takes_ref "brig rm"    rm "$ref"
   # And the verbless form, which is taught nowhere and accepted anyway. Last,


### PR DESCRIPTION
## Summary

After `brig run -d`, or a boot that never became ready, no brig command showed what happened. brig's only advice was to leave brig for `hull logs <sandbox>` or `nerdctl logs <sandbox>`, which asks the reader for two facts brig has and they do not: the sandbox name, which is not the ref, and which runtime is underneath. The gateway wrote its own log beside its socket and nothing pointed at it.

`brig logs <ref>` resolves the ref to its sandbox and runtime the way every other ref'd verb does, then streams. `--gateway` reads the shared gateway's log; `--gateway <ref>` reads the gateway serving that sandbox alone, which since #130 is the case this is most for. Control sequences are filtered by default, `--raw` hands back the bytes. Three commits, each describing one change and each building and testing on its own.

## Related issues

Closes #25, closes #136.

## Changes

- `Runtime` gains `Logs(LogsSpec)` beside `LogsHint`, in both adapters. The runtime's own stderr goes to a separate `Err` writer, filtered alike, so `brig logs claude > out.txt` leaves a diagnostic on the terminal rather than in the file.
- `brig logs <ref> [--follow] [--tail N] [--raw]`. `--since` from #25 is dropped: hull offers `--follow` and `--tail` only (checked against `hull 0.1.0-rc21`), and brig promises only what both runtimes have.
- `brig logs --gateway [<ref>]`. The isolated log does not survive a stop; `clearGatewayRecord` is untouched. A sandbox on the shared gateway is told so from its resolved network rather than offered a guess.
- The boot-failure hint names `brig logs <ref>` first and the runtime's own command second.
- **`brig rm` and `brig logs` exit 3 on a sandbox that does not exist**, asking the runtime's `List` first, naming the ref by its slug. A `List` that fails stays exit 4. `stop` is untouched. `rm` does not prune the index on that path: nothing was removed, so nothing about the index has been settled.
- Docs: README's command table, `docs/runtimes.md` (no longer says `hull logs` is never run; argv listing gains it), `docs/troubleshooting.md` (the hint, verbatim), `docs/security.md` (`brig logs` stays in the middle of the stream and filters; `--raw` re-opens the surface that page describes).

## Checklist

- [x] `make all` passes (vet, test, build)
- [x] `script/smoke.sh` passes, with new cases for the argv brig hands the runtime, the missing-sandbox exits, and the ref round-trip
- [x] I have added or updated tests covering the change
- [x] I have run `go test ./... -race`
- [x] I have exercised the change against a real runtime: `brig logs --gateway`, `brig logs nosuch@x` (3), `brig logs claude` on a missing sandbox (3), `brig rm claude -n Refactor` naming the slug, all on hull 0.1.0-rc21
- [x] I have updated the affected docs (README, `docs/security.md`, `docs/runtimes.md`, `docs/troubleshooting.md`)

## Credentials and the sandbox boundary

Touches `internal/wrap` only in `Remove`, which keeps its index bookkeeping; the not-found path now leaves the index alone, pinned by `TestRemoveSandboxKeepsTheIndexOnMissing`. Nothing here reads or forwards a credential, and `brig logs` reads host-side files the runtime already writes.