### PR TITLE
feat(cli): add --json to the read verbs

### DIFF
--- a/cmd/brig/doctor.go
+++ b/cmd/brig/doctor.go
@@ -79,6 +79,11 @@ func doctorCmd(out io.Writer, args []string) error {
 	if err != nil {
 		return err
 	}
+	// The global position sets the same bool, so `brig --json doctor` and
+	// `brig doctor --json` are one request and the report is unchanged either
+	// way. #7 made --json a global flag; doctor keeps its own for the release the
+	// two spellings overlap. See globalJSON.
+	jsonOut = jsonOut || globalJSON
 
 	// Reloaded here rather than reusing the load main already did, so this
 	// command holds the problems that load reported -- one line per bad file --
@@ -112,9 +117,9 @@ func doctorCmd(out io.Writer, args []string) error {
 }
 
 // parseDoctorArgs reads doctor's own flag and its one optional operand. --json
-// is a flag of the verb, the way `brig policy show --json` is, rather than a
-// global left of the verb: an unknown token in the global position is a usage
-// error today, and moving --json there is another issue's job.
+// is a flag of the verb here, and #7 also made it a global left of the verb;
+// doctorCmd ORs the two so both spellings reach the same report. This parser
+// keeps reading the local one for the release the two overlap.
 func parseDoctorArgs(args []string) (jsonOut bool, agent string, err error) {
 	for _, a := range args {
 		switch {

--- a/cmd/brig/exit.go
+++ b/cmd/brig/exit.go
@@ -28,12 +28,29 @@ const (
 	exitCredentials = 6
 )
 
+// agentExit carries the agent's own exit status up to main, so brig returns
+// exactly what the agent returned under --json. It is not a failure of brig's:
+// the Run object has already been printed and the agent's output has already
+// gone to the inherited streams, so main neither prints nor decorates it -- it
+// reads the code off here and exits with it. Error is empty for that reason;
+// nothing prints it.
+type agentExit struct{ code int }
+
+func (e *agentExit) Error() string { return "" }
+
 // exitCode reads the exit status for a finished run out of its error. It reads
 // the cause rather than the message, so a wrapped error keeps its class the
 // whole way up the stack, and the order is most specific first.
 func exitCode(err error) int {
 	if err == nil {
 		return exitOK
+	}
+	// The agent's own status, when the agent ran under --json. Read first: it is
+	// the one error whose code is not a class of brig's but a number brig is
+	// passing through unchanged.
+	var ae *agentExit
+	if errors.As(err, &ae) {
+		return ae.code
 	}
 	var ue *usageError
 	if errors.As(err, &ue) {

--- a/cmd/brig/hygiene_test.go
+++ b/cmd/brig/hygiene_test.go
@@ -84,7 +84,7 @@ func TestLsAndRemoveAllRefuseArguments(t *testing.T) {
 		fn   func([]string) error
 		args []string
 	}{
-		{"ls", func(args []string) error { return listSandboxes(args, false) }, []string{"claude"}},
+		{"ls", func(args []string) error { return listSandboxes(args, false, false) }, []string{"claude"}},
 		{"rm --all", func(args []string) error { return removeAll("brig rm --all", args) },
 			[]string{"--dry-run"}},
 		{"reset", func(args []string) error { return removeAll("brig reset", args) },
@@ -368,10 +368,19 @@ func TestBrigFlagsOverlapWithShippedAgentsOnlyWhereKnown(t *testing.T) {
 // No agent is named yet at that point, so nothing else can claim it.
 //
 // The tokens below are not brig flags. Adding one as a global flag means
-// removing it here.
+// removing it here. --json is now one -- #7 added it -- so it is accepted where
+// it used to be refused; the refusal is asserted on tokens that are still not
+// brig's.
 func TestGlobalPositionRefusesAnUnknownToken(t *testing.T) {
+	// --json is a global flag now, so the global position accepts it: it is read,
+	// and the verb line comes back untouched for the dispatch to act on.
+	if _, rest, err := parseGlobal([]string{"--json", "ls"}); err != nil {
+		t.Errorf("parseGlobal rejected --json, which is a global flag now: %v", err)
+	} else if len(rest) != 1 || rest[0] != "ls" {
+		t.Errorf("parseGlobal(--json ls) returned verb line %q, want [ls]", rest)
+	}
+
 	for _, args := range [][]string{
-		{"--json", "run", "claude"},
 		{"--nope", "ls"},
 		{"-y", "rm", "claude"},
 	} {

--- a/cmd/brig/jsonout.go
+++ b/cmd/brig/jsonout.go
@@ -33,6 +33,21 @@ import (
 // bumps.
 const jsonAPIVersion = policy.APIVersion
 
+// Two JSON shapes, and the rule that decides which a verb prints:
+//
+//   - A LIST or REPORT verb prints the envelope: jsonDocument wraps the payload
+//     under data, so `ls`, `info`, `agent ls`, `secret ls` and `doctor` all read
+//     the same {apiVersion, kind, data} whatever they list. A list goes straight
+//     under data (there is no items wrapper); a report puts its own object there.
+//   - A DOCUMENT verb prints the payload bare, no envelope: `agent show`,
+//     `agent export`, `agent new` and `policy show` each render one profile or
+//     policy meant to be saved to a file and read back by brig, so wrapping it
+//     would make the file something brig no longer imports. Those four keep the
+//     bare shape they had; #7 does not touch them.
+//
+// The dividing line is what the output is FOR: a thing to read or pipe takes the
+// envelope, a thing to write to disk stays bare.
+
 // jsonDocument wraps a command's payload with the apiVersion that pins its
 // shape and the kind that names it, both beside the payload rather than folded
 // into it, so a consumer reads the two envelope fields the same way whatever

--- a/cmd/brig/jsonout.go
+++ b/cmd/brig/jsonout.go
@@ -65,3 +65,16 @@ func writeJSONDocument(w io.Writer, kind string, data any) error {
 	enc.SetIndent("", "  ")
 	return enc.Encode(jsonDocument{APIVersion: jsonAPIVersion, Kind: kind, Data: data})
 }
+
+// writeJSONLine encodes one payload as a jsonDocument on a single line, the
+// deliberate opposite of writeJSONDocument's indentation.
+//
+// #110's Run object is printed to stdout after the agent's own inherited output,
+// so a script's rule for finding it is "the last line of stdout is brig's". An
+// indented object spanning many lines would break that rule, and there is no
+// person reading a run's stdout for whom the indentation was ever the point --
+// the agent already wrote there. Same envelope, same fields; only the framing
+// differs, so a consumer parses it exactly as it parses the read verbs.
+func writeJSONLine(w io.Writer, kind string, data any) error {
+	return json.NewEncoder(w).Encode(jsonDocument{APIVersion: jsonAPIVersion, Kind: kind, Data: data})
+}

--- a/cmd/brig/jsonout_test.go
+++ b/cmd/brig/jsonout_test.go
@@ -262,11 +262,12 @@ func TestJSONPositionsAndRefusals(t *testing.T) {
 
 	// Refused, both positions, on the verbs with no JSON form. Exit 2, and the
 	// message names a verb that does have one so the reader can move the flag.
+	// run and sh are NOT here since #110: --json runs the agent as a child and
+	// prints a Run object, so it is accepted rather than refused -- see
+	// run_json_test.go.
 	refuse := [][]string{
 		{"--json", "stop", "claude"}, {"stop", "claude", "--json"},
 		{"--json", "rm", "claude"}, {"rm", "claude", "--json"},
-		{"--json", "run", "claude"}, {"run", "claude", "--json"},
-		{"--json", "sh", "claude"}, {"sh", "claude", "--json"},
 	}
 	for _, args := range refuse {
 		scratchHost(t)

--- a/cmd/brig/jsonout_test.go
+++ b/cmd/brig/jsonout_test.go
@@ -1,0 +1,319 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/brig-sh/brig/internal/profile"
+	"github.com/brig-sh/brig/internal/secret"
+)
+
+// Every --json shape is the shared envelope: it parses, and it carries the
+// apiVersion that pins it and the kind that names it. doctor already asserts
+// this for its own; these are the four #7 adds.
+
+// ls is SandboxList: the runtime once beside the list, and each sandbox with the
+// ref split into agent and label. A sandbox with no ref is still in the list,
+// ref-less, with its sandbox name -- the way the table shows it exists too.
+func TestLsJSONShape(t *testing.T) {
+	rows := []sandboxRow{
+		{ref: "claude-code@refactor", name: "brig-claude-code-refactor", state: "stopped", workspace: "/ws/refactor"},
+		{ref: "", name: "brig-mystery", state: "running", workspace: ""},
+	}
+
+	var buf bytes.Buffer
+	if err := writeJSONDocument(&buf, "SandboxList", sandboxListData(rows, doctorRuntime{bin: "/opt/hull"})); err != nil {
+		t.Fatal(err)
+	}
+
+	var doc struct {
+		APIVersion string          `json:"apiVersion"`
+		Kind       string          `json:"kind"`
+		Data       sandboxListJSON `json:"data"`
+	}
+	if err := json.Unmarshal(buf.Bytes(), &doc); err != nil {
+		t.Fatalf("ls --json did not parse: %v\n%s", err, buf.String())
+	}
+	if doc.APIVersion != jsonAPIVersion || doc.Kind != "SandboxList" {
+		t.Errorf("envelope is %q/%q, want %q/SandboxList", doc.APIVersion, doc.Kind, jsonAPIVersion)
+	}
+	if !doc.Data.Runtime.Available || doc.Data.Runtime.Kind != "hull" || doc.Data.Runtime.Bin != "/opt/hull" {
+		t.Errorf("the runtime is not named beside the list: %+v", doc.Data.Runtime)
+	}
+	if len(doc.Data.Sandboxes) != 2 {
+		t.Fatalf("the list has %d sandboxes, want 2: %+v", len(doc.Data.Sandboxes), doc.Data.Sandboxes)
+	}
+	first := doc.Data.Sandboxes[0]
+	if first.Ref != "claude-code@refactor" || first.Agent != "claude-code" || first.Label != "refactor" {
+		t.Errorf("the ref is not split into agent and label: %+v", first)
+	}
+	if first.Sandbox == "" || first.State == "" || first.Workspace == "" {
+		t.Errorf("a listed sandbox is missing a field: %+v", first)
+	}
+	// The ref-less sandbox is present, named, and carries no invented ref.
+	mystery := doc.Data.Sandboxes[1]
+	if mystery.Ref != "" || mystery.Agent != "" || mystery.Sandbox != "brig-mystery" {
+		t.Errorf("a sandbox with no ref is not listed the way the table shows it: %+v", mystery)
+	}
+
+	// No runtime is a complete document too: an empty list, the runtime marked
+	// unavailable, no kind or bin claimed.
+	empty := sandboxListData(nil, nil)
+	if empty.Runtime.Available || empty.Runtime.Kind != "" {
+		t.Errorf("no runtime is not marked unavailable: %+v", empty.Runtime)
+	}
+	if empty.Sandboxes == nil {
+		t.Error("an empty list marshals to null rather than []")
+	}
+}
+
+// agent ls is AgentList: each agent with its aliases, kind, image, origin, and
+// -- for a file-backed one -- the file behind it.
+func TestAgentLsJSONShape(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("BRIG_PROFILE_DIR", dir)
+	own := []byte("name: mine\nimage: docker.io/me/mine:latest\n" +
+		"guestHome: /home/mine\nbinary: m\nmem: 1\ncpus: 1\n")
+	if err := os.WriteFile(filepath.Join(dir, "mine.yaml"), own, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := profile.Load(profile.Dir()); err != nil {
+		t.Fatal(err)
+	}
+
+	out, err := captureStdout(t, func() error { return agentCmd([]string{"ls", "--json"}) })
+	if err != nil {
+		t.Fatal(err)
+	}
+	var doc struct {
+		APIVersion string      `json:"apiVersion"`
+		Kind       string      `json:"kind"`
+		Data       []agentJSON `json:"data"`
+	}
+	if err := json.Unmarshal([]byte(out), &doc); err != nil {
+		t.Fatalf("agent ls --json did not parse: %v\n%s", err, out)
+	}
+	if doc.APIVersion != jsonAPIVersion || doc.Kind != "AgentList" {
+		t.Errorf("envelope is %q/%q, want %q/AgentList", doc.APIVersion, doc.Kind, jsonAPIVersion)
+	}
+
+	byName := map[string]agentJSON{}
+	for _, a := range doc.Data {
+		byName[a.Name] = a
+	}
+	// A built-in, addressed by its alias: brig ships it, no file backs it, and it
+	// carries its kind and image.
+	cc, ok := byName["claude-code"]
+	if !ok {
+		t.Fatalf("claude-code is not in the listing: %+v", doc.Data)
+	}
+	if !cc.BuiltIn || cc.File != "" {
+		t.Errorf("a built-in names a file or is not marked built in: %+v", cc)
+	}
+	if cc.Kind == "" || cc.Image == "" {
+		t.Errorf("a listed agent is missing its kind or image: %+v", cc)
+	}
+	if !containsStr(cc.Aliases, "claude") {
+		t.Errorf("claude-code does not list its alias: %+v", cc.Aliases)
+	}
+	// A profile of your own: file-backed, so it names its file and is not built
+	// in.
+	mine, ok := byName["mine"]
+	if !ok {
+		t.Fatalf("the file-backed profile is not in the listing: %+v", doc.Data)
+	}
+	if mine.BuiltIn || mine.File == "" {
+		t.Errorf("a file-backed profile is marked built in or names no file: %+v", mine)
+	}
+}
+
+// secret ls is SecretList: names, dates and provenance -- and never a value,
+// which List does not decrypt and neither does the JSON. This is the assertion
+// #7 calls a defect if it fails.
+func TestSecretLsJSONShape(t *testing.T) {
+	f := newFake(t)
+	const planted = "super-secret-token-value-99"
+	f.seedWithProvenance("gh-token", planted, secret.Provenance{From: "keychain:GitHub"})
+	f.seed("hand-made", planted) // no provenance, the dash case
+
+	var buf bytes.Buffer
+	if err := secretCmd(&buf, []string{"ls", "--json"}); err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(buf.String(), planted) {
+		t.Fatalf("secret ls --json leaked a value:\n%s", buf.String())
+	}
+
+	var doc struct {
+		APIVersion string       `json:"apiVersion"`
+		Kind       string       `json:"kind"`
+		Data       []secretJSON `json:"data"`
+	}
+	if err := json.Unmarshal(buf.Bytes(), &doc); err != nil {
+		t.Fatalf("secret ls --json did not parse: %v\n%s", err, buf.String())
+	}
+	if doc.APIVersion != jsonAPIVersion || doc.Kind != "SecretList" {
+		t.Errorf("envelope is %q/%q, want %q/SecretList", doc.APIVersion, doc.Kind, jsonAPIVersion)
+	}
+	if len(doc.Data) != 2 {
+		t.Fatalf("the list has %d secrets, want 2: %+v", len(doc.Data), doc.Data)
+	}
+	byName := map[string]secretJSON{}
+	for _, s := range doc.Data {
+		byName[s.Name] = s
+	}
+	if got := byName["gh-token"]; got.Provenance != "keychain:GitHub" || got.Modified == "" {
+		t.Errorf("gh-token lost its provenance or date: %+v", got)
+	}
+	// A hand-created secret has no provenance, and the field is absent rather
+	// than an invented word -- the same rule the text FROM column follows.
+	if got := byName["hand-made"]; got.Provenance != "" {
+		t.Errorf("a hand-created secret invented a provenance: %+v", got)
+	}
+
+	// An empty store is data: [] and exit 0, not the prose hint.
+	g := newFake(t)
+	_ = g
+	var empty bytes.Buffer
+	if err := secretCmd(&empty, []string{"ls", "--json"}); err != nil {
+		t.Fatal(err)
+	}
+	var emptyDoc struct {
+		Data []secretJSON `json:"data"`
+	}
+	if err := json.Unmarshal(empty.Bytes(), &emptyDoc); err != nil {
+		t.Fatalf("empty secret ls --json did not parse: %v\n%s", err, empty.String())
+	}
+	if len(emptyDoc.Data) != 0 {
+		t.Errorf("an empty store is not an empty list: %+v", emptyDoc.Data)
+	}
+	if strings.Contains(empty.String(), "no secrets yet") {
+		t.Errorf("--json printed the prose hint:\n%s", empty.String())
+	}
+}
+
+// info is Info, driven end to end through run() with no runtime on PATH: it
+// exits 0 -- ErrNoRuntime is swallowed for info -- and prints a complete,
+// parseable document with the runtime marked unavailable. Both spellings of the
+// flag reach it.
+func TestInfoJSONThroughRun(t *testing.T) {
+	for _, args := range [][]string{
+		{"--json", "info", "claude"}, // the global position, canonical
+		{"info", "claude", "--json"}, // and the local one people type
+	} {
+		scratchHost(t)
+		out, err := captureStdout(t, func() error { return run(args) })
+		if err != nil {
+			t.Fatalf("brig %s: %v", strings.Join(args, " "), err)
+		}
+		var doc struct {
+			APIVersion string `json:"apiVersion"`
+			Kind       string `json:"kind"`
+			Data       struct {
+				Profile string `json:"profile"`
+				Runtime struct {
+					Available bool `json:"available"`
+				} `json:"runtime"`
+			} `json:"data"`
+		}
+		if err := json.Unmarshal([]byte(out), &doc); err != nil {
+			t.Fatalf("brig %s did not print parseable JSON: %v\n%s", strings.Join(args, " "), err, out)
+		}
+		if doc.APIVersion != jsonAPIVersion || doc.Kind != "Info" {
+			t.Errorf("brig %s envelope is %q/%q, want %q/Info", strings.Join(args, " "), doc.APIVersion, doc.Kind, jsonAPIVersion)
+		}
+		if doc.Data.Profile == "" {
+			t.Errorf("brig %s printed an incomplete object:\n%s", strings.Join(args, " "), out)
+		}
+		if doc.Data.Runtime.Available {
+			t.Errorf("brig %s marked the runtime available with none on PATH", strings.Join(args, " "))
+		}
+	}
+}
+
+// The read verbs accept --json in both positions; the verbs with no JSON form
+// refuse it in both, with a usage error (exit 2) that names the verbs that do.
+func TestJSONPositionsAndRefusals(t *testing.T) {
+	// Accepted, global and local. secret ls needs a store, so it gets a fake one;
+	// the rest answer on a bare host.
+	accept := [][]string{
+		{"--json", "ls"}, {"ls", "--json"},
+		{"--json", "agent", "ls"}, {"agent", "ls", "--json"},
+		{"--json", "info", "claude"}, {"info", "claude", "--json"},
+	}
+	for _, args := range accept {
+		scratchHost(t)
+		if _, err := captureStdout(t, func() error { return run(args) }); err != nil {
+			t.Errorf("brig %s was refused: %v", strings.Join(args, " "), err)
+		}
+	}
+	// secret ls, both positions, against a fake store.
+	for _, args := range [][]string{{"--json", "secret", "ls"}, {"secret", "ls", "--json"}} {
+		scratchHost(t)
+		newFake(t)
+		if _, err := captureStdout(t, func() error { return run(args) }); err != nil {
+			t.Errorf("brig %s was refused: %v", strings.Join(args, " "), err)
+		}
+	}
+
+	// Refused, both positions, on the verbs with no JSON form. Exit 2, and the
+	// message names a verb that does have one so the reader can move the flag.
+	refuse := [][]string{
+		{"--json", "stop", "claude"}, {"stop", "claude", "--json"},
+		{"--json", "rm", "claude"}, {"rm", "claude", "--json"},
+		{"--json", "run", "claude"}, {"run", "claude", "--json"},
+		{"--json", "sh", "claude"}, {"sh", "claude", "--json"},
+	}
+	for _, args := range refuse {
+		scratchHost(t)
+		_, err := captureStdout(t, func() error { return run(args) })
+		if err == nil {
+			t.Errorf("brig %s was accepted", strings.Join(args, " "))
+			continue
+		}
+		if code := exitCode(err); code != exitUsage {
+			t.Errorf("brig %s exits %d, want %d: %v", strings.Join(args, " "), code, exitUsage, err)
+		}
+		if !strings.Contains(err.Error(), "ls") {
+			t.Errorf("brig %s does not name a verb that takes --json: %v", strings.Join(args, " "), err)
+		}
+	}
+}
+
+// -q and --json together, and --verbose and --json together, are both fine: the
+// notices go to stderr and the JSON to stdout, so a script gets clean JSON on
+// stdout whichever of the other two it also asked for.
+func TestJSONWithQuietAndVerbose(t *testing.T) {
+	for _, args := range [][]string{
+		{"-q", "--json", "ls"},
+		{"--verbose", "--json", "ls"},
+	} {
+		scratchHost(t)
+		out, err := captureStdout(t, func() error { return run(args) })
+		if err != nil {
+			t.Fatalf("brig %s: %v", strings.Join(args, " "), err)
+		}
+		var doc struct {
+			Kind string `json:"kind"`
+		}
+		if err := json.Unmarshal([]byte(out), &doc); err != nil {
+			t.Fatalf("brig %s did not put clean JSON on stdout: %v\n%s", strings.Join(args, " "), err, out)
+		}
+		if doc.Kind != "SandboxList" {
+			t.Errorf("brig %s stdout is not the listing: %q", strings.Join(args, " "), out)
+		}
+	}
+}
+
+func containsStr(list []string, want string) bool {
+	for _, s := range list {
+		if s == want {
+			return true
+		}
+	}
+	return false
+}

--- a/cmd/brig/listing_test.go
+++ b/cmd/brig/listing_test.go
@@ -90,11 +90,11 @@ func TestListingQuietPrintsRefsOnly(t *testing.T) {
 	// -q is a flag on ls, and the only one. Anything else is still refused.
 	scratchHost(t)
 	for _, args := range [][]string{{"-q"}, {"--quiet"}} {
-		if _, err := captureStdout(t, func() error { return listSandboxes(args, false) }); err != nil {
+		if _, err := captureStdout(t, func() error { return listSandboxes(args, false, false) }); err != nil {
 			t.Errorf("brig ls %s: %v", args[0], err)
 		}
 	}
-	if _, err := captureStdout(t, func() error { return listSandboxes([]string{"-x"}, false) }); err == nil {
+	if _, err := captureStdout(t, func() error { return listSandboxes([]string{"-x"}, false, false) }); err == nil {
 		t.Error("brig ls -x was accepted")
 	}
 }
@@ -126,6 +126,20 @@ func TestListingRefsRoundTripThroughEveryVerb(t *testing.T) {
 	refs := strings.Fields(buf.String())
 	if len(refs) < 2 {
 		t.Fatalf("ls -q printed %d refs, want the sessions in the index: %q", len(refs), refs)
+	}
+
+	// The same promise holds for `ls --json`: every ref it prints is a ref, and
+	// it prints exactly the refs -q does. If the two disagreed, a script reading
+	// the JSON would get an operand no verb takes -- the fault this test is about,
+	// one shape further out.
+	jsonRefs := []string{}
+	for _, s := range sandboxListData(rows, nil).Sandboxes {
+		if s.Ref != "" {
+			jsonRefs = append(jsonRefs, s.Ref)
+		}
+	}
+	if strings.Join(jsonRefs, " ") != strings.Join(refs, " ") {
+		t.Fatalf("ls --json prints refs %q, ls -q prints %q", jsonRefs, refs)
 	}
 
 	// Every verb that takes a session, in the spelling the help text teaches

--- a/cmd/brig/main.go
+++ b/cmd/brig/main.go
@@ -19,6 +19,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"syscall"
 
 	"github.com/brig-sh/brig/internal/creds"
 	"github.com/brig-sh/brig/internal/profile"
@@ -85,6 +86,9 @@ global flags (left of the command, as in: brig -q run claude):
       --json             machine-readable output, for the read verbs: ls, info,
                          agent ls, secret ls and doctor. Also accepted after the
                          verb (brig ls --json). Every other verb refuses it
+      --json (with run)  run the agent as a child and, after it exits, print one
+                         JSON line with its exit status -- so a script can tell
+                         "brig refused" from "the agent failed"
 Within one apiVersion the JSON only ever gains fields, never renames or drops
 one, and no field carries a credential value -- so a script written against it
 keeps parsing, and a machine-readable dump stays a place a secret cannot leak.
@@ -136,16 +140,55 @@ settings (BRIG_<AGENT>_<KEY> wins over BRIG_<KEY>; see the README for all):
 `
 
 func main() {
-	if err := run(os.Args[1:]); err != nil {
-		fmt.Fprintln(os.Stderr, "brig: "+err.Error())
-		// The exit status is a stable, documented set: a script can tell "you
-		// asked for the wrong thing" from "it ran and failed" from "the sandbox
-		// could not be verified" without parsing the message. exitCode owns the
-		// mapping; the README documents it. A run refused for any reason still
-		// exits non-zero, so a stop or a boot that removed or started nothing
-		// never reads as success.
-		os.Exit(exitCode(err))
+	err := run(os.Args[1:])
+	if err == nil {
+		return
 	}
+	// The agent ran under --json: its own exit status is brig's, its output has
+	// already gone to the inherited streams, and runAgent has already printed the
+	// one-line Run object. brig adds nothing -- no "brig:" line, no second object
+	// -- it just returns what the agent returned.
+	var ae *agentExit
+	if errors.As(err, &ae) {
+		os.Exit(ae.code)
+	}
+	fmt.Fprintln(os.Stderr, "brig: "+err.Error())
+	// The exit status is a stable, documented set: a script can tell "you
+	// asked for the wrong thing" from "it ran and failed" from "the sandbox
+	// could not be verified" without parsing the message. exitCode owns the
+	// mapping; the README documents it. A run refused for any reason still
+	// exits non-zero, so a stop or a boot that removed or started nothing
+	// never reads as success.
+	os.Exit(exitCode(err))
+}
+
+// run is the entry point dispatch is wrapped in, so the --json run/sh path has
+// one place to print its Run object when brig refuses.
+//
+// A refusal -- an unknown agent, a boot that would not come up -- returns from
+// deep inside dispatch as an ordinary error, at a depth that knows nothing about
+// --json. The success and detach paths print their own object, where the exit
+// status and the sandbox name are known; this catches the other half, so every
+// --json run ends in exactly one Run line whether the agent started or not. The
+// object carries stage "brig" and the reason, and brig's exit is the class the
+// error maps to -- the object is what tells "brig refused" from "the agent
+// exited non-zero", not the number.
+//
+// jsonRun is nil unless this invocation is a --json run or sh, so an ordinary
+// command's errors are untouched.
+func run(args []string) error {
+	jsonRun = nil
+	err := dispatch(args)
+	if err == nil || jsonRun == nil {
+		return err
+	}
+	var ae *agentExit
+	if errors.As(err, &ae) {
+		// The agent ran; its object is already printed. Leave it to main.
+		return err
+	}
+	_ = writeRunObject("brig", exitCode(err), err.Error(), "")
+	return err
 }
 
 // usageError is a command that was typed wrong: an unknown flag, a stray
@@ -169,7 +212,7 @@ func (e *notFoundError) Error() string { return e.msg }
 // notFoundf builds a notFoundError the way fmt.Errorf builds an ordinary one.
 func notFoundf(format string, a ...any) error { return &notFoundError{fmt.Sprintf(format, a...)} }
 
-func run(args []string) error {
+func dispatch(args []string) error {
 	// The global position first, so a flag written left of the verb is named
 	// rather than read as a command.
 	g, verbLine, err := parseGlobal(args)
@@ -362,17 +405,37 @@ func run(args []string) error {
 		verb, rest = "run", verbLine
 	}
 
+	// The Run object has to be there for a refusal that happens inside parse
+	// too -- a ref that will not parse is the common one -- so the context is
+	// made before parse, off the token the reader typed, and refreshed below
+	// with the resolved ref once parse has one. Without this a typo in the ref
+	// left stdout empty under --json, and a script's rule that the last line
+	// of stdout is brig's held for every refusal but that one.
+	if verb == "run" || verb == "sh" {
+		if wantJSON, operand := peekRunLine(rest); globalJSON || wantJSON {
+			jsonRun = &jsonRunContext{ref: operand}
+		}
+	}
 	opts, profileName, tail, err := parse(verb, rest)
 	if err != nil {
 		return err
 	}
-	// --json on a run-line verb. info answers it; every other verb here has no
-	// JSON form and refuses it by name. The global position was already refused
-	// above for those verbs; this catches `brig run claude --json`, where --json
-	// is brig's own token rather than the agent's, so it is named rather than
-	// forwarded. Both spellings fold into one decision.
+	// --json on a run-line verb. info and env answer it with a report; run and
+	// sh answer it by running the agent as a child and printing a Run object
+	// after it (see #110 and runAgent); every other verb here has no JSON form
+	// and refuses it by name. The global position was already refused above for
+	// the verbs that have none; this catches `brig run claude --json`, where
+	// --json is brig's own token rather than the agent's, so it is named rather
+	// than forwarded. Both spellings fold into one decision.
 	wantJSON := globalJSON || opts.json
-	if wantJSON && verb != "info" && verb != "env" {
+	switch {
+	case !wantJSON:
+	case verb == "info" || verb == "env":
+	case verb == "run" || verb == "sh":
+		// The state main needs to print the Run object once dispatch returns. The
+		// sandbox name is not known until Load below; the ref is what was typed.
+		jsonRun = &jsonRunContext{ref: refDisplay(profileName, opts)}
+	default:
 		return jsonUnsupportedf(verb)
 	}
 	// Both at once asks for two contradictory things, and either winner would
@@ -417,7 +480,7 @@ func run(args []string) error {
 			"%s explains how to build one", t.Name, verb, t.Name, profile.BringYourOwnImageDoc)
 	}
 
-	rt, err := runtime.DetectFor(runtime.Preference{Bin: t.RuntimeBin})
+	rt, err := detectRuntimeFor(runtime.Preference{Bin: t.RuntimeBin})
 	if err != nil {
 		// brig info is the report worth giving when the runtime is the thing
 		// that is broken: only one of its lines comes from the runtime, and the
@@ -451,6 +514,12 @@ func run(args []string) error {
 	// sandbox is refused later, at EnsureRunning; this only names the directory.
 	if cfg.RawName != "" && cfg.RawName != cfg.Slug {
 		warnf("session %q uses %s (sandbox %s)", cfg.RawName, cfg.Workspace, cfg.VMName)
+	}
+	// The sandbox name for the Run object, now that Load has resolved it. A
+	// refusal before this point (an unknown agent) prints the object with the
+	// name still empty, which is honest: no sandbox was named yet.
+	if jsonRun != nil {
+		jsonRun.sandbox = cfg.VMName
 	}
 
 	// Stopping and removing need nothing but the instance name, and are
@@ -521,6 +590,16 @@ func run(args []string) error {
 		if err := cfg.EnsureRunning(set); err != nil {
 			return err
 		}
+		// Under --json, down the child path so brig survives the shell and reports
+		// its exit status on a Run line, the same handover an agent gets. Only sh
+		// reaches here with jsonRun set -- shell is refused above.
+		if jsonRun != nil {
+			code, err := cfg.ShellAttached(set, tail)
+			if err != nil {
+				return err
+			}
+			return emitAgentRun(code)
+		}
 		return cfg.Shell(set, tail)
 	case "exec":
 		if len(tail) == 0 {
@@ -531,7 +610,7 @@ func run(args []string) error {
 		}
 		return cfg.Exec(set, tail, isTerminal())
 	}
-	return runAgent(cfg, set, t, tail, opts.detach)
+	return runAgent(cfg, set, t, tail, opts.detach, jsonRun != nil)
 }
 
 // showsEnvelope reports whether this invocation prints the execution envelope
@@ -549,7 +628,7 @@ func showsEnvelope(verb string, v wrap.Verbosity) bool {
 	return false
 }
 
-func runAgent(cfg *wrap.Config, set creds.Set, t profile.Profile, tail []string, detach bool) error {
+func runAgent(cfg *wrap.Config, set creds.Set, t profile.Profile, tail []string, detach, wantJSON bool) error {
 	// A windowed agent owns its own console, so there is nothing to pass
 	// through and nothing to exec into: starting it IS the command.
 	if t.IsGUI() && len(tail) > 0 {
@@ -559,21 +638,49 @@ func runAgent(cfg *wrap.Config, set creds.Set, t profile.Profile, tail []string,
 	if err := cfg.EnsureRunning(set); err != nil {
 		return err
 	}
+	// Each branch below has a --json form: the object stands in for the text it
+	// would otherwise print, because a script asked for one machine-readable line
+	// and a bare name or a warning beside it would be the noise --json exists to
+	// remove. stage says which branch spoke -- gui, detached, or the agent having
+	// run -- so the reader need not infer it from the exit status.
 	switch {
 	case t.IsGUI():
+		// The window is up; there is nothing to attach to.
+		if wantJSON {
+			_ = writeRunObject("gui", exitOK, "", "")
+			return nil
+		}
 		warnf("sandbox %s is running; the %s window should be visible.", cfg.VMName, t.GUITitle)
 		return nil
 	case detach:
 		// The sandbox is up and will stay up; print the name so a script can
 		// exec into it.
+		if wantJSON {
+			_ = writeRunObject("detached", exitOK, "", "")
+			return nil
+		}
 		fmt.Println(cfg.VMName)
 		return nil
 	case t.IsShell():
 		// The "agent" is the guest shell itself, so a bare run is a login
 		// shell and trailing words are one command.
+		if wantJSON {
+			code, err := cfg.ShellAttached(set, tail)
+			if err != nil {
+				return err
+			}
+			return emitAgentRun(code)
+		}
 		return cfg.Shell(set, tail)
 	}
 	argv := append([]string{t.Binary}, agentArgs(cfg, t, tail)...)
+	if wantJSON {
+		code, err := cfg.ExecAttached(set, argv, isTerminal())
+		if err != nil {
+			return err
+		}
+		return emitAgentRun(code)
+	}
 	return cfg.Exec(set, argv, isTerminal())
 }
 
@@ -2697,13 +2804,14 @@ var verbosity = wrap.Normal
 var globalJSON bool
 
 // verbTakesGlobalJSON reports whether the verb in the global position has a
-// --json form to ask for. The five read verbs do; agent and secret only in
-// their ls subcommand, which is the one that lists. Everything else -- run, sh,
-// stop, rm, and the verbs that manage rather than list -- has none, so --json
-// left of it is a usage error rather than a flag dropped on the floor.
+// --json form to ask for. The five read verbs do; run and sh do since #110,
+// where --json runs the agent as a child and prints its outcome; agent and
+// secret only in their ls subcommand, which is the one that lists. Everything
+// else -- stop, rm, and the verbs that manage rather than list -- has none, so
+// --json left of it is a usage error rather than a flag dropped on the floor.
 func verbTakesGlobalJSON(verb string, rest []string) bool {
 	switch verb {
-	case "ls", "info", "env", "doctor":
+	case "ls", "info", "env", "doctor", "run", "sh":
 		return true
 	case "agent", "secret":
 		return len(rest) > 0 && rest[0] == "ls"
@@ -2720,7 +2828,139 @@ func verbTakesGlobalJSON(verb string, rest []string) bool {
 func jsonUnsupportedf(verb string) error {
 	return usagef("`brig %s` has no --json output. --json is for the read verbs: "+
 		"ls, info, agent ls, secret ls, doctor (env takes it too, but env is "+
-		"deprecated; prefer info)", verb)
+		"deprecated; prefer info), and for run and sh", verb)
+}
+
+// jsonRun is the state the --json run/sh path needs to print its one-line Run
+// object. It is package state for the same reason globalJSON is: the object is
+// printed at the top of the call chain, and the values in it -- the ref, the
+// sandbox name -- become known at different depths of dispatch. nil means this
+// invocation is not a --json run, so run() prints nothing on the way out.
+var jsonRun *jsonRunContext
+
+// jsonRunContext carries the two fields every Run object names whatever its
+// stage: the ref that was typed and the sandbox it resolved to.
+type jsonRunContext struct {
+	ref     string
+	sandbox string
+}
+
+// detectRuntimeFor is the seam the run-line tests replace, so a test can drive a
+// full run against a fake runtime with none on PATH. Everything else calls
+// runtime.DetectFor. It is the run-line sibling of detectRuntime, which the read
+// verbs already use for the same reason.
+var detectRuntimeFor = runtime.DetectFor
+
+// runData is the payload of a Run object: what a --json run says about itself
+// once the agent has run, or once brig has refused to run it.
+//
+// error and signal are omitempty because each names a case that did not always
+// happen: error only on a brig refusal, signal only on an agent the kernel
+// killed. ref and sandbox are always present, so a consumer reads them
+// unconditionally. See #110 and the field rule in jsonout.go.
+type runData struct {
+	Ref     string `json:"ref"`
+	Sandbox string `json:"sandbox"`
+	Stage   string `json:"stage"`
+	Exit    int    `json:"exit"`
+	Error   string `json:"error,omitempty"`
+	Signal  string `json:"signal,omitempty"`
+}
+
+// writeRunObject prints one Run object to stdout, compact, on its own line. It
+// reads the ref and sandbox off jsonRun, so every caller names them the same way
+// and none has to thread them through.
+func writeRunObject(stage string, exit int, errMsg, signal string) error {
+	return writeJSONLine(os.Stdout, "Run", runData{
+		Ref:     jsonRun.ref,
+		Sandbox: jsonRun.sandbox,
+		Stage:   stage,
+		Exit:    exit,
+		Error:   errMsg,
+		Signal:  signal,
+	})
+}
+
+// emitAgentRun prints the Run object for an agent that ran and returns the
+// agentExit that carries its status up to main. stage is "agent"; the signal is
+// derived from the status, since a child the kernel killed comes back as 128
+// plus the signal number.
+func emitAgentRun(code int) error {
+	_ = writeRunObject("agent", code, "", signalName(code))
+	return &agentExit{code: code}
+}
+
+// refDisplay is the ref a Run object names: the agent, and the session label
+// when one was given. It is what the reader typed, reconstructed from the parsed
+// parts, so it reads back as a ref every verb takes.
+func refDisplay(agent string, o options) string {
+	if o.nameGiven && o.load.Name != "" {
+		return agent + "@" + o.load.Name
+	}
+	return agent
+}
+
+// peekRunLine reads a run line only as far as its first bare word: whether
+// --json stands among brig's own flags before the ref, and what that word is.
+// It exists because parse can refuse the ref before it has told anyone about
+// the flags left of it, and the Run object for that refusal still has to be
+// printed and still has to name what was typed. A flag that takes a value skips
+// the value, the way split does, so `--mem 4096` is not read as the ref.
+func peekRunLine(rest []string) (wantJSON bool, operand string) {
+	for i := 0; i < len(rest); i++ {
+		a := rest[i]
+		if a == "--" || !strings.HasPrefix(a, "-") {
+			if a != "--" {
+				operand = a
+			}
+			return wantJSON, operand
+		}
+		name, _, inline := strings.Cut(a, "=")
+		if name == "--json" {
+			wantJSON = true
+		}
+		if mine, takesValue := ours(name, posRun); mine && takesValue && !inline {
+			i++
+		}
+	}
+	return wantJSON, ""
+}
+
+// signalName maps a 128+n exit status back to the signal that produced it, for
+// the Run object's signal field. Empty for an ordinary exit -- a status at or
+// below 128 is the program's own -- so the field is present only when a signal
+// actually killed the agent. Only the signals a child is plausibly killed by are
+// named; an unrecognised one leaves the field empty rather than inventing a
+// name.
+func signalName(code int) string {
+	if code <= 128 {
+		return ""
+	}
+	switch syscall.Signal(code - 128) {
+	case syscall.SIGHUP:
+		return "SIGHUP"
+	case syscall.SIGINT:
+		return "SIGINT"
+	case syscall.SIGQUIT:
+		return "SIGQUIT"
+	case syscall.SIGILL:
+		return "SIGILL"
+	case syscall.SIGABRT:
+		return "SIGABRT"
+	case syscall.SIGFPE:
+		return "SIGFPE"
+	case syscall.SIGKILL:
+		return "SIGKILL"
+	case syscall.SIGSEGV:
+		return "SIGSEGV"
+	case syscall.SIGPIPE:
+		return "SIGPIPE"
+	case syscall.SIGALRM:
+		return "SIGALRM"
+	case syscall.SIGTERM:
+		return "SIGTERM"
+	}
+	return ""
 }
 
 // warnf prints one of brig's own notices to stderr: a warning, a deprecation, a

--- a/cmd/brig/main.go
+++ b/cmd/brig/main.go
@@ -82,6 +82,12 @@ global flags (left of the command, as in: brig -q run claude):
                          line. A verification that did not hold is printed
                          even here
                          (-q after the verb still works this release)
+      --json             machine-readable output, for the read verbs: ls, info,
+                         agent ls, secret ls and doctor. Also accepted after the
+                         verb (brig ls --json). Every other verb refuses it
+Within one apiVersion the JSON only ever gains fields, never renames or drops
+one, and no field carries a credential value -- so a script written against it
+keeps parsing, and a machine-readable dump stays a place a secret cannot leak.
 
 flags (before the agent's own arguments; -- ends brig's parsing):
       --image IMAGE      guest image to boot
@@ -177,6 +183,7 @@ func run(args []string) error {
 	// notices have already printed by the time it is known, which is one more
 	// reason the flag has moved.
 	verbosity = g.verbosity()
+	globalJSON = g.json
 	if len(verbLine) == 0 {
 		// No verb: a bare `brig`, or global flags and nothing to do with them.
 		fmt.Print(usage)
@@ -198,6 +205,14 @@ func run(args []string) error {
 		warnf("%s", hint)
 	}
 	warnDeprecatedProfileKeys()
+
+	// --json in the global position is refused here, before the verb runs, when
+	// the verb has no JSON form. The run-line spelling is refused later, where
+	// opts.json is known; this catches the canonical position. See
+	// jsonUnsupportedf.
+	if globalJSON && !verbTakesGlobalJSON(verb, rest) {
+		return jsonUnsupportedf(verb)
+	}
 
 	switch verb {
 	case "-h", "--help", "help":
@@ -225,7 +240,7 @@ func run(args []string) error {
 	// or that commit breaks every script anyone has written.
 	case "profiles":
 		deprecated("brig profiles", "brig agent ls")
-		return listProfiles()
+		return listProfiles(globalJSON)
 	case "profile":
 		return deprecatedProfileCmd(rest)
 	case "policies":
@@ -247,7 +262,7 @@ func run(args []string) error {
 	// does not gain one.
 	case "agents":
 		deprecated("brig agents", "brig agent ls")
-		return listProfiles()
+		return listProfiles(globalJSON)
 	case "template":
 		deprecated("brig template", "brig agent")
 		if len(rest) > 0 && rest[0] == "edit" {
@@ -259,7 +274,7 @@ func run(args []string) error {
 		// The two readings agree -- bare refs ARE identifiers only -- and ls
 		// still reads -q after the verb itself, which is the spelling the
 		// round-trip test consumes.
-		return listSandboxes(rest, verbosity <= wrap.Quiet)
+		return listSandboxes(rest, verbosity <= wrap.Quiet, globalJSON)
 	case "reset":
 		// reset was the one verb whose name did not say what it acts on, which
 		// is the whole of its problem: it removes every sandbox brig has, and it
@@ -350,6 +365,15 @@ func run(args []string) error {
 	opts, profileName, tail, err := parse(verb, rest)
 	if err != nil {
 		return err
+	}
+	// --json on a run-line verb. info answers it; every other verb here has no
+	// JSON form and refuses it by name. The global position was already refused
+	// above for those verbs; this catches `brig run claude --json`, where --json
+	// is brig's own token rather than the agent's, so it is named rather than
+	// forwarded. Both spellings fold into one decision.
+	wantJSON := globalJSON || opts.json
+	if wantJSON && verb != "info" && verb != "env" {
+		return jsonUnsupportedf(verb)
 	}
 	// Both at once asks for two contradictory things, and either winner would
 	// be silent about the other: the directory would be mounted with
@@ -468,11 +492,20 @@ func run(args []string) error {
 
 	switch verb {
 	case "info":
+		if wantJSON {
+			// The Info kind of the shared envelope, built from the same Config the
+			// text report reads -- see (*Config).InfoData. Written to Out, which is
+			// stdout, the way `doctor --json` writes its report.
+			return writeJSONDocument(cfg.Out, "Info", cfg.InfoData(set))
+		}
 		cfg.Info(set)
 		return nil
 	case "env":
 		// The retired spelling of the same report; the notice for it is printed
 		// by the dispatch above.
+		if wantJSON {
+			return writeJSONDocument(cfg.Out, "Info", cfg.InfoData(set))
+		}
 		cfg.Info(set)
 		return nil
 	case "create":
@@ -560,6 +593,7 @@ type options struct {
 	detach    bool
 	quiet     bool
 	offline   bool
+	json      bool
 }
 
 // position is where on a brig command line a flag is legal.
@@ -582,8 +616,9 @@ type options struct {
 type position int
 
 const (
-	// posGlobal is left of the verb: `brig --json run claude`. Closed and
-	// empty today; see splitGlobal.
+	// posGlobal is left of the verb: `brig -q run claude`. A closed set --
+	// --verbose, -q and --json -- and a token in it that brig does not own is a
+	// mistake to name; see splitGlobal.
 	posGlobal position = iota + 1
 	// posRun is the run line, from the verb to the ref. Every flag brig has
 	// today is here.
@@ -664,6 +699,21 @@ var brigFlags = []struct {
 	{long: "quiet", short: "q", position: posGlobal},
 	{long: "quiet", short: "q", position: posRun, runOnly: true,
 		retiredAs: "brig <verb> <ref> -q", retiredTo: "brig -q <verb> <ref>"},
+	// --json asks the read verbs -- ls, info, agent ls, secret ls, doctor -- for
+	// machine-readable output rather than aligned text. Global, because which
+	// form the whole invocation prints is a fact about the invocation, and left
+	// of the verb is the one position that never collides with an agent's own
+	// --json. No short form: -j is nobody's convention worth taking.
+	//
+	// Also on the run line, and not retiring there: `brig info claude --json` is
+	// what people type, and -q already works in both places, so the local
+	// spelling is a peer of the global one rather than a spelling on its way out.
+	// It prints no notice for that reason. The global position is what the help
+	// text teaches. A run-line verb with no JSON form refuses it by name -- see
+	// jsonUnsupportedf -- which is why it is brig's own token here rather than one
+	// forwarded to the agent; #110 defines what --json means on the run line.
+	{long: "json", position: posGlobal},
+	{long: "json", position: posRun},
 }
 
 // deprecatedFlags are the spellings on their way out, and what replaces each.
@@ -738,11 +788,11 @@ func retiredAt(arg string, at position) (was, now string) {
 
 // splitGlobal finds the verb and refuses anything standing left of it.
 //
-// The global position is closed. --verbose and -q live there, both facts about
-// the whole invocation rather than about one run line, and a token brig does
-// not own is refused rather than read as something else. `brig --json run
-// claude` is a line someone will type, and the two other readings are "the
-// command is --json" and "the agent wants it": one reports a command that does
+// The global position is closed. --verbose, -q and --json live there, each a
+// fact about the whole invocation rather than about one run line, and a token
+// brig does not own is refused rather than read as something else. `brig --nope
+// run claude` is a line someone will type, and the two other readings are "the
+// command is --nope" and "the agent wants it": one reports a command that does
 // not exist, the other hands a word to an agent that does not have it. Naming
 // the token is the reading that is true.
 //
@@ -786,6 +836,7 @@ func verbSpelling(arg string) bool {
 type globals struct {
 	quiet   bool
 	verbose bool
+	json    bool
 }
 
 // verbosity is the level these two flags ask for. Neither given is the default,
@@ -820,6 +871,7 @@ func parseGlobal(args []string) (g globals, rest []string, err error) {
 	for _, spelling := range []string{"quiet", "q"} {
 		fs.BoolVar(&g.quiet, spelling, false, "")
 	}
+	fs.BoolVar(&g.json, "json", false, "")
 	if err := fs.Parse(mine); err != nil {
 		return globals{}, nil, rewriteFlagError(err)
 	}
@@ -1143,6 +1195,10 @@ func parse(verb string, args []string) (o options, profileName string, tail []st
 		// Suppresses the execution envelope on run and create, for a script or
 		// a returning session that has already seen it.
 		{"quiet", "q", func(n string) { fs.BoolVar(&o.quiet, n, false, "") }},
+		// The run-line spelling of --json. info answers it; every other run-line
+		// verb refuses it by name -- see the run() dispatch. Its being brig's own
+		// token here rather than the agent's is what makes that refusal possible.
+		{"json", "", func(n string) { fs.BoolVar(&o.json, n, false, "") }},
 	} {
 		// Both spellings write the same variable, so whichever the user typed
 		// lands in one place and the last one on the line wins.
@@ -1305,24 +1361,28 @@ func spell(name string) string {
 // It leads with the ref, which is what every other verb takes: a listing whose
 // identifier no verb accepts is a listing a reader cannot act on, and copying
 // what it printed used to be an error.
-func listSandboxes(args []string, quiet bool) error {
-	// ls names no session and -q is the only flag it has, so anything else here
-	// is a token it would otherwise read and discard -- `brig ls claude` looks
-	// like it filters to one agent and does not. Refuse it rather than answer a
-	// question that was not asked.
+func listSandboxes(args []string, quiet, jsonOut bool) error {
+	// ls names no session, and -q and --json are the only flags it has, so
+	// anything else here is a token it would otherwise read and discard --
+	// `brig ls claude` looks like it filters to one agent and does not. Refuse it
+	// rather than answer a question that was not asked.
 	//
 	// Read here rather than through the flag package because ls is dispatched
 	// before the run line is parsed: it has no ref to parse, and the run line's
 	// parser exists to find where brig's arguments stop, which on this verb is
-	// immediately. Both spellings, because -q and --quiet are one flag
-	// everywhere else brig reads them.
+	// immediately. Both spellings of each, because -q/--quiet and the global and
+	// local --json are one flag everywhere else brig reads them. --json after the
+	// verb prints no notice: it is a peer of the global spelling, not one
+	// retiring in favour of it.
 	for _, a := range args {
 		switch a {
 		case "-q", "--quiet":
 			quiet = true
+		case "--json":
+			jsonOut = true
 		default:
 			return usagef("unexpected argument %q; `brig ls` takes no arguments "+
-				"other than -q", a)
+				"other than -q and --json", a)
 		}
 	}
 	rt, err := runtime.Detect()
@@ -1333,6 +1393,13 @@ func listSandboxes(args []string, quiet bool) error {
 			// named, exactly as run does, rather than answering a question that
 			// was not asked.
 			return err
+		}
+		// No runtime, so no sandboxes and none holding a name. --json says exactly
+		// that -- an empty list, the runtime marked unavailable -- and exits 0, the
+		// same answer the text form gives without the prose a parser would have to
+		// skip.
+		if jsonOut {
+			return writeJSONDocument(os.Stdout, "SandboxList", sandboxListData(nil, nil))
 		}
 		// No runtime on PATH means nothing is running and nothing is holding a
 		// name: there is nothing to list. Answer the question that was asked --
@@ -1363,6 +1430,12 @@ func listSandboxes(args []string, quiet bool) error {
 	// can be dropped. See wrap.PruneSessions.
 	pruneSessionIndex(list)
 	rows := sandboxRows(list, rt)
+	// --json before either text form, so `brig -q --json ls` is JSON and not the
+	// -q refs: the two answer different readers, and asking for both asks for the
+	// machine-readable one.
+	if jsonOut {
+		return writeJSONDocument(os.Stdout, "SandboxList", sandboxListData(rows, rt))
+	}
 	if quiet {
 		printRefs(os.Stdout, rows)
 		return nil
@@ -1424,6 +1497,62 @@ type sandboxRow struct {
 	name      string
 	state     string
 	workspace string
+}
+
+// sandboxListJSON is `brig ls` as data, the SandboxList payload. The runtime
+// sits once beside the list rather than on every row -- it is the same runtime
+// for all of them -- and image is left out, unlike #7's sketch: it is not in
+// hand for a listing and loading every profile to fill it would make ls pay for
+// a column a reader can get from `brig info`. See sandboxListData.
+type sandboxListJSON struct {
+	Runtime   sandboxRuntimeJSON `json:"runtime"`
+	Sandboxes []sandboxJSON      `json:"sandboxes"`
+}
+
+// sandboxRuntimeJSON is the runtime the listing ran against, or one marked
+// unavailable when none is on PATH -- the case the text form answers with a
+// note and an empty table.
+type sandboxRuntimeJSON struct {
+	Kind      string `json:"kind,omitempty"`
+	Bin       string `json:"bin,omitempty"`
+	Available bool   `json:"available"`
+}
+
+// sandboxJSON is one sandbox as data. agent and label are the parsed ref, so a
+// consumer need not split it; both are omitted, with ref, for a sandbox brig has
+// no ref to print -- and sandbox is set even then, so the JSON shows the sandbox
+// exists the way the table's placeholder row does.
+type sandboxJSON struct {
+	Ref       string `json:"ref,omitempty"`
+	Agent     string `json:"agent,omitempty"`
+	Label     string `json:"label,omitempty"`
+	Sandbox   string `json:"sandbox"`
+	State     string `json:"state"`
+	Workspace string `json:"workspace,omitempty"`
+}
+
+// sandboxListData turns the rows the table prints into the SandboxList payload.
+// It reads the same sandboxRows the two text printers do, so the JSON and the
+// table cannot come to list different sandboxes. rt is nil when no runtime is on
+// PATH, which marks the runtime unavailable rather than omitting it.
+func sandboxListData(rows []sandboxRow, rt runtime.Runtime) sandboxListJSON {
+	out := sandboxListJSON{Sandboxes: []sandboxJSON{}}
+	if rt != nil {
+		out.Runtime = sandboxRuntimeJSON{Kind: rt.Kind(), Bin: rt.Bin(), Available: true}
+	}
+	for _, r := range rows {
+		s := sandboxJSON{Sandbox: r.name, State: r.state, Workspace: r.workspace}
+		// A ref brig has for the sandbox carries its agent and label, split here so
+		// the consumer does not. A row with none is included ref-less: the sandbox
+		// is real, and the table shows it too.
+		if r.ref != "" {
+			if ref, err := session.ParseRef(r.ref); err == nil {
+				s.Ref, s.Agent, s.Label = r.ref, ref.Agent, ref.Label
+			}
+		}
+		out.Sandboxes = append(out.Sandboxes, s)
+	}
+	return out
 }
 
 // noRef is what the table shows for a sandbox with no ref to print.
@@ -1684,8 +1813,11 @@ func removeAll(spelling string, args []string) error {
 // listing -- so it says where each profile came from, because "the image is
 // not what I expected" and "there is a file I forgot about" are the same
 // question.
-func listProfiles() error {
+func listProfiles(jsonOut bool) error {
 	all := profile.All()
+	if jsonOut {
+		return writeJSONDocument(os.Stdout, "AgentList", agentListData(all))
+	}
 	// The short spellings, in a column of their own: `brig run claude` runs
 	// claude-code, and this listing is where someone finds that out. The
 	// column is as wide as the spellings in it and absent when there are none,
@@ -1777,6 +1909,74 @@ func listProfiles() error {
 	return nil
 }
 
+// agentLsJSON reads `brig agent ls`'s own arguments: --json, and nothing else.
+// ls names no agent and has no other flag, so any other token is one it would
+// read and discard -- the same refusal `brig ls` makes, for the same reason.
+func agentLsJSON(args []string) (bool, error) {
+	jsonOut := false
+	for _, a := range args {
+		switch a {
+		case "--json":
+			jsonOut = true
+		default:
+			return false, usagef("unexpected argument %q; `brig agent ls` takes no "+
+				"arguments other than --json", a)
+		}
+	}
+	return jsonOut, nil
+}
+
+// agentJSON is one agent as data, the AgentList row. aliases is the short
+// spellings brig answers to; file is the path only for a file-backed profile,
+// absent for a built-in that has no file. builtIn and overridesBuiltIn are the
+// two the text listing marks in prose: whether brig ships it, and whether a file
+// of yours is shadowing one brig ships.
+type agentJSON struct {
+	Name             string   `json:"name"`
+	Aliases          []string `json:"aliases,omitempty"`
+	Kind             string   `json:"kind"`
+	Image            string   `json:"image"`
+	BuiltIn          bool     `json:"builtIn"`
+	OverridesBuiltIn bool     `json:"overridesBuiltIn"`
+	Unpublished      bool     `json:"unpublished"`
+	Reserved         bool     `json:"reserved"`
+	File             string   `json:"file,omitempty"`
+}
+
+// agentListData turns the merged profile set into the AgentList payload, from
+// the same registry views the text listing reads: profile.All for the set,
+// Aliases for the spellings, IsCustom and OverridesBuiltIn for the origin, and
+// Path for the file behind a file-backed one.
+func agentListData(all []profile.Profile) []agentJSON {
+	out := make([]agentJSON, 0, len(all))
+	for _, p := range all {
+		// The default applied: Parse leaves an agent's Kind empty because agent is
+		// the zero value, and a listing that omitted the kind of every ordinary
+		// agent would be reporting an absence rather than the fact.
+		kind := string(p.Kind)
+		if kind == "" {
+			kind = string(profile.KindAgent)
+		}
+		row := agentJSON{
+			Name:             p.Name,
+			Aliases:          profile.Aliases(p.Name),
+			Kind:             kind,
+			Image:            p.Image,
+			BuiltIn:          !profile.IsCustom(p.Name),
+			OverridesBuiltIn: profile.OverridesBuiltIn(p.Name),
+			Unpublished:      p.Unpublished,
+			Reserved:         p.Reserved,
+		}
+		// Only a file-backed profile has a file; a built-in is compiled in and has
+		// none, so the field is absent rather than an empty path.
+		if path, ok := profile.Path(p.Name); ok {
+			row.File = path
+		}
+		out = append(out, row)
+	}
+	return out
+}
+
 // importableNames and handCreatedNames split a profile's requirement list the
 // way the two commands that fill it do. A secret with no sources is
 // hand-created by definition, so the listing points at the command that can
@@ -1859,10 +2059,11 @@ func agentCmd(args []string) error {
 		fmt.Print(agentUsage)
 		return nil
 	case "ls":
-		if err := rejectAgentTail("brig agent ls", "takes no arguments", args[1:]); err != nil {
+		jsonOut, err := agentLsJSON(args[1:])
+		if err != nil {
 			return err
 		}
-		return listProfiles()
+		return listProfiles(jsonOut || globalJSON)
 	case "show":
 		err = showAgent(args[1:])
 	case "new":
@@ -1881,12 +2082,13 @@ func agentCmd(args []string) error {
 	case "list":
 		deprecated("brig agent list", "brig agent ls")
 		// The retired spelling behaves exactly like the verb it maps onto, the
-		// refusal of a stray word included, so it names `brig agent ls` too:
-		// the notice above already pointed the reader there.
-		if err := rejectAgentTail("brig agent ls", "takes no arguments", args[1:]); err != nil {
+		// refusal of a stray word and the reading of --json included, so it
+		// names `brig agent ls` too: the notice above already pointed there.
+		jsonOut, err := agentLsJSON(args[1:])
+		if err != nil {
 			return err
 		}
-		return listProfiles()
+		return listProfiles(jsonOut || globalJSON)
 	case "save":
 		deprecated("brig agent save", "brig agent export")
 		err = exportProfile(args[1:])
@@ -2483,6 +2685,43 @@ func deprecated(old, replacement string) {
 // rather than values a command returns. run sets it on every invocation, so a
 // test that drives run twice does not inherit the first one's level.
 var verbosity = wrap.Normal
+
+// globalJSON is whether --json was given left of the verb, read off the global
+// position with verbosity and for the same reason: which form the whole
+// invocation prints is a fact about the invocation, known before any verb runs.
+// A package var rather than a threaded value because the read verbs are reached
+// through four different dispatch paths -- ls inline, agent and secret through
+// their groups, doctor through its own parser -- and a parameter on each would
+// be a parameter most of them ignore. run sets it every invocation, so a test
+// driving run twice does not inherit the first one's setting.
+var globalJSON bool
+
+// verbTakesGlobalJSON reports whether the verb in the global position has a
+// --json form to ask for. The five read verbs do; agent and secret only in
+// their ls subcommand, which is the one that lists. Everything else -- run, sh,
+// stop, rm, and the verbs that manage rather than list -- has none, so --json
+// left of it is a usage error rather than a flag dropped on the floor.
+func verbTakesGlobalJSON(verb string, rest []string) bool {
+	switch verb {
+	case "ls", "info", "env", "doctor":
+		return true
+	case "agent", "secret":
+		return len(rest) > 0 && rest[0] == "ls"
+	}
+	return false
+}
+
+// jsonUnsupportedf is the refusal a verb with no JSON form gives to --json: a
+// usage error (exit 2) that names the verbs that do have one, so the reader
+// moves the flag rather than guessing which command it belongs on. env takes
+// it too, because a deprecated spelling keeps working until it is removed,
+// but it is named as deprecated rather than listed, so nobody lands on it
+// from here.
+func jsonUnsupportedf(verb string) error {
+	return usagef("`brig %s` has no --json output. --json is for the read verbs: "+
+		"ls, info, agent ls, secret ls, doctor (env takes it too, but env is "+
+		"deprecated; prefer info)", verb)
+}
 
 // warnf prints one of brig's own notices to stderr: a warning, a deprecation, a
 // word about what a line now means.

--- a/cmd/brig/profile_test.go
+++ b/cmd/brig/profile_test.go
@@ -156,7 +156,7 @@ func TestListProfilesShowsTheAliases(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	out, err := captureStdout(t, listProfiles)
+	out, err := captureStdout(t, func() error { return listProfiles(false) })
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -225,7 +225,7 @@ func TestListProfilesReportsBindingsAndRequiredSecrets(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	out, err := captureStdout(t, listProfiles)
+	out, err := captureStdout(t, func() error { return listProfiles(false) })
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -502,7 +502,7 @@ func TestListProfilesSeparatesImportableSecretsFromHandCreatedOnes(t *testing.T)
 	if err := profile.Load(profile.Dir()); err != nil {
 		t.Fatal(err)
 	}
-	out, err := captureStdout(t, listProfiles)
+	out, err := captureStdout(t, func() error { return listProfiles(false) })
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/brig/run_json_test.go
+++ b/cmd/brig/run_json_test.go
@@ -1,0 +1,241 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/brig-sh/brig/internal/profile"
+	"github.com/brig-sh/brig/internal/runtime"
+)
+
+// jsonRuntime is a runtime a full `brig run` can drive with none on PATH. It
+// boots trivially -- nothing is running, so a first boot is recorded and the
+// readiness probe passes -- and records which handover the run reached, which is
+// the fact the tests below turn on. attachFn is what Attach runs, so a case can
+// hand back a real exit status.
+type jsonRuntime struct {
+	runtime.Runtime
+	replaced int
+	attached int
+	attachFn func(runtime.ExecSpec) (int, error)
+}
+
+func (r *jsonRuntime) Kind() string                 { return "hull" }
+func (r *jsonRuntime) Bin() string                  { return "hull" }
+func (r *jsonRuntime) Running(string) (bool, error) { return false, nil }
+func (r *jsonRuntime) Run(runtime.RunSpec) error    { return nil }
+func (r *jsonRuntime) Probe(runtime.ExecSpec) bool  { return true }
+func (r *jsonRuntime) Output(runtime.ExecSpec) (string, error) {
+	return "", nil
+}
+func (r *jsonRuntime) Stop(string) error                  { return nil }
+func (r *jsonRuntime) Remove(string) error                { return nil }
+func (r *jsonRuntime) PinsDigest() bool                   { return false }
+func (r *jsonRuntime) LocalDigest(string) (string, error) { return "", nil }
+func (r *jsonRuntime) LogsHint(name string) string        { return "hull logs " + name }
+
+// Replace records the handover and returns rather than exec'ing -- a real
+// syscall.Exec would replace the test binary. That it is a no-op here is the
+// whole point: the default path must reach it and not Attach.
+func (r *jsonRuntime) Replace(runtime.ExecSpec) error {
+	r.replaced++
+	return nil
+}
+
+func (r *jsonRuntime) Attach(spec runtime.ExecSpec) (int, error) {
+	r.attached++
+	if r.attachFn != nil {
+		return r.attachFn(spec)
+	}
+	return 0, nil
+}
+
+// jsonRunHost points brig's whole environment at scratch directories and hands
+// run() the given fake runtime through the detection seam, so a full run drives
+// the fake with nothing on the host. It writes a minimal agent profile named
+// "faker" -- no genericBoot, no secrets -- so the boot needs neither boot assets
+// nor a keychain.
+func jsonRunHost(t *testing.T, rt runtime.Runtime) {
+	t.Helper()
+	dir := t.TempDir()
+	t.Setenv("BRIG_PROFILE_DIR", dir)
+	t.Setenv("BRIG_STATE_DIR", t.TempDir())
+	t.Setenv("BRIG_WORKSPACE", t.TempDir())
+	t.Setenv("BRIG_VERIFY", "off")
+	t.Setenv("BRIG_RUNTIME", "")
+	emptyPath(t)
+	body := "name: faker\nimage: img\nguestHome: /home/faker\nbinary: agent\nmem: 1024\ncpus: 1\n"
+	if err := os.WriteFile(filepath.Join(dir, "faker.yaml"), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := profile.Load(profile.Dir()); err != nil {
+		t.Fatal(err)
+	}
+	prev := detectRuntimeFor
+	detectRuntimeFor = func(runtime.Preference) (runtime.Runtime, error) { return rt, nil }
+	t.Cleanup(func() { detectRuntimeFor = prev })
+}
+
+// lastJSONLine parses the final non-empty line of out as a Run object. brig
+// prints its object after the agent's own inherited output, so a script's rule
+// is "the last line of stdout is brig's" -- this is that rule, in a test.
+func lastJSONLine(t *testing.T, out string) map[string]any {
+	t.Helper()
+	lines := strings.Split(strings.TrimRight(out, "\n"), "\n")
+	last := lines[len(lines)-1]
+	var doc map[string]any
+	if err := json.Unmarshal([]byte(last), &doc); err != nil {
+		t.Fatalf("last stdout line is not JSON: %q\n(full stdout: %q)", last, out)
+	}
+	return doc
+}
+
+// The test that protects every interactive user: a run WITHOUT --json hands the
+// terminal over with Replace and never touches the child path. A regression here
+// is an agent that has lost its tty, so this goes first.
+func TestRunWithoutJSONReachesReplaceNeverAttach(t *testing.T) {
+	rt := &jsonRuntime{}
+	jsonRunHost(t, rt)
+
+	if _, err := captureStdout(t, func() error { return run([]string{"run", "faker"}) }); err != nil {
+		t.Fatalf("run faker: %v", err)
+	}
+	if rt.replaced != 1 {
+		t.Errorf("Replace called %d times, want 1", rt.replaced)
+	}
+	if rt.attached != 0 {
+		t.Errorf("a default run reached the child path %d times, want 0", rt.attached)
+	}
+}
+
+// Under --json the agent runs as a child, and its own exit status is brig's. The
+// child here really exits 7, through the production RunAttached, so this pins the
+// whole chain: Attach's status, the Run object, and the status brig returns.
+func TestRunJSONPropagatesTheAgentExitStatus(t *testing.T) {
+	rt := &jsonRuntime{attachFn: func(runtime.ExecSpec) (int, error) {
+		return runtime.RunAttached([]string{"/bin/sh", "-c", "exit 7"}, nil)
+	}}
+	jsonRunHost(t, rt)
+
+	out, err := captureStdout(t, func() error { return run([]string{"--json", "run", "faker"}) })
+	if rt.attached != 1 {
+		t.Errorf("the agent reached the child path %d times, want 1", rt.attached)
+	}
+	if got := exitCode(err); got != 7 {
+		t.Errorf("brig exit = %d, want 7", got)
+	}
+	doc := lastJSONLine(t, out)
+	if doc["kind"] != "Run" {
+		t.Errorf("kind = %v, want Run", doc["kind"])
+	}
+	data, _ := doc["data"].(map[string]any)
+	if data["stage"] != "agent" {
+		t.Errorf("stage = %v, want agent", data["stage"])
+	}
+	if data["exit"] != float64(7) {
+		t.Errorf("exit = %v, want 7", data["exit"])
+	}
+	if _, ok := data["error"]; ok {
+		t.Errorf("an agent that ran carried an error field: %v", data["error"])
+	}
+}
+
+// A brig refusal under --json is one line too, with stage "brig" and the
+// message, and nothing else on stdout: the object is what a script parses to
+// tell "brig would not start this" from "the agent exited non-zero", which the
+// exit status alone cannot say.
+func TestRunJSONReportsABrigRefusal(t *testing.T) {
+	// No runtime needed: an unknown profile is refused before detection.
+	t.Setenv("BRIG_PROFILE_DIR", t.TempDir())
+	if err := profile.Load(profile.Dir()); err != nil {
+		t.Fatal(err)
+	}
+
+	var err error
+	out, _ := captureStdout(t, func() error { err = run([]string{"--json", "run", "nosuchagent"}); return nil })
+	if got := exitCode(err); got != exitNotFound {
+		t.Errorf("brig exit = %d, want %d (not found)", got, exitNotFound)
+	}
+	if lines := strings.Count(strings.TrimRight(out, "\n"), "\n"); lines != 0 {
+		t.Errorf("stdout has more than one line:\n%s", out)
+	}
+	doc := lastJSONLine(t, out)
+	data, _ := doc["data"].(map[string]any)
+	if data["stage"] != "brig" {
+		t.Errorf("stage = %v, want brig", data["stage"])
+	}
+	if msg, _ := data["error"].(string); msg == "" || !strings.Contains(msg, "nosuchagent") {
+		t.Errorf("error = %q, want it to name the refused agent", data["error"])
+	}
+	if data["exit"] != float64(exitNotFound) {
+		t.Errorf("exit = %v, want %d", data["exit"], exitNotFound)
+	}
+}
+
+// A ref that will not parse is refused inside parse, before the run line has
+// been read. Under --json that refusal is still one Run line, stage brig, with
+// the usage exit, in either position of the flag, so a script's rule -- the
+// last line of stdout is brig's -- holds for a typo as much as for an unknown
+// agent.
+func TestRunJSONReportsABadRef(t *testing.T) {
+	t.Setenv("BRIG_PROFILE_DIR", t.TempDir())
+	if err := profile.Load(profile.Dir()); err != nil {
+		t.Fatal(err)
+	}
+	for _, args := range [][]string{
+		{"--json", "run", "claude@BAD"},
+		{"run", "--json", "claude@BAD"},
+		{"run", "--mem", "4096", "--json", "claude@BAD"},
+	} {
+		var err error
+		out, _ := captureStdout(t, func() error { err = run(args); return nil })
+		if got := exitCode(err); got != exitUsage {
+			t.Errorf("%q: exit %d, want %d", args, got, exitUsage)
+		}
+		doc := lastJSONLine(t, out)
+		data, _ := doc["data"].(map[string]any)
+		if data["stage"] != "brig" || data["ref"] != "claude@BAD" {
+			t.Errorf("%q: stage %v ref %v, want brig and claude@BAD", args, data["stage"], data["ref"])
+		}
+		if data["exit"] != float64(exitUsage) {
+			t.Errorf("%q: exit field %v, want %d", args, data["exit"], exitUsage)
+		}
+	}
+}
+
+// -d starts the sandbox and stops. Under --json it says so as the object, with
+// the sandbox name a script would attach to; the text form still prints the bare
+// name and nothing more.
+func TestDetachJSONPrintsTheObjectAndTextPrintsTheName(t *testing.T) {
+	rt := &jsonRuntime{}
+	jsonRunHost(t, rt)
+
+	out, err := captureStdout(t, func() error { return run([]string{"--json", "run", "faker", "-d"}) })
+	if err != nil {
+		t.Fatalf("run -d --json: %v", err)
+	}
+	doc := lastJSONLine(t, out)
+	data, _ := doc["data"].(map[string]any)
+	if data["stage"] != "detached" {
+		t.Errorf("stage = %v, want detached", data["stage"])
+	}
+	if data["sandbox"] != "brig-faker" {
+		t.Errorf("sandbox = %v, want brig-faker", data["sandbox"])
+	}
+	if rt.replaced != 0 || rt.attached != 0 {
+		t.Errorf("-d ran the agent: replaced=%d attached=%d", rt.replaced, rt.attached)
+	}
+
+	rt2 := &jsonRuntime{}
+	jsonRunHost(t, rt2)
+	textOut, err := captureStdout(t, func() error { return run([]string{"run", "faker", "-d"}) })
+	if err != nil {
+		t.Fatalf("run -d: %v", err)
+	}
+	if strings.TrimSpace(textOut) != "brig-faker" {
+		t.Errorf("text -d printed %q, want the bare sandbox name", textOut)
+	}
+}

--- a/cmd/brig/runtime_guard_test.go
+++ b/cmd/brig/runtime_guard_test.go
@@ -45,7 +45,7 @@ func TestLsSurfacesUnknownRuntime(t *testing.T) {
 	t.Setenv("BRIG_PROFILE_DIR", t.TempDir())
 	t.Setenv("BRIG_RUNTIME", "podman")
 
-	err := listSandboxes(nil, false)
+	err := listSandboxes(nil, false, false)
 	if err == nil {
 		t.Fatal("brig ls with an unknown BRIG_RUNTIME was accepted")
 	}
@@ -93,7 +93,7 @@ func TestLsWithoutARuntimeSaysNothingToList(t *testing.T) {
 	t.Setenv("BRIG_RUNTIME", "")
 	emptyPath(t)
 
-	if err := listSandboxes(nil, false); err != nil {
+	if err := listSandboxes(nil, false, false); err != nil {
 		t.Errorf("ls with no runtime on PATH failed instead of listing nothing: %v", err)
 	}
 }

--- a/cmd/brig/secret.go
+++ b/cmd/brig/secret.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"strings"
 	"text/tabwriter"
+	"time"
 
 	"github.com/brig-sh/brig/internal/secret"
 	"github.com/brig-sh/brig/internal/wrap"
@@ -223,15 +224,23 @@ func deleteSecret(out io.Writer, args []string) error {
 // Taking one silently is how `brig secret ls gh-token` -- someone reaching for
 // read -- prints everything and exits 0.
 func listSecrets(out io.Writer, args []string) error {
-	if len(args) > 0 {
-		if isHelp(args[0]) {
+	// --json is the one flag ls takes, in the local position as well as the
+	// global one -- see globalJSON. Anything else is a token it would read and
+	// discard: a flag it does not have, or a name that reads like a filter it
+	// does not apply.
+	jsonOut := globalJSON
+	for _, a := range args {
+		switch {
+		case a == "--json":
+			jsonOut = true
+		case isHelp(a):
 			return flag.ErrHelp
+		case strings.HasPrefix(a, "-"):
+			return fmt.Errorf("ls takes no flags other than --json, so it has no use for %s", a)
+		default:
+			return fmt.Errorf("ls lists every secret and takes no name. For one secret's "+
+				"value: `brig secret read %s`", a)
 		}
-		if strings.HasPrefix(args[0], "-") {
-			return fmt.Errorf("ls takes no flags, so it has no use for %s", args[0])
-		}
-		return fmt.Errorf("ls lists every secret and takes no name. For one secret's "+
-			"value: `brig secret read %s`", args[0])
 	}
 	store, err := openStore()
 	if err != nil {
@@ -240,6 +249,11 @@ func listSecrets(out io.Writer, args []string) error {
 	list, err := store.List()
 	if err != nil {
 		return err
+	}
+	if jsonOut {
+		// An empty store is data: [] and exit 0, not the prose hint below: a parser
+		// reads an empty list, and the note about how to add one is for a person.
+		return writeJSONDocument(out, "SecretList", secretListData(list))
 	}
 	// An empty store is an ordinary state, not an error, and is the moment to
 	// say how to leave it.
@@ -268,6 +282,33 @@ func listSecrets(out io.Writer, args []string) error {
 		fmt.Fprintf(w, "%s\t%s\t%s\n", s.Name, updated, from)
 	}
 	return w.Flush()
+}
+
+// secretJSON is one secret as data, the SecretList row: the name, when it was
+// last written, and where it came from -- and never the value, which List does
+// not decrypt and neither does this. modified is RFC 3339 and omitted when the
+// backend carries no date; provenance is omitted when the secret was created by
+// hand, the same "absent rather than invented" rule the text column follows.
+type secretJSON struct {
+	Name       string `json:"name"`
+	Modified   string `json:"modified,omitempty"`
+	Provenance string `json:"provenance,omitempty"`
+}
+
+// secretListData turns store.List into the SecretList payload. The list is the
+// same [] secret.Secret the text listing reads, names and dates only, so the two
+// forms cannot come to disagree about what is stored. An empty store is an empty
+// list, not nil, so the payload is data: [] rather than data: null.
+func secretListData(list []secret.Secret) []secretJSON {
+	out := make([]secretJSON, 0, len(list))
+	for _, s := range list {
+		row := secretJSON{Name: s.Name, Provenance: s.Provenance.From}
+		if !s.Modified.IsZero() {
+			row.Modified = s.Modified.Format(time.RFC3339)
+		}
+		out = append(out, row)
+	}
+	return out
 }
 
 // isHelp reports whether a token is someone asking for help. The verbs that

--- a/docs/security.md
+++ b/docs/security.md
@@ -654,6 +654,11 @@ It does not filter what the agent writes to your terminal. `brig` hands the
 tty over with `syscall.Exec` and is gone before the agent produces a byte,
 which is what buys correct `^C` handling and a truthful exit status -- and it
 means every byte the agent emits reaches your terminal emulator unexamined.
+The one exception is `--json`: there `brig` stays alive as the agent's parent
+so it can print one status line after the agent exits. The tty is still the
+agent's, `brig` reads nothing the agent prints and writes nothing to it, and
+the exit status is still the agent's own. What changes is only that `brig` is
+present for the run rather than gone.
 That is a real surface: OSC 52 writes to, and reads from, the system
 clipboard; DCS sequences are forwarded verbatim by `tmux` and `screen` to the
 *outer* terminal; and a cursor-position query makes the terminal type its

--- a/internal/runtime/attach.go
+++ b/internal/runtime/attach.go
@@ -1,0 +1,114 @@
+package runtime
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"os/signal"
+	"syscall"
+)
+
+// execHandover and attachHandover are the two ways a built command is handed
+// down, kept behind package vars so a test can capture the argv and env each
+// receives without a syscall.Exec that never returns. Replace and Attach share
+// one builder already -- replaceCmd in each adapter -- and stubbing these is how
+// a test proves the two paths cannot drift.
+var (
+	execHandover   = syscall.Exec
+	attachHandover = RunAttached
+)
+
+// RunAttached runs argv as a child of brig, inheriting brig's own stdin, stdout
+// and stderr, waits for it, and returns its exit status. argv[0] is the binary;
+// env is the full child environment. Both adapters build the pair from the very
+// function their Replace uses, so the child and the process replacement cannot
+// drift.
+//
+// It is the child-process counterpart of syscall.Exec. Replace hands the
+// terminal, the signals and the exit status straight to the runtime and never
+// returns, which is the right default: the agent's TUI wants a real tty with
+// nothing between it and the keyboard. Attach keeps brig alive across the exec
+// so brig can report the outcome on a machine-readable line afterwards, which
+// Replace by definition cannot -- there is no brig left once the exec has
+// happened.
+//
+// A child killed by a signal is reported as 128 plus the signal number, the
+// convention a shell follows, so a caller mapping the status onto its own exit
+// returns the same number a shell would for the same death.
+func RunAttached(argv, env []string) (int, error) {
+	cmd := exec.Command(argv[0], argv[1:]...)
+	cmd.Env = env
+	cmd.Stdin, cmd.Stdout, cmd.Stderr = os.Stdin, os.Stdout, os.Stderr
+
+	// Registered before Start so a signal that arrives in the gap between fork
+	// and the forwarding goroutine is buffered rather than taking brig down
+	// under the default disposition.
+	sigs := make(chan os.Signal, 1)
+	signal.Notify(sigs, os.Interrupt, syscall.SIGTERM, syscall.SIGHUP)
+	defer signal.Stop(sigs)
+
+	if err := cmd.Start(); err != nil {
+		return 0, err
+	}
+
+	// The child holds the terminal, so it sits in brig's own process group and a
+	// Ctrl-C from the tty is delivered by the kernel to BOTH brig and the child
+	// at the same instant. brig must therefore neither exit on SIGINT nor
+	// forward it: the child already has it, and a second copy -- or brig dying
+	// and orphaning the child mid-keystroke -- is exactly the bug this guards
+	// against. So SIGINT is caught and dropped, and brig goes on waiting.
+	//
+	// SIGTERM and SIGHUP are different in kind: they reach brig alone (a `kill`,
+	// a hung-up session), not through the tty, so the child never sees them
+	// unless brig passes them on. Those are forwarded. SIGWINCH needs nothing --
+	// the child owns the tty and the kernel resizes its pty directly. The
+	// deferred signal.Stop restores the default handling, so nothing outlives
+	// the one child this call waits on.
+	//
+	// This is the reasoning most likely to be "corrected" wrongly later: do not
+	// add SIGINT to the forwarded set, and do not make SIGINT return early.
+	//
+	// It rests on the child sharing brig's process group, which it does because
+	// nothing here calls Setpgid. If that ever changes, a Ctrl-C reaches brig
+	// alone and this handler must start forwarding it. Forwarding it today
+	// would hand the child a second SIGINT for every keystroke, and an agent
+	// that reads the second as "quit" -- most TUIs do -- would exit on the
+	// first. There is no second-Ctrl-C escape here on purpose: brig waits for
+	// the child, and the child is what the keystroke is for.
+	done := make(chan struct{})
+	go func() {
+		for {
+			select {
+			case s := <-sigs:
+				switch s {
+				case syscall.SIGTERM, syscall.SIGHUP:
+					_ = cmd.Process.Signal(s)
+				}
+			case <-done:
+				return
+			}
+		}
+	}()
+
+	err := cmd.Wait()
+	close(done)
+	return attachedStatus(err)
+}
+
+// attachedStatus reads the child's exit status out of what cmd.Wait returned:
+// its own exit code when it exited, or 128 plus the signal number when a signal
+// killed it. A non-exit error -- the child could not be started or waited on --
+// is brig's own failure and is returned as the error, not folded into a status.
+func attachedStatus(err error) (int, error) {
+	if err == nil {
+		return 0, nil
+	}
+	var ee *exec.ExitError
+	if errors.As(err, &ee) {
+		if ws, ok := ee.Sys().(syscall.WaitStatus); ok && ws.Signaled() {
+			return 128 + int(ws.Signal()), nil
+		}
+		return ee.ExitCode(), nil
+	}
+	return 0, err
+}

--- a/internal/runtime/attach_test.go
+++ b/internal/runtime/attach_test.go
@@ -1,0 +1,155 @@
+package runtime
+
+import (
+	"os"
+	"reflect"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// Replace and Attach must be the same exec asked for two ways: the terminal
+// handover and the --json child differ only in whether brig survives them, never
+// in what they run or the environment they run it in. A drift there is a
+// credential forwarded to one path and not the other, or a --json run that
+// behaves unlike the interactive one it is meant to report on.
+//
+// The two handovers are captured through the package seams rather than actually
+// exec'd -- syscall.Exec would replace the test binary and never return -- so
+// what is compared is exactly the argv and env each method handed down.
+func TestReplaceAndAttachBuildTheSameCommand(t *testing.T) {
+	spec := ExecSpec{
+		Name: "brig-x",
+		Cmd:  []string{"agent", "--flag", "v"},
+		Cwd:  "/work/proj",
+		TTY:  true,
+		Env:  []Var{{Name: "GH_TOKEN", Value: "t", Secret: true}},
+	}
+
+	for _, tc := range []struct {
+		name    string
+		replace func() ([]string, []string)
+		attach  func() ([]string, []string)
+	}{
+		{
+			name: "hull",
+			replace: func() ([]string, []string) {
+				return captureHandover(t, func() { _ = (&hull{bin: "/opt/hull"}).Replace(spec) },
+					func() (int, error) { return 0, nil })
+			},
+			attach: func() ([]string, []string) {
+				return captureAttach(t, func() { _, _ = (&hull{bin: "/opt/hull"}).Attach(spec) })
+			},
+		},
+		{
+			name: "nerdctl",
+			replace: func() ([]string, []string) {
+				return captureHandover(t, func() { _ = (&nerdctl{bin: "/usr/bin/nerdctl"}).Replace(spec) },
+					func() (int, error) { return 0, nil })
+			},
+			attach: func() ([]string, []string) {
+				return captureAttach(t, func() { _, _ = (&nerdctl{bin: "/usr/bin/nerdctl"}).Attach(spec) })
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			rArgv, rEnv := tc.replace()
+			aArgv, aEnv := tc.attach()
+			if !reflect.DeepEqual(rArgv, aArgv) {
+				t.Errorf("argv differs between Replace and Attach:\n  replace: %v\n  attach:  %v", rArgv, aArgv)
+			}
+			if !reflect.DeepEqual(rEnv, aEnv) {
+				t.Errorf("env differs between Replace and Attach:\n  replace: %v\n  attach:  %v", rEnv, aEnv)
+			}
+		})
+	}
+}
+
+// captureHandover runs fn with execHandover stubbed to record the argv and env
+// it is given rather than replacing the process, restoring the seam after.
+func captureHandover(t *testing.T, fn func(), _ func() (int, error)) (argv, env []string) {
+	t.Helper()
+	prev := execHandover
+	execHandover = func(_ string, a, e []string) error { argv, env = a, e; return nil }
+	t.Cleanup(func() { execHandover = prev })
+	fn()
+	return argv, env
+}
+
+// captureAttach is captureHandover for the child path.
+func captureAttach(t *testing.T, fn func()) (argv, env []string) {
+	t.Helper()
+	prev := attachHandover
+	attachHandover = func(a, e []string) (int, error) { argv, env = a, e; return 0, nil }
+	t.Cleanup(func() { attachHandover = prev })
+	fn()
+	return argv, env
+}
+
+// A child that exits with a status hands that status straight back, so a --json
+// run can report the agent's own code as brig's.
+func TestRunAttachedReturnsTheChildExitStatus(t *testing.T) {
+	code, err := RunAttached([]string{"/bin/sh", "-c", "exit 7"}, nil)
+	if err != nil {
+		t.Fatalf("RunAttached: %v", err)
+	}
+	if code != 7 {
+		t.Errorf("exit status = %d, want 7", code)
+	}
+}
+
+// A child brig cannot even start is brig's own failure, returned as an error
+// rather than folded into a status a script would read as the agent's.
+func TestRunAttachedReturnsAnErrorWhenTheChildCannotStart(t *testing.T) {
+	if _, err := RunAttached([]string{"/no/such/binary/at/all"}, nil); err == nil {
+		t.Fatal("a child that could not be started returned no error")
+	}
+}
+
+// SIGTERM reaches brig alone -- a kill, a closed session -- not through the tty,
+// so the child never sees it unless brig forwards it. brig forwards it, the
+// child dies of it, and brig's status is 128 plus the signal number, the shell's
+// convention. Without the forwarding a `kill` of a --json run would leave the
+// agent running.
+func TestRunAttachedForwardsSIGTERM(t *testing.T) {
+	go func() {
+		// After RunAttached has registered its handler and started the child.
+		time.Sleep(300 * time.Millisecond)
+		_ = syscall.Kill(os.Getpid(), syscall.SIGTERM)
+	}()
+	code, err := RunAttached([]string{"/bin/sh", "-c", "sleep 30"}, nil)
+	if err != nil {
+		t.Fatalf("RunAttached: %v", err)
+	}
+	if want := 128 + int(syscall.SIGTERM); code != want {
+		t.Errorf("exit status = %d, want %d (128 + SIGTERM)", code, want)
+	}
+}
+
+// SIGINT is the opposite case: the tty delivers it to the child directly, so a
+// second copy from brig -- or brig exiting and orphaning the child -- is the
+// bug. brig catches SIGINT, drops it, and goes on waiting. The child here never
+// receives it (the test signals brig alone, not the child's group), so a brig
+// that exited early or forwarded it would end the wait before the child was
+// stopped some other way.
+func TestRunAttachedDoesNotExitEarlyOnSIGINT(t *testing.T) {
+	start := time.Now()
+	go func() {
+		time.Sleep(200 * time.Millisecond)
+		// Dropped by brig: the child keeps sleeping, brig keeps waiting.
+		_ = syscall.Kill(os.Getpid(), syscall.SIGINT)
+		time.Sleep(400 * time.Millisecond)
+		// What actually ends the wait, proving SIGINT did not.
+		_ = syscall.Kill(os.Getpid(), syscall.SIGTERM)
+	}()
+	code, err := RunAttached([]string{"/bin/sh", "-c", "sleep 30"}, nil)
+	if err != nil {
+		t.Fatalf("RunAttached: %v", err)
+	}
+	if elapsed := time.Since(start); elapsed < 400*time.Millisecond {
+		t.Errorf("returned after %v, too soon -- SIGINT cut the wait short", elapsed)
+	}
+	if want := 128 + int(syscall.SIGTERM); code != want {
+		t.Errorf("exit status = %d, want %d -- SIGINT, not SIGTERM, ended it", code, want)
+	}
+}

--- a/internal/runtime/hull.go
+++ b/internal/runtime/hull.go
@@ -11,7 +11,6 @@ import (
 	"strconv"
 	"strings"
 	"sync"
-	"syscall"
 	"time"
 )
 
@@ -586,7 +585,16 @@ func (h *hull) Feed(spec ExecSpec) error {
 // status is brig's exit status without any relaying.
 func (h *hull) Replace(spec ExecSpec) error {
 	argv, env := h.replaceCmd(spec)
-	return syscall.Exec(h.bin, argv, env)
+	return execHandover(h.bin, argv, env)
+}
+
+// Attach runs the same handover as a child instead of replacing brig, for the
+// --json path that has to outlive the exec to report its exit status. It builds
+// its command from replaceCmd, the one function Replace uses too, so the child
+// and the process replacement carry byte-for-byte the same argv and env.
+func (h *hull) Attach(spec ExecSpec) (int, error) {
+	argv, env := h.replaceCmd(spec)
+	return attachHandover(argv, env)
 }
 
 // replaceCmd builds the handover argv and environment in one place, so a test

--- a/internal/runtime/nerdctl.go
+++ b/internal/runtime/nerdctl.go
@@ -8,7 +8,6 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
-	"syscall"
 )
 
 // nerdctl drives the Linux path. It is the same product logic over
@@ -421,10 +420,27 @@ func (n *nerdctl) Feed(spec ExecSpec) error {
 	return nil
 }
 
-func (n *nerdctl) Replace(spec ExecSpec) error {
+// replaceCmd builds the handover argv and environment in one place, so the
+// terminal handover and the --json child cannot drift: Replace and Attach both
+// read from here, the way the hull adapter's replaceCmd serves both there.
+func (n *nerdctl) replaceCmd(spec ExecSpec) (argv, env []string) {
 	args, envVals := n.execArgs(spec)
-	argv := append([]string{n.bin}, args...)
-	return syscall.Exec(n.bin, argv, mergeEnv(telemetryEnv(spec.Counted), envVals))
+	argv = append([]string{n.bin}, args...)
+	env = mergeEnv(telemetryEnv(spec.Counted), envVals)
+	return argv, env
+}
+
+func (n *nerdctl) Replace(spec ExecSpec) error {
+	argv, env := n.replaceCmd(spec)
+	return execHandover(n.bin, argv, env)
+}
+
+// Attach runs the same handover as a child instead of replacing brig, for the
+// --json path. It builds from replaceCmd, exactly as Replace does, so the two
+// carry the same argv and env.
+func (n *nerdctl) Attach(spec ExecSpec) (int, error) {
+	argv, env := n.replaceCmd(spec)
+	return attachHandover(argv, env)
 }
 
 func (n *nerdctl) Stop(name string) error { return n.quiet("stop", name) }

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -256,6 +256,17 @@ type Runtime interface {
 	// success. This is how the agent's own TUI gets a real tty without brig
 	// sitting in the middle of it.
 	Replace(spec ExecSpec) error
+	// Attach runs the exec as a child of brig instead of replacing brig with
+	// it: brig's own stdin, stdout and stderr are inherited, brig waits, and the
+	// child's exit status is returned. A child killed by a signal is reported as
+	// 128 plus the signal number, the shell's convention.
+	//
+	// It is the counterpart to Replace for a caller that has to survive the exec
+	// to report on it -- which is what --json needs and Replace, having left
+	// nothing of brig behind, cannot do. Both build their command from the same
+	// function, so the terminal handover and the child cannot drift. See
+	// RunAttached and the note on Replace.
+	Attach(spec ExecSpec) (int, error)
 	// Stop stops a sandbox, and Remove clears the instance holding the name.
 	Stop(name string) error
 	Remove(name string) error

--- a/internal/wrap/infojson.go
+++ b/internal/wrap/infojson.go
@@ -1,0 +1,272 @@
+package wrap
+
+import (
+	"strings"
+
+	"github.com/brig-sh/brig/internal/creds"
+	"github.com/brig-sh/brig/internal/profile"
+	"github.com/brig-sh/brig/internal/runtime"
+	"github.com/brig-sh/brig/internal/verify"
+)
+
+// InfoData is `brig info` as data: the same facts (*Config).envelope and
+// (*Config).Status assemble for the text report, gathered once here so the two
+// forms cannot come to disagree about what a sandbox would receive. It is the
+// payload behind the Info kind of the shared JSON envelope.
+//
+// It is read from the same Config, creds.Set and resolved secrets the text
+// report reads -- not re-derived -- so a row added there and a field added here
+// stay in step. The one promise this shares with every other --json shape is
+// the one jsonout.go states: a credential is named and sourced, never valued,
+// not here and not in an error string. listSecrets below reads provenance
+// without decrypting, the same no-value read the text report makes.
+//
+// A method beside envelope and Status rather than a second gather, so the JSON
+// and the text say the same thing for the same reason the block and the report
+// already do.
+func (c *Config) InfoData(set creds.Set) InfoDocument {
+	d := InfoDocument{
+		Session:     c.RawName,
+		Profile:     c.Profile.Name,
+		Sandbox:     c.VMName,
+		Runtime:     c.infoRuntime(),
+		Isolation:   c.isolationLine(),
+		Workspace:   c.Workspace,
+		Image:       InfoImage{Ref: c.Image, Pull: c.Pull},
+		Verify:      c.infoVerify(),
+		Network:     c.Network.Line(),
+		Credentials: c.infoCredentials(set),
+		Git:         c.infoGit(),
+		ArgvExposed: runtime.ArgvExposed(set.Vars),
+	}
+	if c.Project != "" {
+		d.Project = &InfoProject{Host: c.Project, Guest: c.GuestProject}
+	}
+	if len(c.Profile.Deny) > 0 {
+		d.Deny = c.infoDeny(set)
+	}
+	d.GuestLogin = c.infoGuestLogin(set)
+	if c.GitIdentity {
+		d.Identity = &InfoIdentity{Cwd: c.Cwd, Name: c.GitName, Email: c.GitEmail}
+	}
+	return d
+}
+
+// InfoDocument is the Info payload. Every field is a fact the text report
+// already prints; none carries a credential value.
+type InfoDocument struct {
+	Session     string           `json:"session,omitempty"`
+	Profile     string           `json:"profile"`
+	Sandbox     string           `json:"sandbox"`
+	Runtime     InfoRuntime      `json:"runtime"`
+	Isolation   string           `json:"isolation"`
+	Workspace   string           `json:"workspace"`
+	Project     *InfoProject     `json:"project,omitempty"`
+	Image       InfoImage        `json:"image"`
+	Verify      InfoVerify       `json:"verify"`
+	Network     string           `json:"network"`
+	Credentials []InfoCredential `json:"credentials"`
+	Deny        *InfoDeny        `json:"deny,omitempty"`
+	Git         InfoGit          `json:"git"`
+	// ArgvExposed is the values BRIG_ENV_ARGV would put on the runtime's command
+	// line, by name. Empty -- and omitted -- when the hatch is off, which is the
+	// default. The names are variable names, never values.
+	ArgvExposed []string         `json:"argvExposed,omitempty"`
+	GuestLogin  []InfoGuestLogin `json:"guestLogin,omitempty"`
+	Identity    *InfoIdentity    `json:"identity,omitempty"`
+}
+
+// InfoRuntime is the runtime this run resolved to, and whether it is there at
+// all. Available is false with Kind and Bin empty when no runtime is on PATH:
+// `brig info` answers without one and marks the line unavailable rather than
+// failing, so --json must carry the same complete object.
+type InfoRuntime struct {
+	Kind      string `json:"kind,omitempty"`
+	Bin       string `json:"bin,omitempty"`
+	Available bool   `json:"available"`
+}
+
+// InfoImage is the guest image and the pull policy, the pair the IMAGE row
+// prints.
+type InfoImage struct {
+	Ref  string `json:"ref"`
+	Pull string `json:"pull"`
+}
+
+// InfoVerify is whether the image is checked before boot and whose policy says
+// so: the mode (off, warn, require) and "brig" for brig's own policy or
+// "replaced" for one the BRIG_VERIFY_* variables overrode. The outcome is not
+// here -- `brig info` reports before any boot, so there is nothing verified yet
+// to report, the same reason the VERIFY row prints the mode and not the result.
+type InfoVerify struct {
+	Mode   string `json:"mode"`
+	Policy string `json:"policy"`
+}
+
+// InfoProject is the second host directory a run mounts beside the guest home,
+// and where it lands in the guest. Absent -- and omitted -- on a run that named
+// no project.
+type InfoProject struct {
+	Host  string `json:"host"`
+	Guest string `json:"guest"`
+}
+
+// InfoCredential is one credential this run hands the guest: its name, and
+// where the value came from ("environment", "host", "secret" or "file"). Never
+// the value.
+type InfoCredential struct {
+	Name   string `json:"name"`
+	Source string `json:"source,omitempty"`
+}
+
+// InfoDeny is what the denylist did to this run, rather than the list recited:
+// which of the denied names are being forwarded anyway (with the guard off),
+// which are still withheld, and whether the guard is off at all. The same
+// answer reportDeny gives, because the list on its own is a claim about the
+// future that BRIG_ALLOW_DENIED can make false.
+type InfoDeny struct {
+	Off       bool     `json:"off"`
+	Forwarded []string `json:"forwarded,omitempty"`
+	Withheld  []string `json:"withheld,omitempty"`
+}
+
+// InfoGit is the guest git-over-HTTPS setup: on or off, and when on, the user
+// and the hosts it is written for.
+type InfoGit struct {
+	Enabled bool     `json:"enabled"`
+	User    string   `json:"user,omitempty"`
+	Hosts   []string `json:"hosts,omitempty"`
+}
+
+// InfoIdentity is the guest commit identity as resolved in the invoking
+// directory, which per-directory includeIf rules make a property of where the
+// command ran. Names and an email, never a signing key.
+type InfoIdentity struct {
+	Cwd   string `json:"cwd"`
+	Name  string `json:"name,omitempty"`
+	Email string `json:"email,omitempty"`
+}
+
+// InfoGuestLogin is where the guest's login comes from and whether it is still
+// good: a name and a source, and Expired when its own expiry has passed. Built
+// from provenance the store carries without decrypting, so it is a fact about
+// where a credential came from and never the credential.
+type InfoGuestLogin struct {
+	Name    string `json:"name,omitempty"`
+	Source  string `json:"source,omitempty"`
+	Expired bool   `json:"expired,omitempty"`
+}
+
+// infoRuntime is the InfoRuntime for this run, unavailable when no runtime is
+// on PATH -- the case ErrNoRuntime is swallowed for info, which --json must not
+// undo.
+func (c *Config) infoRuntime() InfoRuntime {
+	if c.Runtime == nil {
+		return InfoRuntime{Available: false}
+	}
+	return InfoRuntime{Kind: c.Runtime.Kind(), Bin: c.Runtime.Bin(), Available: true}
+}
+
+// infoVerify is the InfoVerify for this run. The policy word is the same
+// distinction verifyLine draws in prose: off, a replaced trust policy, or
+// brig's own.
+func (c *Config) infoVerify() InfoVerify {
+	policy := "brig"
+	switch {
+	case c.Verify == verify.Off:
+		policy = "off"
+	case c.VerifyPolicy.Replaced():
+		policy = "replaced"
+	}
+	return InfoVerify{Mode: string(c.Verify), Policy: policy}
+}
+
+// infoCredentials is every credential this run hands the guest, by name and
+// source, the two ways credentialLine names -- an environment variable and a
+// file written into a tmpfs -- gathered from the same structures. Only the
+// presence of a value is read, never the value.
+func (c *Config) infoCredentials(set creds.Set) []InfoCredential {
+	var out []InfoCredential
+	for _, n := range credentialNames(set) {
+		name, source := splitCredentialName(n)
+		out = append(out, InfoCredential{Name: name, Source: source})
+	}
+	for _, b := range c.Profile.Files {
+		// An unreadable ref names no credential, so it is left out rather than
+		// reported -- the same under-report credentialLine makes, and safe for the
+		// same reason: writeSecretFiles would fail the run on it.
+		r, err := profile.ParseRef(b.Ref)
+		if err != nil {
+			continue
+		}
+		if _, ok := c.secrets.Values[r.Name]; ok {
+			out = append(out, InfoCredential{Name: r.Name, Source: "file"})
+		}
+	}
+	return out
+}
+
+// splitCredentialName reads "NAME(source)" into its two parts, the annotation
+// Set carries. A bare name has no annotation, which is the ambient environment,
+// named as such so the source is a word rather than a gap.
+func splitCredentialName(s string) (name, source string) {
+	if i := strings.LastIndex(s, "("); i > 0 && strings.HasSuffix(s, ")") {
+		return strings.TrimRight(s[:i], " "), s[i+1 : len(s)-1]
+	}
+	return s, "environment"
+}
+
+// infoDeny is the InfoDeny for this run, computed from the resolved set the way
+// reportDeny is: what was admitted, what is withheld, and whether the guard is
+// off.
+func (c *Config) infoDeny(set creds.Set) *InfoDeny {
+	d := &InfoDeny{Off: c.AllowDenied}
+	for _, name := range c.Profile.Deny {
+		if set.Has(name) {
+			d.Forwarded = append(d.Forwarded, name)
+			continue
+		}
+		d.Withheld = append(d.Withheld, name)
+	}
+	return d
+}
+
+// infoGit is the InfoGit for this run, the same on/off and, when on, the user
+// and hosts the GitConfig block prints.
+func (c *Config) infoGit() InfoGit {
+	if !c.GitConfig {
+		return InfoGit{Enabled: false}
+	}
+	return InfoGit{Enabled: true, User: c.GitUser, Hosts: c.GitHosts}
+}
+
+// infoGuestLogin is where the guest's login comes from, from the same two
+// sources status.go reads: the deprecated Profile.HostCredential, and imported
+// secrets' provenance. Both read without decrypting a value.
+func (c *Config) infoGuestLogin(set creds.Set) []InfoGuestLogin {
+	var out []InfoGuestLogin
+	if hc := c.Profile.HostCredential; hc != nil {
+		source, forwarded := sourceOf(credentialNames(set), hc.TargetVar)
+		switch {
+		case forwarded && source == "secret":
+			out = append(out, InfoGuestLogin{Name: hc.TargetVar, Source: "secret"})
+		case forwarded && source == "":
+			out = append(out, InfoGuestLogin{Name: hc.TargetVar, Source: "environment"})
+		case c.HostCred != nil && c.HostCred.Expired(nowMilli()):
+			out = append(out, InfoGuestLogin{Name: hc.TargetVar, Source: c.HostCred.Source, Expired: true})
+		case c.HostCred != nil:
+			out = append(out, InfoGuestLogin{Name: hc.TargetVar, Source: c.HostCred.Source})
+		}
+	}
+	if secrets, ok := c.listSecrets(); ok {
+		for _, decl := range c.Profile.Secrets {
+			s, found := secrets[decl.Name]
+			if !found || s.Provenance.From == "" {
+				continue
+			}
+			expired := s.Provenance.ExpiresAt != 0 && s.Provenance.ExpiresAt < nowMilli()
+			out = append(out, InfoGuestLogin{Name: s.Name, Source: s.Provenance.From, Expired: expired})
+		}
+	}
+	return out
+}

--- a/internal/wrap/infojson_test.go
+++ b/internal/wrap/infojson_test.go
@@ -1,0 +1,88 @@
+package wrap
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/brig-sh/brig/internal/creds"
+)
+
+// InfoData is the Info payload, and the one thing it must never do is carry a
+// value. #7 calls this the defect if it fails: a machine-readable dump is one
+// more place a credential can leak, and this asserts it does not -- from the
+// resolved store values a run holds and from the reporting names, the two
+// places a value could get in.
+func TestInfoDataNamesCredentialsNeverValues(t *testing.T) {
+	// A profile that delivers a stored secret as a file, so the file half of the
+	// credential list has something to name.
+	c := bindingConfig(t, "secrets:\n  - tok\n"+
+		"volumes:\n  - kind: tmpfs\n    path: .config\n"+
+		"files:\n  - ref: secrets.tok\n    path: .config/cred\n    mode: \"0600\"\n")
+	c.Runtime = nil // as `brig info` runs it with no runtime on PATH
+
+	const planted = "PLANTED-TOKEN-VALUE"
+	// The value a run resolved, kept on the Config exactly as BuildEnv leaves it
+	// for the file-delivery step to read.
+	c.secrets = creds.Resolution{Values: map[string]string{"tok": planted}}
+	// And an environment-sourced credential, annotated the way creds.Set does.
+	set := creds.Set{Names: []string{"CLAUDE_TOKEN(secret)"}}
+
+	d := c.InfoData(set)
+
+	blob, err := json.Marshal(d)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(blob), planted) {
+		t.Fatalf("info --json leaked a credential value:\n%s", blob)
+	}
+
+	// The names and sources are there, which is the point of the row: the value
+	// is gone, the fact that there is one is not.
+	var gotEnv, gotFile bool
+	for _, cr := range d.Credentials {
+		switch cr.Name {
+		case "CLAUDE_TOKEN":
+			gotEnv = cr.Source == "secret"
+		case "tok":
+			gotFile = cr.Source == "file"
+		}
+	}
+	if !gotEnv {
+		t.Errorf("the env credential is not named with its source: %+v", d.Credentials)
+	}
+	if !gotFile {
+		t.Errorf("the file credential is not named with its source: %+v", d.Credentials)
+	}
+}
+
+// With no runtime on PATH, `brig info --json` still prints a complete object and
+// exits 0 -- ErrNoRuntime is swallowed for info, and --json must not undo that.
+// The runtime is marked unavailable rather than the object being cut short.
+func TestInfoDataWithoutRuntimeIsComplete(t *testing.T) {
+	c := bindingConfig(t, "")
+	c.Runtime = nil
+
+	d := c.InfoData(creds.Set{})
+
+	if d.Runtime.Available {
+		t.Error("the runtime is marked available with none on PATH")
+	}
+	if d.Runtime.Kind != "" || d.Runtime.Bin != "" {
+		t.Errorf("an unavailable runtime still names a kind or bin: %+v", d.Runtime)
+	}
+	// The rest of the object is there: a report that dropped its own fields
+	// because one line could not be filled is the failure this guards.
+	for name, got := range map[string]string{
+		"profile":   d.Profile,
+		"sandbox":   d.Sandbox,
+		"workspace": d.Workspace,
+		"isolation": d.Isolation,
+		"network":   d.Network,
+	} {
+		if got == "" {
+			t.Errorf("info --json without a runtime left %s empty", name)
+		}
+	}
+}

--- a/internal/wrap/run.go
+++ b/internal/wrap/run.go
@@ -635,10 +635,11 @@ func (c *Config) Remove() error {
 	return err
 }
 
-// Exec hands the terminal to a command inside the sandbox. It does not return
-// on success.
-func (c *Config) Exec(set creds.Set, argv []string, tty bool) error {
-	return c.Runtime.Replace(runtime.ExecSpec{
+// execSpec is the one request Exec and ExecAttached both hand the runtime, so
+// the terminal handover and the --json child are the same exec asked for two
+// ways rather than two specs that can disagree.
+func (c *Config) execSpec(set creds.Set, argv []string, tty bool) runtime.ExecSpec {
+	return runtime.ExecSpec{
 		Name: c.VMName,
 		Cmd:  argv,
 		Cwd:  c.GuestCwd,
@@ -651,19 +652,46 @@ func (c *Config) Exec(set creds.Set, argv []string, tty bool) error {
 		CanAsk:  IsTerminal(os.Stdin),
 		Env:     set.Vars,
 		Counted: true,
-	})
+	}
 }
 
-// Shell opens a login shell in the sandbox, or runs one command in it.
+// Exec hands the terminal to a command inside the sandbox. It does not return
+// on success.
+func (c *Config) Exec(set creds.Set, argv []string, tty bool) error {
+	return c.Runtime.Replace(c.execSpec(set, argv, tty))
+}
+
+// ExecAttached runs the command as a child of brig rather than replacing brig
+// with it, and returns the command's exit status. It is the --json counterpart
+// of Exec: brig stays alive across the exec so it can report the outcome, which
+// Replace cannot. The spec is Exec's own, so the child inherits everything the
+// handover would have carried.
+func (c *Config) ExecAttached(set creds.Set, argv []string, tty bool) (int, error) {
+	return c.Runtime.Attach(c.execSpec(set, argv, tty))
+}
+
+// shellArgv is the login-shell command line, built once so Shell and
+// ShellAttached spell it the same way.
 //
 // The trailing words are joined into a single string before the shell sees
 // them, so they land as one argument -- the script text for -c -- rather than
 // one per word. Passed individually, bash takes the first as the script and
 // the rest as $0, $1, ...
-func (c *Config) Shell(set creds.Set, command []string) error {
-	argv := []string{"bash", "-l"}
+func shellArgv(command []string) []string {
 	if len(command) > 0 {
-		argv = []string{"bash", "-lc", strings.Join(command, " ")}
+		return []string{"bash", "-lc", strings.Join(command, " ")}
 	}
-	return c.Exec(set, argv, true)
+	return []string{"bash", "-l"}
+}
+
+// Shell opens a login shell in the sandbox, or runs one command in it.
+func (c *Config) Shell(set creds.Set, command []string) error {
+	return c.Exec(set, shellArgv(command), true)
+}
+
+// ShellAttached is Shell down the child path, so a shell profile under --json
+// behaves like an agent one: brig runs it as a child and reports its exit
+// status rather than replacing itself with it.
+func (c *Config) ShellAttached(set creds.Set, command []string) (int, error) {
+	return c.ExecAttached(set, shellArgv(command), true)
 }

--- a/script/smoke.sh
+++ b/script/smoke.sh
@@ -844,6 +844,20 @@ esac
   && ok "ls -q prints the ref and nothing else" \
   || bad "ls -q prints the ref and nothing else -- got: $(cat "$WORK/refs.out")"
 
+# `brig --json ls` is the machine-readable listing: it parses, and it carries
+# the SandboxList kind of the shared JSON envelope. The global position is the
+# one the help text teaches, so it is the one the smoke asserts.
+"$WORK/brig" --json ls > "$WORK/ls.json" 2>/dev/null
+if command -v python3 >/dev/null 2>&1; then
+  python3 -c 'import json,sys; json.load(open(sys.argv[1]))' "$WORK/ls.json" 2>/dev/null \
+    && ok "brig --json ls is valid JSON" \
+    || bad "brig --json ls is not valid JSON -- got: $(cat "$WORK/ls.json")"
+fi
+case "$(cat "$WORK/ls.json")" in
+  *'"kind": "SandboxList"'*) ok "brig --json ls carries kind SandboxList" ;;
+  *) bad "brig --json ls carries kind SandboxList -- got: $(cat "$WORK/ls.json")" ;;
+esac
+
 # The round trip, against the real binary: every ref the listing prints is a
 # word every verb takes.
 #

--- a/script/smoke.sh
+++ b/script/smoke.sh
@@ -153,7 +153,13 @@ case "$verb" in
           printf '1 1 0:2 / %s rw - fuseblk\n' "$target" >> "$STUB_STATE.mounts"
         fi
         ;;
-      *) printf 'env-token:%s\n' "${CLAUDE_CODE_OAUTH_TOKEN:-<unset>}" >> "$STUB_LOG" ;;
+      *)
+        printf 'env-token:%s\n' "${CLAUDE_CODE_OAUTH_TOKEN:-<unset>}" >> "$STUB_LOG"
+        # The agent (or login shell) exec. STUB_EXEC_EXIT makes it exit non-zero,
+        # which is how the --json case drives the child path: brig runs this as a
+        # child rather than replacing itself, so it survives to report the status.
+        [ -n "${STUB_EXEC_EXIT:-}" ] && exit "$STUB_EXEC_EXIT"
+        ;;
     esac
     ;;
   stop)
@@ -1831,6 +1837,34 @@ grep -q -- "-v is one of brig's own flags" "$WORK/agentv.err" \
 "$WORK/brig" ls -q > "$WORK/lsq.out" 2>&1
 [ "$(cat "$WORK/lsq.out")" = claude-code ] \
   && ok "ls -q is unchanged" || bad "ls -q is unchanged -- got: $(cat "$WORK/lsq.out")"
+
+echo "== run --json =="
+# --json runs the agent as a child instead of replacing brig with it, so brig
+# survives the exec and reports the outcome on one JSON line. The stub's exec
+# exits 7; brig exits 7 too, with that status carried on a parseable last line --
+# which is how a script tells "the agent failed" from "brig refused to start it".
+"$WORK/brig" rm --all > /dev/null 2>&1
+STUB_EXEC_EXIT=7 "$WORK/brig" --json run ubuntu -- true \
+  > "$WORK/json.out" 2> "$WORK/json.err"
+rc=$?
+[ "$rc" = 7 ] && ok "brig --json run exits with the agent's own status" \
+  || bad "brig --json run exits with the agent's own status -- got $rc: $(cat "$WORK/json.err")"
+# The rule a script follows: the last line of stdout is brig's, and it parses.
+last="$(tail -n1 "$WORK/json.out")"
+if command -v python3 >/dev/null 2>&1; then
+  python3 -c 'import json,sys
+d = json.loads(sys.argv[1])
+assert d["kind"] == "Run", d
+assert d["data"]["stage"] == "agent", d
+assert d["data"]["exit"] == 7, d' "$last" 2>/dev/null \
+    && ok "the last stdout line is a Run object with stage agent and exit 7" \
+    || bad "the last stdout line is not the expected Run object -- got: $last"
+fi
+case "$last" in
+  *'"kind":"Run"'*) ok "brig --json run prints a compact Run object" ;;
+  *) bad "brig --json run prints a compact Run object -- got: $last" ;;
+esac
+"$WORK/brig" rm --all > /dev/null 2>&1
 
 echo "== doctor =="
 # brig doctor reports the prerequisites a first run hits, in boot order. On the


### PR DESCRIPTION
Every list command printed aligned text, so a script parsed column positions and any change to the text broke it.

`--json` is now a global flag, left of the verb, and the read verbs also take it right after the verb since that is what people type. It works on `ls`, `info`, `agent ls`, `secret ls` and `doctor`. A verb with no JSON form refuses it with exit 2 and names the verbs that have one; #110 lifts that for `run` next.

All five use the envelope #9 introduced in `jsonout.go`: `{apiVersion, kind, data}`. The rule between the two JSON shapes brig now has is written beside the constants: a document verb (`agent show`, `agent export`, `agent new`, `policy show`) prints the bare document because the output is a file; a list or report verb prints the envelope. The four document verbs are unchanged.

Shapes, all through `writeJSONDocument`:

- `SandboxList`: `data.runtime` once, `data.sandboxes` as `{ref, agent, label, sandbox, state, workspace}`. #7's example put `image` per row; it is not in hand for a listing and would need every profile loaded, so `info` carries it instead.
- `Info`: built from the same data `envelope` and `Status` already assemble, through a new data form in `internal/wrap/infojson.go`. Credentials are name and source only, never a value; the test seeds a known value and asserts it never appears. With no runtime on PATH it still exits 0 with `runtime: {available: false}`, keeping #43.
- `AgentList`, `SecretList`: the fields the text output already has. An empty store is `data: []`, not the prose hint.
- `Doctor`: the verb's own `--json` and the global one set the same bool.

The global-position test that asserted `--json` was refused is rewritten to assert it is accepted, with `--nope` and `-y` still refused. The `ls -q` round-trip property is extended to `ls --json`: every ref it prints is accepted by every verb.

One nit left for review: `info`'s `credentials` is `null` rather than `[]` when nothing is forwarded.

Stacked on #140 for the `jsonout.go` constants; GitHub retargets to `main` when that merges.

Checked on a build of this branch: every shape above, both flag positions, `-q --json`, the three refusals, and `info --json` with hull off PATH. Tested with `go vet ./...`, `go test -race ./...` and `./script/smoke.sh`, which has one new case.

Fixes: #7