### PR TITLE
fix(cli): make rm and logs exit 3 when the sandbox is absent

### DIFF
--- a/cmd/brig/logs.go
+++ b/cmd/brig/logs.go
@@ -96,7 +96,7 @@ func logsCmd(args []string) error {
 	if err != nil {
 		return err
 	}
-	return streamLogs(rt, name, o, os.Stdout)
+	return logsFor(rt, name, ref, o, os.Stdout)
 }
 
 // resolveSandbox turns a ref into the runtime it runs on and the sandbox name
@@ -129,6 +129,28 @@ func resolveSandbox(ref string) (runtime.Runtime, string, error) {
 		return nil, "", err
 	}
 	return rt, cfg.VMName, nil
+}
+
+// logsFor confirms the runtime has the sandbox before streaming its log.
+//
+// There is nothing to read from a sandbox that is not there, which the exit
+// table calls a not-found (3) rather than a log stream that started and failed
+// (1). So the runtime is asked before the stream is opened, and the ref the
+// reader typed -- not the sandbox name -- is what the not-found names. A List
+// that itself fails comes back as is (exit 4, the runtime unavailable), not as
+// absence: the two are different facts. See sandboxPresent.
+//
+// Split from logsCmd so a test can drive it with a runtime double, the way
+// streamLogs is split for the same reason.
+func logsFor(rt runtime.Runtime, name, ref string, o logsOptions, out io.Writer) error {
+	present, err := sandboxPresent(rt, name)
+	if err != nil {
+		return err
+	}
+	if !present {
+		return noSandboxf(ref)
+	}
+	return streamLogs(rt, name, o, out)
 }
 
 // streamLogs hands the runtime the log request, filtering terminal control

--- a/cmd/brig/main.go
+++ b/cmd/brig/main.go
@@ -428,9 +428,13 @@ func run(args []string) error {
 	// keychain prompt that reading the host login may bring up.
 	switch verb {
 	case "stop":
+		// Deliberately not gated on the sandbox existing: stopping one that was
+		// never running is the end state stop asks for, not a failure. See
+		// Config.Stop. rm and logs below are the opposite -- there is nothing to
+		// remove and nothing to read -- which is why only they check first.
 		return cfg.Stop()
 	case "rm":
-		return cfg.Remove()
+		return removeSandbox(cfg, session.Ref{Agent: profileName, Label: cfg.RawName}.String())
 	}
 
 	set, err := cfg.BuildEnv()
@@ -1512,6 +1516,62 @@ func takeAll(args []string) (rest []string, all bool) {
 		rest = append(rest, a)
 	}
 	return rest, all
+}
+
+// removeSandbox is `brig rm <ref>`: be rid of the one sandbox the ref names.
+//
+// It asks the runtime whether that sandbox is there before handing over, so the
+// case the runtime used to answer with its own "instance not found" -- there is
+// nothing to remove -- is reported as a not-found (exit 3), the code the README
+// gives a name that resolves to nothing, rather than as a removal that ran and
+// failed (exit 1). A List that itself fails is a runtime that could not be asked
+// (exit 4), a different fact the exit table keeps apart, so it comes back
+// untouched rather than being read as absence.
+func removeSandbox(cfg *wrap.Config, ref string) error {
+	present, err := sandboxPresent(cfg.Runtime, cfg.VMName)
+	if err != nil {
+		return err
+	}
+	if !present {
+		// Not pruned here. "Not in the list" is not always "gone": hull.List
+		// falls back to a plain `ps` on a hull without `ps -a`, and that listing
+		// carries only the running instances, so a stopped sandbox reads as
+		// absent while it is still in hull's store. Forgetting its index entry on
+		// that reading would drop the workspace record of a sandbox that is
+		// really there. The entry goes when a removal actually happens, in
+		// Remove, or when ls prunes against a full listing; a stale entry for a
+		// sandbox that is truly gone costs nothing until then.
+		return noSandboxf(ref)
+	}
+	return cfg.Remove()
+}
+
+// sandboxPresent reports whether the runtime has a sandbox of this name at all,
+// running or stopped.
+//
+// It is how rm and logs tell "there is nothing here" -- a not-found, exit 3 --
+// from a runtime that could not be asked -- its own error, exit 4. The two are
+// different facts and the README's exit table keeps them apart, so a List that
+// fails is returned as is rather than folded into absence.
+func sandboxPresent(rt runtime.Runtime, name string) (bool, error) {
+	list, err := rt.List()
+	if err != nil {
+		return false, err
+	}
+	for _, inst := range list {
+		if inst.Name == name {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// noSandboxf is the not-found a ref'd verb gives when the runtime has no sandbox
+// for the ref. It names the ref the reader typed -- the word `brig ls` prints
+// and the one they will reach for next -- rather than the sandbox name they
+// never chose.
+func noSandboxf(ref string) error {
+	return notFoundf("no sandbox for %s. `brig ls` lists them", ref)
 }
 
 // removeAll stops and removes every sandbox brig started. Workspaces are left

--- a/cmd/brig/notfound_test.go
+++ b/cmd/brig/notfound_test.go
@@ -1,0 +1,197 @@
+package main
+
+import (
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/brig-sh/brig/internal/runtime"
+	"github.com/brig-sh/brig/internal/wrap"
+)
+
+// listRuntime answers what rm and logs ask before they act: whether a sandbox
+// of a given name exists, and -- once they know it does -- the removal or the
+// log stream. The interface is embedded rather than implemented, the repo's
+// pattern: a call to any other method is one these verbs have no business
+// making, and the nil panic says that louder than a stub returning nothing.
+type listRuntime struct {
+	runtime.Runtime
+	instances []runtime.Instance
+	listErr   error
+	lists     int
+	stopped   bool
+	removed   bool
+	logged    bool
+}
+
+func (r *listRuntime) List() ([]runtime.Instance, error) {
+	r.lists++
+	return r.instances, r.listErr
+}
+
+func (r *listRuntime) Stop(string) error           { r.stopped = true; return nil }
+func (r *listRuntime) Remove(string) error         { r.removed = true; return nil }
+func (r *listRuntime) Logs(runtime.LogsSpec) error { r.logged = true; return nil }
+
+// present is a runtime that has brig-claude-code, absent one that has nothing.
+func present() *listRuntime {
+	return &listRuntime{instances: []runtime.Instance{{Name: "brig-claude-code", State: "running"}}}
+}
+func absent() *listRuntime { return &listRuntime{} }
+
+// With no sandbox for the ref, rm is a name that resolves to nothing: exit 3,
+// naming the ref the reader typed rather than the sandbox name they never chose.
+// It used to hand back the runtime's own "instance not found" and exit 1.
+func TestRemoveSandboxOnMissingIsNotFound(t *testing.T) {
+	t.Setenv("BRIG_STATE_DIR", t.TempDir())
+	rt := absent()
+	cfg := &wrap.Config{VMName: "brig-claude-code", Runtime: rt}
+
+	err := removeSandbox(cfg, "claude")
+	if err == nil {
+		t.Fatal("rm of a missing sandbox was reported as success")
+	}
+	if _, ok := err.(*notFoundError); !ok {
+		t.Errorf("rm of a missing sandbox is not a not-found error: %T: %v", err, err)
+	}
+	if exitCode(err) != exitNotFound {
+		t.Errorf("rm of a missing sandbox exits %d, want %d", exitCode(err), exitNotFound)
+	}
+	if !strings.Contains(err.Error(), "claude") {
+		t.Errorf("the error does not name the ref: %v", err)
+	}
+	if rt.removed {
+		t.Error("rm reached the runtime's Remove for a sandbox that is not there")
+	}
+}
+
+// A sandbox that is there is removed as before: the check is a gate, not a
+// detour.
+func TestRemoveSandboxProceedsWhenPresent(t *testing.T) {
+	t.Setenv("BRIG_STATE_DIR", t.TempDir())
+	rt := present()
+	cfg := &wrap.Config{VMName: "brig-claude-code", Runtime: rt}
+
+	if err := removeSandbox(cfg, "claude"); err != nil {
+		t.Fatalf("rm of a present sandbox failed: %v", err)
+	}
+	if !rt.removed {
+		t.Error("rm did not reach the runtime's Remove for a sandbox that is there")
+	}
+}
+
+// A List that fails is a runtime that could not be asked, not a sandbox that is
+// gone: the error comes back as is, so exitCode reads it as the runtime class
+// rather than not-found. Turning "could not ask" into "not there" would erase a
+// fact the README's exit table keeps apart.
+func TestRemoveSandboxPropagatesAListError(t *testing.T) {
+	t.Setenv("BRIG_STATE_DIR", t.TempDir())
+	boom := errors.New("cannot connect to the daemon")
+	rt := &listRuntime{listErr: boom}
+	cfg := &wrap.Config{VMName: "brig-claude-code", Runtime: rt}
+
+	err := removeSandbox(cfg, "claude")
+	if !errors.Is(err, boom) {
+		t.Fatalf("a List error was not returned as is: %v", err)
+	}
+	if _, ok := err.(*notFoundError); ok {
+		t.Error("a List error was misreported as not-found")
+	}
+	if rt.removed {
+		t.Error("rm removed a sandbox after failing to list them")
+	}
+}
+
+// The missing path does not prune. "Not in the list" is not always "gone":
+// hull.List falls back to a plain ps on a hull without ps -a, and that listing
+// carries only the running instances, so a stopped sandbox reads as absent
+// while it is still in hull's store. Its index entry stays until a removal
+// actually happens, or until ls prunes against a full listing.
+func TestRemoveSandboxKeepsTheIndexOnMissing(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("BRIG_STATE_DIR", dir)
+	sessions := filepath.Join(dir, "sessions.json")
+	if err := os.WriteFile(sessions,
+		[]byte(`{"claude@refactor":{"home":"/ws","sandbox":"brig-claude-code"}}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	err := removeSandbox(&wrap.Config{VMName: "brig-claude-code", Runtime: absent()}, "claude@refactor")
+	if exitCode(err) != exitNotFound {
+		t.Fatalf("rm of a missing sandbox exits %d, want %d: %v", exitCode(err), exitNotFound, err)
+	}
+	blob, readErr := os.ReadFile(sessions)
+	if readErr != nil {
+		t.Fatal(readErr)
+	}
+	if !strings.Contains(string(blob), "brig-claude-code") {
+		t.Errorf("the index entry was pruned on a listing that may not have been complete: %s", blob)
+	}
+}
+
+// logs mirrors rm: nothing to read from a sandbox that is not there is a
+// not-found (exit 3) naming the ref, not a log stream that started and failed.
+func TestLogsForOnMissingIsNotFound(t *testing.T) {
+	rt := absent()
+	err := logsFor(rt, "brig-claude-code", "claude", logsOptions{tail: -1}, io.Discard)
+	if err == nil {
+		t.Fatal("logs of a missing sandbox was reported as success")
+	}
+	if _, ok := err.(*notFoundError); !ok {
+		t.Errorf("logs of a missing sandbox is not a not-found error: %T: %v", err, err)
+	}
+	if exitCode(err) != exitNotFound {
+		t.Errorf("logs of a missing sandbox exits %d, want %d", exitCode(err), exitNotFound)
+	}
+	if !strings.Contains(err.Error(), "claude") {
+		t.Errorf("the error does not name the ref: %v", err)
+	}
+	if rt.logged {
+		t.Error("logs streamed from a sandbox that is not there")
+	}
+}
+
+// A sandbox that is there streams as before.
+func TestLogsForProceedsWhenPresent(t *testing.T) {
+	rt := present()
+	if err := logsFor(rt, "brig-claude-code", "claude", logsOptions{tail: -1}, io.Discard); err != nil {
+		t.Fatalf("logs of a present sandbox failed: %v", err)
+	}
+	if !rt.logged {
+		t.Error("logs did not stream from a sandbox that is there")
+	}
+}
+
+// A List that fails comes back as is here too, never as not-found.
+func TestLogsForPropagatesAListError(t *testing.T) {
+	boom := errors.New("cannot connect to the daemon")
+	rt := &listRuntime{listErr: boom}
+	err := logsFor(rt, "brig-claude-code", "claude", logsOptions{tail: -1}, io.Discard)
+	if !errors.Is(err, boom) {
+		t.Fatalf("a List error was not returned as is: %v", err)
+	}
+	if _, ok := err.(*notFoundError); ok {
+		t.Error("a List error was misreported as not-found")
+	}
+	if rt.logged {
+		t.Error("logs streamed after failing to list the sandboxes")
+	}
+}
+
+// stop is the verb this change must not widen: stopping a sandbox that is not
+// running is the end state stop asks for, not a failure, so it stays exit 0 and
+// never consults the list. Pinned with the same double, whose List would flag it
+// if stop grew the gate rm and logs have.
+func TestStopIsNotGatedOnTheSandboxExisting(t *testing.T) {
+	rt := absent()
+	cfg := &wrap.Config{VMName: "brig-claude-code", Runtime: rt}
+	if err := cfg.Stop(); err != nil {
+		t.Errorf("stop of a missing sandbox was reported as a failure: %v", err)
+	}
+	if rt.lists != 0 {
+		t.Errorf("stop consulted the sandbox list %d times; it must not gate on existence", rt.lists)
+	}
+}

--- a/internal/wrap/run.go
+++ b/internal/wrap/run.go
@@ -648,9 +648,23 @@ func (c *Config) Stop() error {
 func (c *Config) Remove() error {
 	_ = c.Runtime.Stop(c.VMName)
 	err := c.Runtime.Remove(c.VMName)
+	c.Forget()
+	return err
+}
+
+// Forget clears the index entries that name this sandbox: the workspace record
+// and the slug claim. Both are idempotent, so it is safe whether or not the
+// sandbox still exists.
+//
+// A method of its own, so that rm's not-found path can prune too. When the
+// runtime has no sandbox for the ref there is nothing to remove, but the entry
+// still names a sandbox the user has asked to be rid of, so clearing it there
+// leaves no stale record of a name nothing holds -- the same prune Remove does
+// after the runtime call, reached from the one path where there was no runtime
+// call to do it.
+func (c *Config) Forget() {
 	ForgetSandbox(c.VMName)
 	ForgetSlugClaim(c.VMName)
-	return err
 }
 
 // Exec hands the terminal to a command inside the sandbox. It does not return

--- a/script/smoke.sh
+++ b/script/smoke.sh
@@ -809,6 +809,11 @@ echo "== logs =="
 # the ref resolves to, and the flags the line carried. The stub logs its argv
 # like every other verb, so this asserts what reached the runtime. --tail -1 is
 # the default brig passes, which both runtimes read as "all".
+#
+# A sandbox has to exist for there to be a log to read: logs asks the runtime's
+# list first and is a not-found otherwise, which the case below the lifecycle
+# section pins. The stop above left none, so boot one here.
+"$WORK/brig" run claude -d > /dev/null 2>&1
 : > "$STUB_LOG"
 "$WORK/brig" logs claude > /dev/null 2>&1
 grep -q '^argv: logs --tail -1 brig-claude-code' "$STUB_LOG" \
@@ -910,6 +915,26 @@ grep -q '^argv: rm brig-claude-code' "$STUB_LOG" \
 "$WORK/brig" rm --all > /dev/null 2>&1
 grep -q '^argv: rm brig-claude-code' "$STUB_LOG" \
   && ok "rm --all removes brig sandboxes" || bad "rm --all removes brig sandboxes"
+
+echo "== rm and logs with no sandbox =="
+# Nothing holds the name now, so rm and logs name a sandbox that resolves to
+# nothing: exit 3, the code the table gives a name that is not there, and a
+# message naming the ref rather than the runtime's own "instance not found".
+# They used to hand that error back and exit 1.
+out="$("$WORK/brig" rm claude 2>&1)"; rc=$?
+[ "$rc" = 3 ] && ok "rm of a missing sandbox exits 3" \
+  || bad "rm of a missing sandbox exits 3 -- got $rc: $out"
+case "$out" in
+  *"no sandbox for claude"*) ok "rm names the ref, not the sandbox" ;;
+  *) bad "rm names the ref -- got: $out" ;;
+esac
+out="$("$WORK/brig" logs claude 2>&1)"; rc=$?
+[ "$rc" = 3 ] && ok "logs of a missing sandbox exits 3" \
+  || bad "logs of a missing sandbox exits 3 -- got $rc: $out"
+case "$out" in
+  *"no sandbox for claude"*) ok "logs names the ref, not the sandbox" ;;
+  *) bad "logs names the ref -- got: $out" ;;
+esac
 
 echo "== remembered workspace =="
 # A session created with -w used to be restarted by the next verb that left the


### PR DESCRIPTION
`brig rm claude` and `brig logs claude` with no sandbox for `claude` handed back the runtime's own error and exited 1. README documents 3 as "no such profile or sandbox", which is this case.

Both verbs now ask the runtime's `List` for the sandbox name before handing over. Absent:

```
brig: no sandbox for claude. `brig ls` lists them
```

exit 3, naming the ref typed rather than the sandbox name. Present: `Remove` and `Logs` as before. A `List` that itself fails comes back as is, exit 4, not folded into not-found; the two are different facts and the exit table keeps them apart.

`stop` is deliberately untouched and still exits 0 on a missing sandbox: that is the end state it asks for. A comment at the dispatch says so, and a test pins it.

`rm` on the not-found path still prunes the index entry, since it names a sandbox the user asked to be rid of. `Forget` is pulled out of `Remove` so both paths share it.

Stacked on #137 because it touches `logs.go`; GitHub retargets to `main` when that merges.

Checked on a build of this branch: `rm claude`, `logs claude` and `rm claude@refactor` exit 3 with the message above; `stop claude` exits 0. Tested with `go vet ./...`, `go test -race ./...` and `./script/smoke.sh`.

Fixes: #136