### PR TITLE
feat(run): run the agent as a child under --json

### DIFF
--- a/cmd/brig/exit.go
+++ b/cmd/brig/exit.go
@@ -28,12 +28,29 @@ const (
 	exitCredentials = 6
 )
 
+// agentExit carries the agent's own exit status up to main, so brig returns
+// exactly what the agent returned under --json. It is not a failure of brig's:
+// the Run object has already been printed and the agent's output has already
+// gone to the inherited streams, so main neither prints nor decorates it -- it
+// reads the code off here and exits with it. Error is empty for that reason;
+// nothing prints it.
+type agentExit struct{ code int }
+
+func (e *agentExit) Error() string { return "" }
+
 // exitCode reads the exit status for a finished run out of its error. It reads
 // the cause rather than the message, so a wrapped error keeps its class the
 // whole way up the stack, and the order is most specific first.
 func exitCode(err error) int {
 	if err == nil {
 		return exitOK
+	}
+	// The agent's own status, when the agent ran under --json. Read first: it is
+	// the one error whose code is not a class of brig's but a number brig is
+	// passing through unchanged.
+	var ae *agentExit
+	if errors.As(err, &ae) {
+		return ae.code
 	}
 	var ue *usageError
 	if errors.As(err, &ue) {

--- a/cmd/brig/jsonout.go
+++ b/cmd/brig/jsonout.go
@@ -65,3 +65,16 @@ func writeJSONDocument(w io.Writer, kind string, data any) error {
 	enc.SetIndent("", "  ")
 	return enc.Encode(jsonDocument{APIVersion: jsonAPIVersion, Kind: kind, Data: data})
 }
+
+// writeJSONLine encodes one payload as a jsonDocument on a single line, the
+// deliberate opposite of writeJSONDocument's indentation.
+//
+// #110's Run object is printed to stdout after the agent's own inherited output,
+// so a script's rule for finding it is "the last line of stdout is brig's". An
+// indented object spanning many lines would break that rule, and there is no
+// person reading a run's stdout for whom the indentation was ever the point --
+// the agent already wrote there. Same envelope, same fields; only the framing
+// differs, so a consumer parses it exactly as it parses the read verbs.
+func writeJSONLine(w io.Writer, kind string, data any) error {
+	return json.NewEncoder(w).Encode(jsonDocument{APIVersion: jsonAPIVersion, Kind: kind, Data: data})
+}

--- a/cmd/brig/jsonout_test.go
+++ b/cmd/brig/jsonout_test.go
@@ -262,11 +262,12 @@ func TestJSONPositionsAndRefusals(t *testing.T) {
 
 	// Refused, both positions, on the verbs with no JSON form. Exit 2, and the
 	// message names a verb that does have one so the reader can move the flag.
+	// run and sh are NOT here since #110: --json runs the agent as a child and
+	// prints a Run object, so it is accepted rather than refused -- see
+	// run_json_test.go.
 	refuse := [][]string{
 		{"--json", "stop", "claude"}, {"stop", "claude", "--json"},
 		{"--json", "rm", "claude"}, {"rm", "claude", "--json"},
-		{"--json", "run", "claude"}, {"run", "claude", "--json"},
-		{"--json", "sh", "claude"}, {"sh", "claude", "--json"},
 	}
 	for _, args := range refuse {
 		scratchHost(t)

--- a/cmd/brig/main.go
+++ b/cmd/brig/main.go
@@ -19,6 +19,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"syscall"
 
 	"github.com/brig-sh/brig/internal/creds"
 	"github.com/brig-sh/brig/internal/profile"
@@ -85,6 +86,9 @@ global flags (left of the command, as in: brig -q run claude):
       --json             machine-readable output, for the read verbs: ls, info,
                          agent ls, secret ls and doctor. Also accepted after the
                          verb (brig ls --json). Every other verb refuses it
+      --json (with run)  run the agent as a child and, after it exits, print one
+                         JSON line with its exit status -- so a script can tell
+                         "brig refused" from "the agent failed"
 Within one apiVersion the JSON only ever gains fields, never renames or drops
 one, and no field carries a credential value -- so a script written against it
 keeps parsing, and a machine-readable dump stays a place a secret cannot leak.
@@ -136,16 +140,55 @@ settings (BRIG_<AGENT>_<KEY> wins over BRIG_<KEY>; see the README for all):
 `
 
 func main() {
-	if err := run(os.Args[1:]); err != nil {
-		fmt.Fprintln(os.Stderr, "brig: "+err.Error())
-		// The exit status is a stable, documented set: a script can tell "you
-		// asked for the wrong thing" from "it ran and failed" from "the sandbox
-		// could not be verified" without parsing the message. exitCode owns the
-		// mapping; the README documents it. A run refused for any reason still
-		// exits non-zero, so a stop or a boot that removed or started nothing
-		// never reads as success.
-		os.Exit(exitCode(err))
+	err := run(os.Args[1:])
+	if err == nil {
+		return
 	}
+	// The agent ran under --json: its own exit status is brig's, its output has
+	// already gone to the inherited streams, and runAgent has already printed the
+	// one-line Run object. brig adds nothing -- no "brig:" line, no second object
+	// -- it just returns what the agent returned.
+	var ae *agentExit
+	if errors.As(err, &ae) {
+		os.Exit(ae.code)
+	}
+	fmt.Fprintln(os.Stderr, "brig: "+err.Error())
+	// The exit status is a stable, documented set: a script can tell "you
+	// asked for the wrong thing" from "it ran and failed" from "the sandbox
+	// could not be verified" without parsing the message. exitCode owns the
+	// mapping; the README documents it. A run refused for any reason still
+	// exits non-zero, so a stop or a boot that removed or started nothing
+	// never reads as success.
+	os.Exit(exitCode(err))
+}
+
+// run is the entry point dispatch is wrapped in, so the --json run/sh path has
+// one place to print its Run object when brig refuses.
+//
+// A refusal -- an unknown agent, a boot that would not come up -- returns from
+// deep inside dispatch as an ordinary error, at a depth that knows nothing about
+// --json. The success and detach paths print their own object, where the exit
+// status and the sandbox name are known; this catches the other half, so every
+// --json run ends in exactly one Run line whether the agent started or not. The
+// object carries stage "brig" and the reason, and brig's exit is the class the
+// error maps to -- the object is what tells "brig refused" from "the agent
+// exited non-zero", not the number.
+//
+// jsonRun is nil unless this invocation is a --json run or sh, so an ordinary
+// command's errors are untouched.
+func run(args []string) error {
+	jsonRun = nil
+	err := dispatch(args)
+	if err == nil || jsonRun == nil {
+		return err
+	}
+	var ae *agentExit
+	if errors.As(err, &ae) {
+		// The agent ran; its object is already printed. Leave it to main.
+		return err
+	}
+	_ = writeRunObject("brig", exitCode(err), err.Error(), "")
+	return err
 }
 
 // usageError is a command that was typed wrong: an unknown flag, a stray
@@ -169,7 +212,7 @@ func (e *notFoundError) Error() string { return e.msg }
 // notFoundf builds a notFoundError the way fmt.Errorf builds an ordinary one.
 func notFoundf(format string, a ...any) error { return &notFoundError{fmt.Sprintf(format, a...)} }
 
-func run(args []string) error {
+func dispatch(args []string) error {
 	// The global position first, so a flag written left of the verb is named
 	// rather than read as a command.
 	g, verbLine, err := parseGlobal(args)
@@ -362,17 +405,37 @@ func run(args []string) error {
 		verb, rest = "run", verbLine
 	}
 
+	// The Run object has to be there for a refusal that happens inside parse
+	// too -- a ref that will not parse is the common one -- so the context is
+	// made before parse, off the token the reader typed, and refreshed below
+	// with the resolved ref once parse has one. Without this a typo in the ref
+	// left stdout empty under --json, and a script's rule that the last line
+	// of stdout is brig's held for every refusal but that one.
+	if verb == "run" || verb == "sh" {
+		if wantJSON, operand := peekRunLine(rest); globalJSON || wantJSON {
+			jsonRun = &jsonRunContext{ref: operand}
+		}
+	}
 	opts, profileName, tail, err := parse(verb, rest)
 	if err != nil {
 		return err
 	}
-	// --json on a run-line verb. info answers it; every other verb here has no
-	// JSON form and refuses it by name. The global position was already refused
-	// above for those verbs; this catches `brig run claude --json`, where --json
-	// is brig's own token rather than the agent's, so it is named rather than
-	// forwarded. Both spellings fold into one decision.
+	// --json on a run-line verb. info and env answer it with a report; run and
+	// sh answer it by running the agent as a child and printing a Run object
+	// after it (see #110 and runAgent); every other verb here has no JSON form
+	// and refuses it by name. The global position was already refused above for
+	// the verbs that have none; this catches `brig run claude --json`, where
+	// --json is brig's own token rather than the agent's, so it is named rather
+	// than forwarded. Both spellings fold into one decision.
 	wantJSON := globalJSON || opts.json
-	if wantJSON && verb != "info" && verb != "env" {
+	switch {
+	case !wantJSON:
+	case verb == "info" || verb == "env":
+	case verb == "run" || verb == "sh":
+		// The state main needs to print the Run object once dispatch returns. The
+		// sandbox name is not known until Load below; the ref is what was typed.
+		jsonRun = &jsonRunContext{ref: refDisplay(profileName, opts)}
+	default:
 		return jsonUnsupportedf(verb)
 	}
 	// Both at once asks for two contradictory things, and either winner would
@@ -417,7 +480,7 @@ func run(args []string) error {
 			"%s explains how to build one", t.Name, verb, t.Name, profile.BringYourOwnImageDoc)
 	}
 
-	rt, err := runtime.DetectFor(runtime.Preference{Bin: t.RuntimeBin})
+	rt, err := detectRuntimeFor(runtime.Preference{Bin: t.RuntimeBin})
 	if err != nil {
 		// brig info is the report worth giving when the runtime is the thing
 		// that is broken: only one of its lines comes from the runtime, and the
@@ -451,6 +514,12 @@ func run(args []string) error {
 	// sandbox is refused later, at EnsureRunning; this only names the directory.
 	if cfg.RawName != "" && cfg.RawName != cfg.Slug {
 		warnf("session %q uses %s (sandbox %s)", cfg.RawName, cfg.Workspace, cfg.VMName)
+	}
+	// The sandbox name for the Run object, now that Load has resolved it. A
+	// refusal before this point (an unknown agent) prints the object with the
+	// name still empty, which is honest: no sandbox was named yet.
+	if jsonRun != nil {
+		jsonRun.sandbox = cfg.VMName
 	}
 
 	// Stopping and removing need nothing but the instance name, and are
@@ -521,6 +590,16 @@ func run(args []string) error {
 		if err := cfg.EnsureRunning(set); err != nil {
 			return err
 		}
+		// Under --json, down the child path so brig survives the shell and reports
+		// its exit status on a Run line, the same handover an agent gets. Only sh
+		// reaches here with jsonRun set -- shell is refused above.
+		if jsonRun != nil {
+			code, err := cfg.ShellAttached(set, tail)
+			if err != nil {
+				return err
+			}
+			return emitAgentRun(code)
+		}
 		return cfg.Shell(set, tail)
 	case "exec":
 		if len(tail) == 0 {
@@ -531,7 +610,7 @@ func run(args []string) error {
 		}
 		return cfg.Exec(set, tail, isTerminal())
 	}
-	return runAgent(cfg, set, t, tail, opts.detach)
+	return runAgent(cfg, set, t, tail, opts.detach, jsonRun != nil)
 }
 
 // showsEnvelope reports whether this invocation prints the execution envelope
@@ -549,7 +628,7 @@ func showsEnvelope(verb string, v wrap.Verbosity) bool {
 	return false
 }
 
-func runAgent(cfg *wrap.Config, set creds.Set, t profile.Profile, tail []string, detach bool) error {
+func runAgent(cfg *wrap.Config, set creds.Set, t profile.Profile, tail []string, detach, wantJSON bool) error {
 	// A windowed agent owns its own console, so there is nothing to pass
 	// through and nothing to exec into: starting it IS the command.
 	if t.IsGUI() && len(tail) > 0 {
@@ -559,21 +638,49 @@ func runAgent(cfg *wrap.Config, set creds.Set, t profile.Profile, tail []string,
 	if err := cfg.EnsureRunning(set); err != nil {
 		return err
 	}
+	// Each branch below has a --json form: the object stands in for the text it
+	// would otherwise print, because a script asked for one machine-readable line
+	// and a bare name or a warning beside it would be the noise --json exists to
+	// remove. stage says which branch spoke -- gui, detached, or the agent having
+	// run -- so the reader need not infer it from the exit status.
 	switch {
 	case t.IsGUI():
+		// The window is up; there is nothing to attach to.
+		if wantJSON {
+			_ = writeRunObject("gui", exitOK, "", "")
+			return nil
+		}
 		warnf("sandbox %s is running; the %s window should be visible.", cfg.VMName, t.GUITitle)
 		return nil
 	case detach:
 		// The sandbox is up and will stay up; print the name so a script can
 		// exec into it.
+		if wantJSON {
+			_ = writeRunObject("detached", exitOK, "", "")
+			return nil
+		}
 		fmt.Println(cfg.VMName)
 		return nil
 	case t.IsShell():
 		// The "agent" is the guest shell itself, so a bare run is a login
 		// shell and trailing words are one command.
+		if wantJSON {
+			code, err := cfg.ShellAttached(set, tail)
+			if err != nil {
+				return err
+			}
+			return emitAgentRun(code)
+		}
 		return cfg.Shell(set, tail)
 	}
 	argv := append([]string{t.Binary}, agentArgs(cfg, t, tail)...)
+	if wantJSON {
+		code, err := cfg.ExecAttached(set, argv, isTerminal())
+		if err != nil {
+			return err
+		}
+		return emitAgentRun(code)
+	}
 	return cfg.Exec(set, argv, isTerminal())
 }
 
@@ -2608,13 +2715,14 @@ var verbosity = wrap.Normal
 var globalJSON bool
 
 // verbTakesGlobalJSON reports whether the verb in the global position has a
-// --json form to ask for. The five read verbs do; agent and secret only in
-// their ls subcommand, which is the one that lists. Everything else -- run, sh,
-// stop, rm, and the verbs that manage rather than list -- has none, so --json
-// left of it is a usage error rather than a flag dropped on the floor.
+// --json form to ask for. The five read verbs do; run and sh do since #110,
+// where --json runs the agent as a child and prints its outcome; agent and
+// secret only in their ls subcommand, which is the one that lists. Everything
+// else -- stop, rm, and the verbs that manage rather than list -- has none, so
+// --json left of it is a usage error rather than a flag dropped on the floor.
 func verbTakesGlobalJSON(verb string, rest []string) bool {
 	switch verb {
-	case "ls", "info", "env", "doctor":
+	case "ls", "info", "env", "doctor", "run", "sh":
 		return true
 	case "agent", "secret":
 		return len(rest) > 0 && rest[0] == "ls"
@@ -2631,7 +2739,139 @@ func verbTakesGlobalJSON(verb string, rest []string) bool {
 func jsonUnsupportedf(verb string) error {
 	return usagef("`brig %s` has no --json output. --json is for the read verbs: "+
 		"ls, info, agent ls, secret ls, doctor (env takes it too, but env is "+
-		"deprecated; prefer info)", verb)
+		"deprecated; prefer info), and for run and sh", verb)
+}
+
+// jsonRun is the state the --json run/sh path needs to print its one-line Run
+// object. It is package state for the same reason globalJSON is: the object is
+// printed at the top of the call chain, and the values in it -- the ref, the
+// sandbox name -- become known at different depths of dispatch. nil means this
+// invocation is not a --json run, so run() prints nothing on the way out.
+var jsonRun *jsonRunContext
+
+// jsonRunContext carries the two fields every Run object names whatever its
+// stage: the ref that was typed and the sandbox it resolved to.
+type jsonRunContext struct {
+	ref     string
+	sandbox string
+}
+
+// detectRuntimeFor is the seam the run-line tests replace, so a test can drive a
+// full run against a fake runtime with none on PATH. Everything else calls
+// runtime.DetectFor. It is the run-line sibling of detectRuntime, which the read
+// verbs already use for the same reason.
+var detectRuntimeFor = runtime.DetectFor
+
+// runData is the payload of a Run object: what a --json run says about itself
+// once the agent has run, or once brig has refused to run it.
+//
+// error and signal are omitempty because each names a case that did not always
+// happen: error only on a brig refusal, signal only on an agent the kernel
+// killed. ref and sandbox are always present, so a consumer reads them
+// unconditionally. See #110 and the field rule in jsonout.go.
+type runData struct {
+	Ref     string `json:"ref"`
+	Sandbox string `json:"sandbox"`
+	Stage   string `json:"stage"`
+	Exit    int    `json:"exit"`
+	Error   string `json:"error,omitempty"`
+	Signal  string `json:"signal,omitempty"`
+}
+
+// writeRunObject prints one Run object to stdout, compact, on its own line. It
+// reads the ref and sandbox off jsonRun, so every caller names them the same way
+// and none has to thread them through.
+func writeRunObject(stage string, exit int, errMsg, signal string) error {
+	return writeJSONLine(os.Stdout, "Run", runData{
+		Ref:     jsonRun.ref,
+		Sandbox: jsonRun.sandbox,
+		Stage:   stage,
+		Exit:    exit,
+		Error:   errMsg,
+		Signal:  signal,
+	})
+}
+
+// emitAgentRun prints the Run object for an agent that ran and returns the
+// agentExit that carries its status up to main. stage is "agent"; the signal is
+// derived from the status, since a child the kernel killed comes back as 128
+// plus the signal number.
+func emitAgentRun(code int) error {
+	_ = writeRunObject("agent", code, "", signalName(code))
+	return &agentExit{code: code}
+}
+
+// refDisplay is the ref a Run object names: the agent, and the session label
+// when one was given. It is what the reader typed, reconstructed from the parsed
+// parts, so it reads back as a ref every verb takes.
+func refDisplay(agent string, o options) string {
+	if o.nameGiven && o.load.Name != "" {
+		return agent + "@" + o.load.Name
+	}
+	return agent
+}
+
+// peekRunLine reads a run line only as far as its first bare word: whether
+// --json stands among brig's own flags before the ref, and what that word is.
+// It exists because parse can refuse the ref before it has told anyone about
+// the flags left of it, and the Run object for that refusal still has to be
+// printed and still has to name what was typed. A flag that takes a value skips
+// the value, the way split does, so `--mem 4096` is not read as the ref.
+func peekRunLine(rest []string) (wantJSON bool, operand string) {
+	for i := 0; i < len(rest); i++ {
+		a := rest[i]
+		if a == "--" || !strings.HasPrefix(a, "-") {
+			if a != "--" {
+				operand = a
+			}
+			return wantJSON, operand
+		}
+		name, _, inline := strings.Cut(a, "=")
+		if name == "--json" {
+			wantJSON = true
+		}
+		if mine, takesValue := ours(name, posRun); mine && takesValue && !inline {
+			i++
+		}
+	}
+	return wantJSON, ""
+}
+
+// signalName maps a 128+n exit status back to the signal that produced it, for
+// the Run object's signal field. Empty for an ordinary exit -- a status at or
+// below 128 is the program's own -- so the field is present only when a signal
+// actually killed the agent. Only the signals a child is plausibly killed by are
+// named; an unrecognised one leaves the field empty rather than inventing a
+// name.
+func signalName(code int) string {
+	if code <= 128 {
+		return ""
+	}
+	switch syscall.Signal(code - 128) {
+	case syscall.SIGHUP:
+		return "SIGHUP"
+	case syscall.SIGINT:
+		return "SIGINT"
+	case syscall.SIGQUIT:
+		return "SIGQUIT"
+	case syscall.SIGILL:
+		return "SIGILL"
+	case syscall.SIGABRT:
+		return "SIGABRT"
+	case syscall.SIGFPE:
+		return "SIGFPE"
+	case syscall.SIGKILL:
+		return "SIGKILL"
+	case syscall.SIGSEGV:
+		return "SIGSEGV"
+	case syscall.SIGPIPE:
+		return "SIGPIPE"
+	case syscall.SIGALRM:
+		return "SIGALRM"
+	case syscall.SIGTERM:
+		return "SIGTERM"
+	}
+	return ""
 }
 
 // warnf prints one of brig's own notices to stderr: a warning, a deprecation, a

--- a/cmd/brig/run_json_test.go
+++ b/cmd/brig/run_json_test.go
@@ -1,0 +1,241 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/brig-sh/brig/internal/profile"
+	"github.com/brig-sh/brig/internal/runtime"
+)
+
+// jsonRuntime is a runtime a full `brig run` can drive with none on PATH. It
+// boots trivially -- nothing is running, so a first boot is recorded and the
+// readiness probe passes -- and records which handover the run reached, which is
+// the fact the tests below turn on. attachFn is what Attach runs, so a case can
+// hand back a real exit status.
+type jsonRuntime struct {
+	runtime.Runtime
+	replaced int
+	attached int
+	attachFn func(runtime.ExecSpec) (int, error)
+}
+
+func (r *jsonRuntime) Kind() string                 { return "hull" }
+func (r *jsonRuntime) Bin() string                  { return "hull" }
+func (r *jsonRuntime) Running(string) (bool, error) { return false, nil }
+func (r *jsonRuntime) Run(runtime.RunSpec) error    { return nil }
+func (r *jsonRuntime) Probe(runtime.ExecSpec) bool  { return true }
+func (r *jsonRuntime) Output(runtime.ExecSpec) (string, error) {
+	return "", nil
+}
+func (r *jsonRuntime) Stop(string) error                  { return nil }
+func (r *jsonRuntime) Remove(string) error                { return nil }
+func (r *jsonRuntime) PinsDigest() bool                   { return false }
+func (r *jsonRuntime) LocalDigest(string) (string, error) { return "", nil }
+func (r *jsonRuntime) LogsHint(name string) string        { return "hull logs " + name }
+
+// Replace records the handover and returns rather than exec'ing -- a real
+// syscall.Exec would replace the test binary. That it is a no-op here is the
+// whole point: the default path must reach it and not Attach.
+func (r *jsonRuntime) Replace(runtime.ExecSpec) error {
+	r.replaced++
+	return nil
+}
+
+func (r *jsonRuntime) Attach(spec runtime.ExecSpec) (int, error) {
+	r.attached++
+	if r.attachFn != nil {
+		return r.attachFn(spec)
+	}
+	return 0, nil
+}
+
+// jsonRunHost points brig's whole environment at scratch directories and hands
+// run() the given fake runtime through the detection seam, so a full run drives
+// the fake with nothing on the host. It writes a minimal agent profile named
+// "faker" -- no genericBoot, no secrets -- so the boot needs neither boot assets
+// nor a keychain.
+func jsonRunHost(t *testing.T, rt runtime.Runtime) {
+	t.Helper()
+	dir := t.TempDir()
+	t.Setenv("BRIG_PROFILE_DIR", dir)
+	t.Setenv("BRIG_STATE_DIR", t.TempDir())
+	t.Setenv("BRIG_WORKSPACE", t.TempDir())
+	t.Setenv("BRIG_VERIFY", "off")
+	t.Setenv("BRIG_RUNTIME", "")
+	emptyPath(t)
+	body := "name: faker\nimage: img\nguestHome: /home/faker\nbinary: agent\nmem: 1024\ncpus: 1\n"
+	if err := os.WriteFile(filepath.Join(dir, "faker.yaml"), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := profile.Load(profile.Dir()); err != nil {
+		t.Fatal(err)
+	}
+	prev := detectRuntimeFor
+	detectRuntimeFor = func(runtime.Preference) (runtime.Runtime, error) { return rt, nil }
+	t.Cleanup(func() { detectRuntimeFor = prev })
+}
+
+// lastJSONLine parses the final non-empty line of out as a Run object. brig
+// prints its object after the agent's own inherited output, so a script's rule
+// is "the last line of stdout is brig's" -- this is that rule, in a test.
+func lastJSONLine(t *testing.T, out string) map[string]any {
+	t.Helper()
+	lines := strings.Split(strings.TrimRight(out, "\n"), "\n")
+	last := lines[len(lines)-1]
+	var doc map[string]any
+	if err := json.Unmarshal([]byte(last), &doc); err != nil {
+		t.Fatalf("last stdout line is not JSON: %q\n(full stdout: %q)", last, out)
+	}
+	return doc
+}
+
+// The test that protects every interactive user: a run WITHOUT --json hands the
+// terminal over with Replace and never touches the child path. A regression here
+// is an agent that has lost its tty, so this goes first.
+func TestRunWithoutJSONReachesReplaceNeverAttach(t *testing.T) {
+	rt := &jsonRuntime{}
+	jsonRunHost(t, rt)
+
+	if _, err := captureStdout(t, func() error { return run([]string{"run", "faker"}) }); err != nil {
+		t.Fatalf("run faker: %v", err)
+	}
+	if rt.replaced != 1 {
+		t.Errorf("Replace called %d times, want 1", rt.replaced)
+	}
+	if rt.attached != 0 {
+		t.Errorf("a default run reached the child path %d times, want 0", rt.attached)
+	}
+}
+
+// Under --json the agent runs as a child, and its own exit status is brig's. The
+// child here really exits 7, through the production RunAttached, so this pins the
+// whole chain: Attach's status, the Run object, and the status brig returns.
+func TestRunJSONPropagatesTheAgentExitStatus(t *testing.T) {
+	rt := &jsonRuntime{attachFn: func(runtime.ExecSpec) (int, error) {
+		return runtime.RunAttached([]string{"/bin/sh", "-c", "exit 7"}, nil)
+	}}
+	jsonRunHost(t, rt)
+
+	out, err := captureStdout(t, func() error { return run([]string{"--json", "run", "faker"}) })
+	if rt.attached != 1 {
+		t.Errorf("the agent reached the child path %d times, want 1", rt.attached)
+	}
+	if got := exitCode(err); got != 7 {
+		t.Errorf("brig exit = %d, want 7", got)
+	}
+	doc := lastJSONLine(t, out)
+	if doc["kind"] != "Run" {
+		t.Errorf("kind = %v, want Run", doc["kind"])
+	}
+	data, _ := doc["data"].(map[string]any)
+	if data["stage"] != "agent" {
+		t.Errorf("stage = %v, want agent", data["stage"])
+	}
+	if data["exit"] != float64(7) {
+		t.Errorf("exit = %v, want 7", data["exit"])
+	}
+	if _, ok := data["error"]; ok {
+		t.Errorf("an agent that ran carried an error field: %v", data["error"])
+	}
+}
+
+// A brig refusal under --json is one line too, with stage "brig" and the
+// message, and nothing else on stdout: the object is what a script parses to
+// tell "brig would not start this" from "the agent exited non-zero", which the
+// exit status alone cannot say.
+func TestRunJSONReportsABrigRefusal(t *testing.T) {
+	// No runtime needed: an unknown profile is refused before detection.
+	t.Setenv("BRIG_PROFILE_DIR", t.TempDir())
+	if err := profile.Load(profile.Dir()); err != nil {
+		t.Fatal(err)
+	}
+
+	var err error
+	out, _ := captureStdout(t, func() error { err = run([]string{"--json", "run", "nosuchagent"}); return nil })
+	if got := exitCode(err); got != exitNotFound {
+		t.Errorf("brig exit = %d, want %d (not found)", got, exitNotFound)
+	}
+	if lines := strings.Count(strings.TrimRight(out, "\n"), "\n"); lines != 0 {
+		t.Errorf("stdout has more than one line:\n%s", out)
+	}
+	doc := lastJSONLine(t, out)
+	data, _ := doc["data"].(map[string]any)
+	if data["stage"] != "brig" {
+		t.Errorf("stage = %v, want brig", data["stage"])
+	}
+	if msg, _ := data["error"].(string); msg == "" || !strings.Contains(msg, "nosuchagent") {
+		t.Errorf("error = %q, want it to name the refused agent", data["error"])
+	}
+	if data["exit"] != float64(exitNotFound) {
+		t.Errorf("exit = %v, want %d", data["exit"], exitNotFound)
+	}
+}
+
+// A ref that will not parse is refused inside parse, before the run line has
+// been read. Under --json that refusal is still one Run line, stage brig, with
+// the usage exit, in either position of the flag, so a script's rule -- the
+// last line of stdout is brig's -- holds for a typo as much as for an unknown
+// agent.
+func TestRunJSONReportsABadRef(t *testing.T) {
+	t.Setenv("BRIG_PROFILE_DIR", t.TempDir())
+	if err := profile.Load(profile.Dir()); err != nil {
+		t.Fatal(err)
+	}
+	for _, args := range [][]string{
+		{"--json", "run", "claude@BAD"},
+		{"run", "--json", "claude@BAD"},
+		{"run", "--mem", "4096", "--json", "claude@BAD"},
+	} {
+		var err error
+		out, _ := captureStdout(t, func() error { err = run(args); return nil })
+		if got := exitCode(err); got != exitUsage {
+			t.Errorf("%q: exit %d, want %d", args, got, exitUsage)
+		}
+		doc := lastJSONLine(t, out)
+		data, _ := doc["data"].(map[string]any)
+		if data["stage"] != "brig" || data["ref"] != "claude@BAD" {
+			t.Errorf("%q: stage %v ref %v, want brig and claude@BAD", args, data["stage"], data["ref"])
+		}
+		if data["exit"] != float64(exitUsage) {
+			t.Errorf("%q: exit field %v, want %d", args, data["exit"], exitUsage)
+		}
+	}
+}
+
+// -d starts the sandbox and stops. Under --json it says so as the object, with
+// the sandbox name a script would attach to; the text form still prints the bare
+// name and nothing more.
+func TestDetachJSONPrintsTheObjectAndTextPrintsTheName(t *testing.T) {
+	rt := &jsonRuntime{}
+	jsonRunHost(t, rt)
+
+	out, err := captureStdout(t, func() error { return run([]string{"--json", "run", "faker", "-d"}) })
+	if err != nil {
+		t.Fatalf("run -d --json: %v", err)
+	}
+	doc := lastJSONLine(t, out)
+	data, _ := doc["data"].(map[string]any)
+	if data["stage"] != "detached" {
+		t.Errorf("stage = %v, want detached", data["stage"])
+	}
+	if data["sandbox"] != "brig-faker" {
+		t.Errorf("sandbox = %v, want brig-faker", data["sandbox"])
+	}
+	if rt.replaced != 0 || rt.attached != 0 {
+		t.Errorf("-d ran the agent: replaced=%d attached=%d", rt.replaced, rt.attached)
+	}
+
+	rt2 := &jsonRuntime{}
+	jsonRunHost(t, rt2)
+	textOut, err := captureStdout(t, func() error { return run([]string{"run", "faker", "-d"}) })
+	if err != nil {
+		t.Fatalf("run -d: %v", err)
+	}
+	if strings.TrimSpace(textOut) != "brig-faker" {
+		t.Errorf("text -d printed %q, want the bare sandbox name", textOut)
+	}
+}

--- a/docs/security.md
+++ b/docs/security.md
@@ -654,6 +654,11 @@ It does not filter what the agent writes to your terminal. `brig` hands the
 tty over with `syscall.Exec` and is gone before the agent produces a byte,
 which is what buys correct `^C` handling and a truthful exit status -- and it
 means every byte the agent emits reaches your terminal emulator unexamined.
+The one exception is `--json`: there `brig` stays alive as the agent's parent
+so it can print one status line after the agent exits. The tty is still the
+agent's, `brig` reads nothing the agent prints and writes nothing to it, and
+the exit status is still the agent's own. What changes is only that `brig` is
+present for the run rather than gone.
 That is a real surface: OSC 52 writes to, and reads from, the system
 clipboard; DCS sequences are forwarded verbatim by `tmux` and `screen` to the
 *outer* terminal; and a cursor-position query makes the terminal type its

--- a/internal/runtime/attach.go
+++ b/internal/runtime/attach.go
@@ -1,0 +1,114 @@
+package runtime
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"os/signal"
+	"syscall"
+)
+
+// execHandover and attachHandover are the two ways a built command is handed
+// down, kept behind package vars so a test can capture the argv and env each
+// receives without a syscall.Exec that never returns. Replace and Attach share
+// one builder already -- replaceCmd in each adapter -- and stubbing these is how
+// a test proves the two paths cannot drift.
+var (
+	execHandover   = syscall.Exec
+	attachHandover = RunAttached
+)
+
+// RunAttached runs argv as a child of brig, inheriting brig's own stdin, stdout
+// and stderr, waits for it, and returns its exit status. argv[0] is the binary;
+// env is the full child environment. Both adapters build the pair from the very
+// function their Replace uses, so the child and the process replacement cannot
+// drift.
+//
+// It is the child-process counterpart of syscall.Exec. Replace hands the
+// terminal, the signals and the exit status straight to the runtime and never
+// returns, which is the right default: the agent's TUI wants a real tty with
+// nothing between it and the keyboard. Attach keeps brig alive across the exec
+// so brig can report the outcome on a machine-readable line afterwards, which
+// Replace by definition cannot -- there is no brig left once the exec has
+// happened.
+//
+// A child killed by a signal is reported as 128 plus the signal number, the
+// convention a shell follows, so a caller mapping the status onto its own exit
+// returns the same number a shell would for the same death.
+func RunAttached(argv, env []string) (int, error) {
+	cmd := exec.Command(argv[0], argv[1:]...)
+	cmd.Env = env
+	cmd.Stdin, cmd.Stdout, cmd.Stderr = os.Stdin, os.Stdout, os.Stderr
+
+	// Registered before Start so a signal that arrives in the gap between fork
+	// and the forwarding goroutine is buffered rather than taking brig down
+	// under the default disposition.
+	sigs := make(chan os.Signal, 1)
+	signal.Notify(sigs, os.Interrupt, syscall.SIGTERM, syscall.SIGHUP)
+	defer signal.Stop(sigs)
+
+	if err := cmd.Start(); err != nil {
+		return 0, err
+	}
+
+	// The child holds the terminal, so it sits in brig's own process group and a
+	// Ctrl-C from the tty is delivered by the kernel to BOTH brig and the child
+	// at the same instant. brig must therefore neither exit on SIGINT nor
+	// forward it: the child already has it, and a second copy -- or brig dying
+	// and orphaning the child mid-keystroke -- is exactly the bug this guards
+	// against. So SIGINT is caught and dropped, and brig goes on waiting.
+	//
+	// SIGTERM and SIGHUP are different in kind: they reach brig alone (a `kill`,
+	// a hung-up session), not through the tty, so the child never sees them
+	// unless brig passes them on. Those are forwarded. SIGWINCH needs nothing --
+	// the child owns the tty and the kernel resizes its pty directly. The
+	// deferred signal.Stop restores the default handling, so nothing outlives
+	// the one child this call waits on.
+	//
+	// This is the reasoning most likely to be "corrected" wrongly later: do not
+	// add SIGINT to the forwarded set, and do not make SIGINT return early.
+	//
+	// It rests on the child sharing brig's process group, which it does because
+	// nothing here calls Setpgid. If that ever changes, a Ctrl-C reaches brig
+	// alone and this handler must start forwarding it. Forwarding it today
+	// would hand the child a second SIGINT for every keystroke, and an agent
+	// that reads the second as "quit" -- most TUIs do -- would exit on the
+	// first. There is no second-Ctrl-C escape here on purpose: brig waits for
+	// the child, and the child is what the keystroke is for.
+	done := make(chan struct{})
+	go func() {
+		for {
+			select {
+			case s := <-sigs:
+				switch s {
+				case syscall.SIGTERM, syscall.SIGHUP:
+					_ = cmd.Process.Signal(s)
+				}
+			case <-done:
+				return
+			}
+		}
+	}()
+
+	err := cmd.Wait()
+	close(done)
+	return attachedStatus(err)
+}
+
+// attachedStatus reads the child's exit status out of what cmd.Wait returned:
+// its own exit code when it exited, or 128 plus the signal number when a signal
+// killed it. A non-exit error -- the child could not be started or waited on --
+// is brig's own failure and is returned as the error, not folded into a status.
+func attachedStatus(err error) (int, error) {
+	if err == nil {
+		return 0, nil
+	}
+	var ee *exec.ExitError
+	if errors.As(err, &ee) {
+		if ws, ok := ee.Sys().(syscall.WaitStatus); ok && ws.Signaled() {
+			return 128 + int(ws.Signal()), nil
+		}
+		return ee.ExitCode(), nil
+	}
+	return 0, err
+}

--- a/internal/runtime/attach_test.go
+++ b/internal/runtime/attach_test.go
@@ -1,0 +1,155 @@
+package runtime
+
+import (
+	"os"
+	"reflect"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// Replace and Attach must be the same exec asked for two ways: the terminal
+// handover and the --json child differ only in whether brig survives them, never
+// in what they run or the environment they run it in. A drift there is a
+// credential forwarded to one path and not the other, or a --json run that
+// behaves unlike the interactive one it is meant to report on.
+//
+// The two handovers are captured through the package seams rather than actually
+// exec'd -- syscall.Exec would replace the test binary and never return -- so
+// what is compared is exactly the argv and env each method handed down.
+func TestReplaceAndAttachBuildTheSameCommand(t *testing.T) {
+	spec := ExecSpec{
+		Name: "brig-x",
+		Cmd:  []string{"agent", "--flag", "v"},
+		Cwd:  "/work/proj",
+		TTY:  true,
+		Env:  []Var{{Name: "GH_TOKEN", Value: "t", Secret: true}},
+	}
+
+	for _, tc := range []struct {
+		name    string
+		replace func() ([]string, []string)
+		attach  func() ([]string, []string)
+	}{
+		{
+			name: "hull",
+			replace: func() ([]string, []string) {
+				return captureHandover(t, func() { _ = (&hull{bin: "/opt/hull"}).Replace(spec) },
+					func() (int, error) { return 0, nil })
+			},
+			attach: func() ([]string, []string) {
+				return captureAttach(t, func() { _, _ = (&hull{bin: "/opt/hull"}).Attach(spec) })
+			},
+		},
+		{
+			name: "nerdctl",
+			replace: func() ([]string, []string) {
+				return captureHandover(t, func() { _ = (&nerdctl{bin: "/usr/bin/nerdctl"}).Replace(spec) },
+					func() (int, error) { return 0, nil })
+			},
+			attach: func() ([]string, []string) {
+				return captureAttach(t, func() { _, _ = (&nerdctl{bin: "/usr/bin/nerdctl"}).Attach(spec) })
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			rArgv, rEnv := tc.replace()
+			aArgv, aEnv := tc.attach()
+			if !reflect.DeepEqual(rArgv, aArgv) {
+				t.Errorf("argv differs between Replace and Attach:\n  replace: %v\n  attach:  %v", rArgv, aArgv)
+			}
+			if !reflect.DeepEqual(rEnv, aEnv) {
+				t.Errorf("env differs between Replace and Attach:\n  replace: %v\n  attach:  %v", rEnv, aEnv)
+			}
+		})
+	}
+}
+
+// captureHandover runs fn with execHandover stubbed to record the argv and env
+// it is given rather than replacing the process, restoring the seam after.
+func captureHandover(t *testing.T, fn func(), _ func() (int, error)) (argv, env []string) {
+	t.Helper()
+	prev := execHandover
+	execHandover = func(_ string, a, e []string) error { argv, env = a, e; return nil }
+	t.Cleanup(func() { execHandover = prev })
+	fn()
+	return argv, env
+}
+
+// captureAttach is captureHandover for the child path.
+func captureAttach(t *testing.T, fn func()) (argv, env []string) {
+	t.Helper()
+	prev := attachHandover
+	attachHandover = func(a, e []string) (int, error) { argv, env = a, e; return 0, nil }
+	t.Cleanup(func() { attachHandover = prev })
+	fn()
+	return argv, env
+}
+
+// A child that exits with a status hands that status straight back, so a --json
+// run can report the agent's own code as brig's.
+func TestRunAttachedReturnsTheChildExitStatus(t *testing.T) {
+	code, err := RunAttached([]string{"/bin/sh", "-c", "exit 7"}, nil)
+	if err != nil {
+		t.Fatalf("RunAttached: %v", err)
+	}
+	if code != 7 {
+		t.Errorf("exit status = %d, want 7", code)
+	}
+}
+
+// A child brig cannot even start is brig's own failure, returned as an error
+// rather than folded into a status a script would read as the agent's.
+func TestRunAttachedReturnsAnErrorWhenTheChildCannotStart(t *testing.T) {
+	if _, err := RunAttached([]string{"/no/such/binary/at/all"}, nil); err == nil {
+		t.Fatal("a child that could not be started returned no error")
+	}
+}
+
+// SIGTERM reaches brig alone -- a kill, a closed session -- not through the tty,
+// so the child never sees it unless brig forwards it. brig forwards it, the
+// child dies of it, and brig's status is 128 plus the signal number, the shell's
+// convention. Without the forwarding a `kill` of a --json run would leave the
+// agent running.
+func TestRunAttachedForwardsSIGTERM(t *testing.T) {
+	go func() {
+		// After RunAttached has registered its handler and started the child.
+		time.Sleep(300 * time.Millisecond)
+		_ = syscall.Kill(os.Getpid(), syscall.SIGTERM)
+	}()
+	code, err := RunAttached([]string{"/bin/sh", "-c", "sleep 30"}, nil)
+	if err != nil {
+		t.Fatalf("RunAttached: %v", err)
+	}
+	if want := 128 + int(syscall.SIGTERM); code != want {
+		t.Errorf("exit status = %d, want %d (128 + SIGTERM)", code, want)
+	}
+}
+
+// SIGINT is the opposite case: the tty delivers it to the child directly, so a
+// second copy from brig -- or brig exiting and orphaning the child -- is the
+// bug. brig catches SIGINT, drops it, and goes on waiting. The child here never
+// receives it (the test signals brig alone, not the child's group), so a brig
+// that exited early or forwarded it would end the wait before the child was
+// stopped some other way.
+func TestRunAttachedDoesNotExitEarlyOnSIGINT(t *testing.T) {
+	start := time.Now()
+	go func() {
+		time.Sleep(200 * time.Millisecond)
+		// Dropped by brig: the child keeps sleeping, brig keeps waiting.
+		_ = syscall.Kill(os.Getpid(), syscall.SIGINT)
+		time.Sleep(400 * time.Millisecond)
+		// What actually ends the wait, proving SIGINT did not.
+		_ = syscall.Kill(os.Getpid(), syscall.SIGTERM)
+	}()
+	code, err := RunAttached([]string{"/bin/sh", "-c", "sleep 30"}, nil)
+	if err != nil {
+		t.Fatalf("RunAttached: %v", err)
+	}
+	if elapsed := time.Since(start); elapsed < 400*time.Millisecond {
+		t.Errorf("returned after %v, too soon -- SIGINT cut the wait short", elapsed)
+	}
+	if want := 128 + int(syscall.SIGTERM); code != want {
+		t.Errorf("exit status = %d, want %d -- SIGINT, not SIGTERM, ended it", code, want)
+	}
+}

--- a/internal/runtime/hull.go
+++ b/internal/runtime/hull.go
@@ -11,7 +11,6 @@ import (
 	"strconv"
 	"strings"
 	"sync"
-	"syscall"
 	"time"
 )
 
@@ -586,7 +585,16 @@ func (h *hull) Feed(spec ExecSpec) error {
 // status is brig's exit status without any relaying.
 func (h *hull) Replace(spec ExecSpec) error {
 	argv, env := h.replaceCmd(spec)
-	return syscall.Exec(h.bin, argv, env)
+	return execHandover(h.bin, argv, env)
+}
+
+// Attach runs the same handover as a child instead of replacing brig, for the
+// --json path that has to outlive the exec to report its exit status. It builds
+// its command from replaceCmd, the one function Replace uses too, so the child
+// and the process replacement carry byte-for-byte the same argv and env.
+func (h *hull) Attach(spec ExecSpec) (int, error) {
+	argv, env := h.replaceCmd(spec)
+	return attachHandover(argv, env)
 }
 
 // replaceCmd builds the handover argv and environment in one place, so a test

--- a/internal/runtime/nerdctl.go
+++ b/internal/runtime/nerdctl.go
@@ -8,7 +8,6 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
-	"syscall"
 )
 
 // nerdctl drives the Linux path. It is the same product logic over
@@ -421,10 +420,27 @@ func (n *nerdctl) Feed(spec ExecSpec) error {
 	return nil
 }
 
-func (n *nerdctl) Replace(spec ExecSpec) error {
+// replaceCmd builds the handover argv and environment in one place, so the
+// terminal handover and the --json child cannot drift: Replace and Attach both
+// read from here, the way the hull adapter's replaceCmd serves both there.
+func (n *nerdctl) replaceCmd(spec ExecSpec) (argv, env []string) {
 	args, envVals := n.execArgs(spec)
-	argv := append([]string{n.bin}, args...)
-	return syscall.Exec(n.bin, argv, mergeEnv(telemetryEnv(spec.Counted), envVals))
+	argv = append([]string{n.bin}, args...)
+	env = mergeEnv(telemetryEnv(spec.Counted), envVals)
+	return argv, env
+}
+
+func (n *nerdctl) Replace(spec ExecSpec) error {
+	argv, env := n.replaceCmd(spec)
+	return execHandover(n.bin, argv, env)
+}
+
+// Attach runs the same handover as a child instead of replacing brig, for the
+// --json path. It builds from replaceCmd, exactly as Replace does, so the two
+// carry the same argv and env.
+func (n *nerdctl) Attach(spec ExecSpec) (int, error) {
+	argv, env := n.replaceCmd(spec)
+	return attachHandover(argv, env)
 }
 
 func (n *nerdctl) Stop(name string) error { return n.quiet("stop", name) }

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -255,6 +255,17 @@ type Runtime interface {
 	// success. This is how the agent's own TUI gets a real tty without brig
 	// sitting in the middle of it.
 	Replace(spec ExecSpec) error
+	// Attach runs the exec as a child of brig instead of replacing brig with
+	// it: brig's own stdin, stdout and stderr are inherited, brig waits, and the
+	// child's exit status is returned. A child killed by a signal is reported as
+	// 128 plus the signal number, the shell's convention.
+	//
+	// It is the counterpart to Replace for a caller that has to survive the exec
+	// to report on it -- which is what --json needs and Replace, having left
+	// nothing of brig behind, cannot do. Both build their command from the same
+	// function, so the terminal handover and the child cannot drift. See
+	// RunAttached and the note on Replace.
+	Attach(spec ExecSpec) (int, error)
 	// Stop stops a sandbox, and Remove clears the instance holding the name.
 	Stop(name string) error
 	Remove(name string) error

--- a/internal/wrap/run.go
+++ b/internal/wrap/run.go
@@ -635,10 +635,11 @@ func (c *Config) Remove() error {
 	return err
 }
 
-// Exec hands the terminal to a command inside the sandbox. It does not return
-// on success.
-func (c *Config) Exec(set creds.Set, argv []string, tty bool) error {
-	return c.Runtime.Replace(runtime.ExecSpec{
+// execSpec is the one request Exec and ExecAttached both hand the runtime, so
+// the terminal handover and the --json child are the same exec asked for two
+// ways rather than two specs that can disagree.
+func (c *Config) execSpec(set creds.Set, argv []string, tty bool) runtime.ExecSpec {
+	return runtime.ExecSpec{
 		Name: c.VMName,
 		Cmd:  argv,
 		Cwd:  c.GuestCwd,
@@ -651,19 +652,46 @@ func (c *Config) Exec(set creds.Set, argv []string, tty bool) error {
 		CanAsk:  IsTerminal(os.Stdin),
 		Env:     set.Vars,
 		Counted: true,
-	})
+	}
 }
 
-// Shell opens a login shell in the sandbox, or runs one command in it.
+// Exec hands the terminal to a command inside the sandbox. It does not return
+// on success.
+func (c *Config) Exec(set creds.Set, argv []string, tty bool) error {
+	return c.Runtime.Replace(c.execSpec(set, argv, tty))
+}
+
+// ExecAttached runs the command as a child of brig rather than replacing brig
+// with it, and returns the command's exit status. It is the --json counterpart
+// of Exec: brig stays alive across the exec so it can report the outcome, which
+// Replace cannot. The spec is Exec's own, so the child inherits everything the
+// handover would have carried.
+func (c *Config) ExecAttached(set creds.Set, argv []string, tty bool) (int, error) {
+	return c.Runtime.Attach(c.execSpec(set, argv, tty))
+}
+
+// shellArgv is the login-shell command line, built once so Shell and
+// ShellAttached spell it the same way.
 //
 // The trailing words are joined into a single string before the shell sees
 // them, so they land as one argument -- the script text for -c -- rather than
 // one per word. Passed individually, bash takes the first as the script and
 // the rest as $0, $1, ...
-func (c *Config) Shell(set creds.Set, command []string) error {
-	argv := []string{"bash", "-l"}
+func shellArgv(command []string) []string {
 	if len(command) > 0 {
-		argv = []string{"bash", "-lc", strings.Join(command, " ")}
+		return []string{"bash", "-lc", strings.Join(command, " ")}
 	}
-	return c.Exec(set, argv, true)
+	return []string{"bash", "-l"}
+}
+
+// Shell opens a login shell in the sandbox, or runs one command in it.
+func (c *Config) Shell(set creds.Set, command []string) error {
+	return c.Exec(set, shellArgv(command), true)
+}
+
+// ShellAttached is Shell down the child path, so a shell profile under --json
+// behaves like an agent one: brig runs it as a child and reports its exit
+// status rather than replacing itself with it.
+func (c *Config) ShellAttached(set creds.Set, command []string) (int, error) {
+	return c.ExecAttached(set, shellArgv(command), true)
 }

--- a/script/smoke.sh
+++ b/script/smoke.sh
@@ -153,7 +153,13 @@ case "$verb" in
           printf '1 1 0:2 / %s rw - fuseblk\n' "$target" >> "$STUB_STATE.mounts"
         fi
         ;;
-      *) printf 'env-token:%s\n' "${CLAUDE_CODE_OAUTH_TOKEN:-<unset>}" >> "$STUB_LOG" ;;
+      *)
+        printf 'env-token:%s\n' "${CLAUDE_CODE_OAUTH_TOKEN:-<unset>}" >> "$STUB_LOG"
+        # The agent (or login shell) exec. STUB_EXEC_EXIT makes it exit non-zero,
+        # which is how the --json case drives the child path: brig runs this as a
+        # child rather than replacing itself, so it survives to report the status.
+        [ -n "${STUB_EXEC_EXIT:-}" ] && exit "$STUB_EXEC_EXIT"
+        ;;
     esac
     ;;
   stop)
@@ -1822,6 +1828,34 @@ grep -q -- "-v is one of brig's own flags" "$WORK/agentv.err" \
 "$WORK/brig" ls -q > "$WORK/lsq.out" 2>&1
 [ "$(cat "$WORK/lsq.out")" = claude-code ] \
   && ok "ls -q is unchanged" || bad "ls -q is unchanged -- got: $(cat "$WORK/lsq.out")"
+
+echo "== run --json =="
+# --json runs the agent as a child instead of replacing brig with it, so brig
+# survives the exec and reports the outcome on one JSON line. The stub's exec
+# exits 7; brig exits 7 too, with that status carried on a parseable last line --
+# which is how a script tells "the agent failed" from "brig refused to start it".
+"$WORK/brig" rm --all > /dev/null 2>&1
+STUB_EXEC_EXIT=7 "$WORK/brig" --json run ubuntu -- true \
+  > "$WORK/json.out" 2> "$WORK/json.err"
+rc=$?
+[ "$rc" = 7 ] && ok "brig --json run exits with the agent's own status" \
+  || bad "brig --json run exits with the agent's own status -- got $rc: $(cat "$WORK/json.err")"
+# The rule a script follows: the last line of stdout is brig's, and it parses.
+last="$(tail -n1 "$WORK/json.out")"
+if command -v python3 >/dev/null 2>&1; then
+  python3 -c 'import json,sys
+d = json.loads(sys.argv[1])
+assert d["kind"] == "Run", d
+assert d["data"]["stage"] == "agent", d
+assert d["data"]["exit"] == 7, d' "$last" 2>/dev/null \
+    && ok "the last stdout line is a Run object with stage agent and exit 7" \
+    || bad "the last stdout line is not the expected Run object -- got: $last"
+fi
+case "$last" in
+  *'"kind":"Run"'*) ok "brig --json run prints a compact Run object" ;;
+  *) bad "brig --json run prints a compact Run object -- got: $last" ;;
+esac
+"$WORK/brig" rm --all > /dev/null 2>&1
 
 echo "== doctor =="
 # brig doctor reports the prerequisites a first run hits, in boot order. On the


### PR DESCRIPTION
`brig run` ends by replacing its own process with the runtime. That is the right default and it stays: the agent owns the terminal, gets signals directly, and its exit status is the command's. It also means brig can never report its own failure in a machine-readable way on a run line, so a script cannot tell "brig refused to start this" from "the agent ran and exited 1".

Under `--json`, and only then, the agent runs as a child. `Attach` joins `Replace` on the runtime interface; both adapters build the child from the same function `Replace` uses, and a test pins that the argv and env are equal. Without `--json` nothing changes, and the first test in the PR is the one that proves `run` still reaches `Replace` and never `Attach`.

**Signals.** The child inherits the tty, so it sits in brig's process group and a Ctrl-C reaches both from the kernel. brig catches SIGINT and waits, forwarding nothing, or the child would get it twice. SIGTERM and SIGHUP reach brig alone and are forwarded. The reasoning is in the comment above the handler because it is the part most likely to be "corrected" wrong later.

**The object.** One compact line on stdout after the agent exits, or instead of running it when brig refuses, so a script's rule is "the last line of stdout is brig's". Kind `Run`, with `stage` (`brig`, `agent`, `detached`, `gui`), `exit`, `error` on a brig refusal, `signal` when the kernel killed the agent, and `ref` and `sandbox` always. brig's exit status keeps its meaning: the agent's own when it ran, the class from the exit table when brig refused. The object is what tells them apart.

`sh` takes the same path on the same mechanism. `-d`, a GUI profile and a shell profile each print their object in place of today's text.

"Always run as a child" was considered and rejected: it changes TTY ownership and signal delivery for every interactive run for the benefit of a flag.

**Second commit.** Found by running the build here: a ref that will not parse is refused inside `parse`, before the JSON context existed, so `brig --json run claude@BAD` printed no line at all. The context is now made before `parse` and refreshed after, in both flag positions.

Stacked on #141 for the global `--json`; retargets to `main` when that merges.

Checked on a build of this branch: an unknown agent, a bad ref in both positions, and a bad `BRIG_RUNTIME_BIN` each print one `Run` line with `stage: brig` and the right exit; `stop` still refuses `--json` naming `run` and `sh`. Tested with `go vet ./...`, `go test -race ./...` and `./script/smoke.sh`, which has two new cases driving the stub's exit status through `--json run`.

Fixes: #110