### PR TITLE
fix(runtime): refuse a GUI profile on the container path

### DIFF
--- a/internal/runtime/nerdctl.go
+++ b/internal/runtime/nerdctl.go
@@ -178,15 +178,33 @@ func (n *nerdctl) isDocker() bool { return filepath.Base(n.bin) == "docker" }
 // nerdctl has a flag for. GenericBoot is not ignored -- urunc reads the same
 // two annotations from the container's OCI spec that hull takes on its command
 // line, so the Linux path is a pass-through.
-// CanRun refuses a policy this runtime cannot enforce, rather than dropping it
-// in silence.
+// CanRun refuses what this runtime cannot honour, rather than dropping it in
+// silence. It guards both paths, which is the whole point of living here rather
+// than in Run: a sandbox that is already up is joined rather than booted, so Run
+// is never called on the second `brig run`, and a check that only guarded Run
+// would refuse a profile the first time and wave it through every time after.
+// That is the failure RunChecker describes; hull refuses in supports, and its
+// CanRun is supports, so both paths are covered the same way here. Run calls
+// CanRun first, so the direct path is unchanged.
 //
-// Nothing here reads spec.Egress: this runtime hands the sandbox to the
-// container network, which brig does not filter. A boot that carried on would
-// print a POLICY row and an isolated NETWORK row over a sandbox with
-// unrestricted egress, which is the exact outcome the refusals on the other
-// backend exist to prevent. See RunChecker for why it is not inside Run.
+// A GUI profile wants a graphical window, and there is nowhere on this path to
+// put one: the container runtime has no display on either driver, so the refusal
+// is about the path rather than a setting to flip. hull refuses the same profile
+// when its backend cannot show a window; refuse it here too, before anything is
+// built, so the two paths exit alike instead of booting headless with the window
+// silently dropped.
+//
+// The policy refusal is here for the same reason: nothing on this runtime reads
+// spec.Egress into the run, which hands the sandbox to the container network
+// that brig does not filter. A boot that carried on would print a POLICY row and
+// an isolated NETWORK row over a sandbox with unrestricted egress, which is the
+// exact outcome the refusals on the other backend exist to prevent.
 func (n *nerdctl) CanRun(spec RunSpec) error {
+	if spec.GUI {
+		return fmt.Errorf("this profile opens a graphical window, which the container runtime cannot "+
+			"display on either driver (%s here); run it on macOS, where hull's vz backend can show it",
+			n.driver())
+	}
 	if spec.Egress.Filtered() && spec.Net != "none" {
 		return fmt.Errorf("a policy applies to this sandbox, and brig enforces one at the " +
 			"user-mode network gateway on macOS; there is no equivalent behind this runtime " +
@@ -196,17 +214,6 @@ func (n *nerdctl) CanRun(spec RunSpec) error {
 }
 
 func (n *nerdctl) Run(spec RunSpec) error {
-	// A GUI profile wants a graphical window, and there is nowhere on this path
-	// to put one: the container runtime has no display on either driver, so the
-	// refusal is about the path rather than a setting to flip. hull refuses the
-	// same profile when its backend cannot show a window; refuse it here too,
-	// before anything is built, so the two paths exit alike instead of booting
-	// headless with the window silently dropped.
-	if spec.GUI {
-		return fmt.Errorf("this profile opens a graphical window, which the container runtime cannot "+
-			"display on either driver (%s here); run it on macOS, where hull's vz backend can show it",
-			n.driver())
-	}
 	if err := n.CanRun(spec); err != nil {
 		return err
 	}

--- a/internal/runtime/nerdctl.go
+++ b/internal/runtime/nerdctl.go
@@ -196,6 +196,17 @@ func (n *nerdctl) CanRun(spec RunSpec) error {
 }
 
 func (n *nerdctl) Run(spec RunSpec) error {
+	// A GUI profile wants a graphical window, and there is nowhere on this path
+	// to put one: the container runtime has no display on either driver, so the
+	// refusal is about the path rather than a setting to flip. hull refuses the
+	// same profile when its backend cannot show a window; refuse it here too,
+	// before anything is built, so the two paths exit alike instead of booting
+	// headless with the window silently dropped.
+	if spec.GUI {
+		return fmt.Errorf("this profile opens a graphical window, which the container runtime cannot "+
+			"display on either driver (%s here); run it on macOS, where hull's vz backend can show it",
+			n.driver())
+	}
 	if err := n.CanRun(spec); err != nil {
 		return err
 	}

--- a/internal/runtime/nerdctl_test.go
+++ b/internal/runtime/nerdctl_test.go
@@ -83,6 +83,41 @@ func TestNerdctlOmitsAnnotationsWithoutGenericBoot(t *testing.T) {
 	}
 }
 
+// A GUI profile has nowhere to draw on this path: the container runtime has no
+// display on either driver. hull refuses the same profile when its backend
+// cannot show a window; the container path must refuse it too, before any
+// command runs, rather than boot headless and drop the window in silence. The
+// stub would exit non-zero and say so if it ran, so the refusal must carry the
+// reason and the alternative, not what the stub said.
+func TestNerdctlRefusesGUIBeforeRunning(t *testing.T) {
+	n := &nerdctl{bin: stubRuntimeBin(t, "STUB RAN", 1)}
+
+	err := n.Run(RunSpec{Name: "brig-x", Image: "img", GUI: true})
+	if err == nil {
+		t.Fatal("expected a GUI profile to be refused on the container path")
+	}
+	if strings.Contains(err.Error(), "STUB RAN") {
+		t.Errorf("a command was built and run before the refusal: %v", err)
+	}
+	// The message must name why this path cannot do it and where it can.
+	if !strings.Contains(err.Error(), "container runtime") {
+		t.Errorf("the refusal does not say why this path cannot show a window: %v", err)
+	}
+	if !strings.Contains(err.Error(), "macOS") {
+		t.Errorf("the refusal does not point at where it can run: %v", err)
+	}
+}
+
+// A non-GUI profile is untouched by the refusal: it reaches the runtime and
+// boots as any ordinary profile does.
+func TestNerdctlRunsNonGUIProfile(t *testing.T) {
+	n := &nerdctl{bin: stubRuntimeBin(t, "pulling ghcr.io/x", 0)}
+
+	if err := n.Run(RunSpec{Name: "brig-x", Image: "img"}); err != nil {
+		t.Fatalf("a non-GUI profile must still run: %v", err)
+	}
+}
+
 // The guest architecture follows the host, and a Linux kernel is named for the
 // architecture it boots.
 func TestBootKernelNameFollowsArch(t *testing.T) {

--- a/internal/runtime/nerdctl_test.go
+++ b/internal/runtime/nerdctl_test.go
@@ -108,6 +108,30 @@ func TestNerdctlRefusesGUIBeforeRunning(t *testing.T) {
 	}
 }
 
+// The refusal lives in CanRun, not just Run, and this pins the property that
+// matters: a sandbox already up is joined rather than booted, so Run is never
+// called on the second `brig run`. Only a check reachable through CanRun covers
+// that join path, so assert CanRun itself refuses a GUI spec.
+func TestNerdctlCanRunRefusesGUI(t *testing.T) {
+	n := &nerdctl{bin: "/usr/local/bin/nerdctl"}
+
+	err := n.CanRun(RunSpec{Name: "brig-x", Image: "img", GUI: true})
+	if err == nil {
+		t.Fatal("expected CanRun to refuse a GUI profile so the join path is covered")
+	}
+	if !strings.Contains(err.Error(), "container runtime") {
+		t.Errorf("the refusal does not say why this path cannot show a window: %v", err)
+	}
+	if !strings.Contains(err.Error(), "macOS") {
+		t.Errorf("the refusal does not point at where it can run: %v", err)
+	}
+
+	// A non-GUI profile passes CanRun, so the ordinary boot path is unaffected.
+	if err := n.CanRun(RunSpec{Name: "brig-x", Image: "img"}); err != nil {
+		t.Errorf("CanRun must let an ordinary profile through: %v", err)
+	}
+}
+
 // A non-GUI profile is untouched by the refusal: it reaches the runtime and
 // boots as any ordinary profile does.
 func TestNerdctlRunsNonGUIProfile(t *testing.T) {


### PR DESCRIPTION
The hull adapter refuses a GUI profile when its backend cannot show a window and names the setting. The nerdctl adapter never read the GUI field, so the same profile on the container path issued an ordinary run: the sandbox started, the window never appeared, nothing said why.

`nerdctl.Run` now refuses a GUI profile before any command is built, in the same shape hull uses. The reason is the path rather than a setting: the container runtime has no display on either driver, so the message says to run it on macOS, where hull's vz backend can show it. A plain error, as hull's is, so the two paths exit alike.

Tested with `go vet ./...`, `go test -race ./...` and `./script/smoke.sh`; the new test asserts the refusal happens before any command runs and that a non-GUI spec is unaffected.

Fixes: #48