### PR TITLE
fix(runtime): check BRIG_RUNTIME_BIN before driving it

### DIFF
--- a/docs/runtimes.md
+++ b/docs/runtimes.md
@@ -144,7 +144,9 @@ the command line even then.
 
 1. `BRIG_RUNTIME` names the backend, `hull` or `nerdctl`. Anything else is
    refused by name. Unset, it is `hull` on macOS and `nerdctl` everywhere else.
-2. `BRIG_RUNTIME_BIN` is the executable to run, and skips the PATH lookup.
+2. `BRIG_RUNTIME_BIN` is the executable to run. A path is taken as it stands
+   and a bare name is looked up on PATH, and either way one that is missing or
+   not executable is reported against the variable before anything runs.
 3. A profile's `runtimeBin` does the same thing without a variable per shell,
    and loses to `BRIG_RUNTIME_BIN`. A leading `~` is expanded, and a path that
    is missing or not executable is reported against the profile that named it.

--- a/internal/runtime/preference_test.go
+++ b/internal/runtime/preference_test.go
@@ -116,6 +116,95 @@ func TestDetectForSentinelMarksOnlyTheMissingRuntime(t *testing.T) {
 	}
 }
 
+// A path in BRIG_RUNTIME_BIN is checked the way a profile's runtimeBin is.
+// Taken on trust, a value that is not there reached the first exec instead,
+// where it surfaced as a sandbox whose state brig could not read and named the
+// variable nowhere (#139).
+func TestDetectForReportsAMissingRuntimeBinFromTheEnvironment(t *testing.T) {
+	t.Setenv("BRIG_RUNTIME", "hull")
+	t.Setenv("BRIG_RUNTIME_BIN", filepath.Join(t.TempDir(), "not-there"))
+
+	_, err := DetectFor(Preference{})
+	if err == nil {
+		t.Fatal("expected a missing BRIG_RUNTIME_BIN to be reported")
+	}
+	if !errors.Is(err, ErrBadRuntime) {
+		t.Errorf("%v does not match ErrBadRuntime, so it would not exit 4", err)
+	}
+	if errors.Is(err, ErrNoRuntime) {
+		t.Errorf("a bad BRIG_RUNTIME_BIN matched ErrNoRuntime, so env/ls would swallow it: %v", err)
+	}
+	// The variable is what the reader has to fix, so the variable is what the
+	// message has to name: the profile is not where this one came from.
+	if !strings.Contains(err.Error(), "BRIG_RUNTIME_BIN") {
+		t.Errorf("error does not name the variable: %v", err)
+	}
+}
+
+// A file that is there but cannot be executed fails the same way: it is a
+// runtime that was named and is broken, not one that is absent.
+func TestDetectForRefusesANonExecutableRuntimeBinFromTheEnvironment(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "hull")
+	if err := os.WriteFile(path, []byte("#!/bin/sh\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("BRIG_RUNTIME", "hull")
+	t.Setenv("BRIG_RUNTIME_BIN", path)
+
+	_, err := DetectFor(Preference{})
+	if err == nil {
+		t.Fatal("expected a non-executable BRIG_RUNTIME_BIN to be refused")
+	}
+	if !errors.Is(err, ErrBadRuntime) {
+		t.Errorf("%v does not match ErrBadRuntime, so it would not exit 4", err)
+	}
+	if !strings.Contains(err.Error(), "BRIG_RUNTIME_BIN") {
+		t.Errorf("error does not name the variable: %v", err)
+	}
+}
+
+// BRIG_RUNTIME_BIN=hull is a name to look up, not a path, and has always been
+// read that way by the exec underneath. Checking it as a path would have
+// refused every value that was working the day before the check landed.
+func TestDetectForResolvesABareRuntimeBinOnPath(t *testing.T) {
+	dir := t.TempDir()
+	bin := executableFile(t, dir, "hull")
+	t.Setenv("BRIG_RUNTIME", "hull")
+	t.Setenv("BRIG_RUNTIME_BIN", "hull")
+	t.Setenv("PATH", dir)
+
+	rt, err := DetectFor(Preference{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rt.Bin() != bin {
+		t.Errorf("Bin() = %q, want the %q found on PATH", rt.Bin(), bin)
+	}
+}
+
+// A bare name nothing on PATH answers is still a runtime that was named and is
+// not there, so it is ErrBadRuntime rather than the "nothing installed"
+// sentinel env and ls degrade over.
+func TestDetectForReportsABareRuntimeBinThatIsNotOnPath(t *testing.T) {
+	t.Setenv("BRIG_RUNTIME", "hull")
+	t.Setenv("BRIG_RUNTIME_BIN", "hull")
+	t.Setenv("PATH", t.TempDir())
+
+	_, err := DetectFor(Preference{})
+	if err == nil {
+		t.Fatal("expected a bare BRIG_RUNTIME_BIN that is not on PATH to be reported")
+	}
+	if !errors.Is(err, ErrBadRuntime) {
+		t.Errorf("%v does not match ErrBadRuntime, so it would not exit 4", err)
+	}
+	if errors.Is(err, ErrNoRuntime) {
+		t.Errorf("a bad BRIG_RUNTIME_BIN matched ErrNoRuntime, so env/ls would swallow it: %v", err)
+	}
+	if !strings.Contains(err.Error(), "BRIG_RUNTIME_BIN") {
+		t.Errorf("error does not name the variable: %v", err)
+	}
+}
+
 // A config file is where people write ~, so it has to mean something.
 func TestRuntimeBinExpandsHome(t *testing.T) {
 	home, err := os.UserHomeDir()

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -14,6 +14,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 )
@@ -281,14 +282,24 @@ func Detect() (Runtime, error) { return DetectFor(Preference{}) }
 // BRIG_RUNTIME forces the backend (hull | nerdctl) and BRIG_RUNTIME_BIN forces
 // the executable, which is how you point brig at a build that is not on PATH.
 // A profile's runtimeBin does the same thing without a variable per shell, and
-// loses to the variable when both are set.
+// loses to the variable when both are set. Whichever named the binary, it is
+// resolved and checked here, before any of it is run: a runtime that is not
+// there is refused with the setting that named it, rather than reaching the
+// first exec as a sandbox brig cannot tell the state of.
 func DetectFor(pref Preference) (Runtime, error) {
 	kind := os.Getenv("BRIG_RUNTIME")
 	if kind == "" {
 		kind = defaultKind()
 	}
 	bin := os.Getenv("BRIG_RUNTIME_BIN")
-	if bin == "" && pref.Bin != "" {
+	switch {
+	case bin != "":
+		resolved, err := runtimeBinFromEnv(bin)
+		if err != nil {
+			return nil, err
+		}
+		bin = resolved
+	case pref.Bin != "":
 		resolved, err := runtimeBinFromProfile(pref.Bin)
 		if err != nil {
 			return nil, err
@@ -320,14 +331,59 @@ func runtimeBinFromProfile(bin string) (string, error) {
 		}
 		bin = filepath.Join(home, bin[2:])
 	}
-	info, err := os.Stat(bin)
-	if err != nil {
-		return "", fmt.Errorf("%w: this profile's runtimeBin is %s, which is not there: %w", ErrBadRuntime, bin, err)
-	}
-	if info.IsDir() || info.Mode()&0o111 == 0 {
-		return "", fmt.Errorf("%w: this profile's runtimeBin is %s, which is not an executable", ErrBadRuntime, bin)
+	if err := runnable(bin); err != nil {
+		return "", fmt.Errorf("%w: this profile's runtimeBin is %s, %w", ErrBadRuntime, bin, err)
 	}
 	return bin, nil
+}
+
+// runtimeBinFromEnv resolves what BRIG_RUNTIME_BIN names.
+//
+// The variable used to be taken as given, which meant a value that was not
+// there reached the first exec instead of being refused: the failure surfaced
+// as a sandbox brig could not tell the state of, and reported the variable
+// nowhere (#139). It is the same mistake a profile's runtimeBin makes and it
+// is checked the same way, in the one place below, with the setting the reader
+// has to fix named rather than the profile.
+//
+// A bare name is a PATH lookup, because that is what BRIG_RUNTIME_BIN=hull has
+// always meant to the exec underneath and to anyone writing it. exec.LookPath
+// does that lookup and its own executable test, so a name it resolves is
+// already known to be runnable; the check below then covers the path it
+// returned and every value that named a path to begin with. Unlike the
+// profile's field a leading ~ is not expanded: this one is read by a shell
+// first, and a shell that did not expand it meant the literal directory.
+func runtimeBinFromEnv(bin string) (string, error) {
+	path := bin
+	if !strings.ContainsRune(bin, filepath.Separator) {
+		found, err := exec.LookPath(bin)
+		if err != nil {
+			return "", fmt.Errorf("%w: BRIG_RUNTIME_BIN is %s, which is not on PATH: %w", ErrBadRuntime, bin, err)
+		}
+		path = found
+	}
+	if err := runnable(path); err != nil {
+		return "", fmt.Errorf("%w: BRIG_RUNTIME_BIN is %s, %w", ErrBadRuntime, bin, err)
+	}
+	return path, nil
+}
+
+// runnable reports why a path cannot be driven as a runtime, or nil when it
+// can: it is on disk, it is not a directory, and it carries an execute bit.
+//
+// One function for both callers, phrased as the clause that follows the name
+// of whatever carried the path, so each says which setting is wrong while the
+// test itself is written once. Two copies is how the variable came to be
+// trusted where the profile's field was not.
+func runnable(bin string) error {
+	info, err := os.Stat(bin)
+	if err != nil {
+		return fmt.Errorf("which is not there: %w", err)
+	}
+	if info.IsDir() || info.Mode()&0o111 == 0 {
+		return errors.New("which is not an executable")
+	}
+	return nil
 }
 
 // envInArgv is the escape hatch for a runtime build that does not yet take a

--- a/script/smoke.sh
+++ b/script/smoke.sh
@@ -1137,6 +1137,15 @@ PATH="" BRIG_RUNTIME_BIN= "$WORK/brig" run claude -d > /dev/null 2>&1; rc=$?
 # A runtime that is named and broken is the same class to a script: also 4.
 BRIG_RUNTIME=podman "$WORK/brig" run claude -d > /dev/null 2>&1; rc=$?
 [ "$rc" = 4 ] && ok "an unknown BRIG_RUNTIME exits 4" || bad "an unknown BRIG_RUNTIME exits 4 -- got $rc"
+# So is a BRIG_RUNTIME_BIN pointing at nothing. It used to be taken on trust and
+# reach the first exec, which failed as "cannot tell whether the sandbox is
+# already running" with exit 1 and no mention of the variable that caused it.
+out="$(BRIG_RUNTIME_BIN=/nonexistent "$WORK/brig" run claude -d 2>&1)"; rc=$?
+[ "$rc" = 4 ] && ok "a BRIG_RUNTIME_BIN that is not there exits 4" || bad "a BRIG_RUNTIME_BIN that is not there exits 4 -- got $rc: $out"
+case "$out" in
+  *BRIG_RUNTIME_BIN*) ok "the refusal names BRIG_RUNTIME_BIN" ;;
+  *) bad "the refusal names BRIG_RUNTIME_BIN -- got: $out" ;;
+esac
 # A credential a run required but could not resolve is 6. A profile of our own
 # that declares a required secret nothing supplies fails at credential
 # resolution, before the sandbox boots -- whether the store is absent (Linux) or


### PR DESCRIPTION
`DetectFor` took `BRIG_RUNTIME_BIN` on trust, where a profile's `runtimeBin` was checked for being on disk and executable and wrapped `ErrBadRuntime` when it was not. The sentinel's own comment said both should reach it; only the profile path did. So a bad value was discovered at the first `ps`, with the runtime's own error and exit 1.

Both paths now share one check. A bare name is looked up on PATH the way `exec.LookPath` does, so `BRIG_RUNTIME_BIN=hull` keeps working; a path that is not there, not a file, or not executable is refused before anything runs, naming the variable, exit 4.

`info` and `ls` still work with no runtime installed: they swallow `ErrNoRuntime`, not `ErrBadRuntime`, and a runtime that was named and is broken is something to fail over.

Checked on a build of this branch: `/nonexistent` and a bare name not on PATH exit 4 naming `BRIG_RUNTIME_BIN`; `BRIG_RUNTIME_BIN=hull` resolves; `info` with hull off PATH still exits 0. Tested with `go vet ./...`, `go test -race ./...` and `./script/smoke.sh`, which has one new case.

Fixes: #139