### PR TITLE
docs: name hull's real build target in the from-source instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,10 +53,12 @@ On macOS the sandbox is a microVM, booted by
 [hull](https://github.com/brig-sh/hull) over Virtualization.framework. The
 Homebrew cask depends on it, so `brew install --cask brig` brings it along.
 
-Building both from source works too:
+Building both from source works too. hull's build target is `make macos`, it
+needs a Rust toolchain for the `hvi` submodule, and the submodule has to be
+cloned:
 
 ```bash
-git clone https://github.com/brig-sh/hull && cd hull && make build
+git clone --recursive https://github.com/brig-sh/hull && cd hull && make macos
 ```
 
 hull ships a `vz-runner` helper that needs the


### PR DESCRIPTION
The README told a reader to clone hull and run `make build`. hull has no such target. Its default is `make macos`, the `hvi` backend is a submodule that needs `--recursive`, and building it needs a Rust toolchain. Following the line as written stops at `No rule to make target \`build'`, which is what #98 reports.

One sentence and one corrected command. The signing paragraph beneath was already right and is unchanged. `docs/runtimes.md` already covers the signing detail in full.

Fixes: #98