### PR TITLE
feat(secret): add a Secret Service backend for Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,8 +129,8 @@ separate Linux re-implementation of it.
 | `brig policy ls\|create\|edit\|show\|rm` | manage policies. `show --json` for JSON instead of YAML |
 | `brig policy attach\|detach <policy> <profile> [-n NAME]` | bind or unbind a policy to every run of a profile, or `-n` for one session |
 | `brig policy check <profile> [-n NAME]` | what is bound to a run of a profile (or `-n` session), and whether brig can enforce anything against it |
-| `brig secret create\|read\|update\|delete\|ls` | keep secrets in your keyring. macOS only for now |
-| `brig secret import <profile>` | fill that profile's secrets from your host, once. macOS only for now |
+| `brig secret create\|read\|update\|delete\|ls` | keep secrets in your keyring |
+| `brig secret import <profile>` | fill that profile's secrets from your host, once |
 | `brig telemetry status\|on\|off` | report what is counted, or turn the counting on or off. See [Telemetry](#telemetry) |
 | `brig version` | |
 

--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -365,18 +365,25 @@ nothing to be there.
 
 ## Linux
 
-There is no backend yet. `brig secret` says so rather than falling back to a
-file, which would be a downgrade nothing told you about:
+Linux stores into a Secret Service keyring on your session bus:
+`gnome-keyring` and KWallet both speak that API. brig keeps one item per secret
+in your default collection, tagged as its own so it lists and touches nothing
+else in the keyring, and unlocks the collection through your keyring UI when it
+is locked.
+
+When there is no session bus, or no keyring answering on it, `brig secret` says
+which is missing rather than falling back to a file, which would be a downgrade
+nothing told you about:
 
 ```console
 $ brig secret create gh-token
-brig: no secret store on this platform: brig secret needs the macOS keychain so far
+brig: no secret store on this platform: a D-Bus session bus is running but no Secret Service answers on it. Install a keyring (gnome-keyring or KWallet, both speak the Secret Service API) and log in to a session that starts it, or bind the secret to a command instead with `brig secret import <profile> --from-command '<sh>'`, which holds no plaintext at rest
 ```
 
-Note that it says so *before* asking for a value. The check happens ahead of
-the read from stdin, so you are not sent off to find a token only to be told
-afterwards that there is nowhere to put it. A Linux backend is
-[#8](https://github.com/brig-sh/brig/issues/8).
+It says so *before* asking for a value. The check happens ahead of the read
+from stdin, so you are not sent off to find a token only to be told afterwards
+that there is nowhere to put it. Binding the secret to a command with
+`--from-command` is the other way out, and holds no plaintext at rest.
 
 ## Errors you are likely to meet
 
@@ -395,7 +402,7 @@ point of the table: the error is the second entry point into these docs.
 | `the value for "x" is N bytes, and the keychain takes at most M` | over [the size limit](#the-size-limit) |
 | `deleting "x" cannot be undone, and there is no terminal to ask on. Pass -y to answer in advance: …` | a cron job or a unit file. `-y` is the answer given ahead |
 | `a secret name holds letters, digits, - and _, ...` | see [Naming a secret](#naming-a-secret) |
-| `no secret store on this platform: brig secret needs the macOS keychain so far` | Linux, [#8](https://github.com/brig-sh/brig/issues/8) |
+| `no secret store on this platform: … no Secret Service answers on it …` | Linux with no keyring on the session bus. Install `gnome-keyring` or KWallet and log in to a session that starts it, or bind the secret with `--from-command` |
 | `"x" is a secret, not a profile, and import takes the profile that declares it: …` | `import`'s first argument is a profile. The message names the one that declares the secret you typed |
 | `nothing to import for "x": … held no value` | the profile's sources exist and none of them had anything. Usually: run the agent on the host once to log in |
 | `"x" is already stored and brig did not put it there, so importing would replace a value you supplied` | you created it by hand. `-y` if replacing it is what you meant |

--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -403,6 +403,7 @@ point of the table: the error is the second entry point into these docs.
 | `deleting "x" cannot be undone, and there is no terminal to ask on. Pass -y to answer in advance: …` | a cron job or a unit file. `-y` is the answer given ahead |
 | `a secret name holds letters, digits, - and _, ...` | see [Naming a secret](#naming-a-secret) |
 | `no secret store on this platform: … no Secret Service answers on it …` | Linux with no keyring on the session bus. Install `gnome-keyring` or KWallet and log in to a session that starts it, or bind the secret with `--from-command` |
+| `no secret store on this platform: … a keyring is running but has no default collection …` | Linux with a keyring but no default collection yet (a headless or freshly provisioned session). Unlock your keyring once from a desktop session, which creates it, or bind the secret with `--from-command` |
 | `"x" is a secret, not a profile, and import takes the profile that declares it: …` | `import`'s first argument is a profile. The message names the one that declares the secret you typed |
 | `nothing to import for "x": … held no value` | the profile's sources exist and none of them had anything. Usually: run the agent on the host once to log in |
 | `"x" is already stored and brig did not put it there, so importing would replace a value you supplied` | you created it by hand. `-y` if replacing it is what you meant |

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,12 @@ module github.com/brig-sh/brig
 // planted by the guest from aiming brig at a host path; see internal/wrap/rootio.go.
 go 1.25
 
-require sigs.k8s.io/yaml v1.6.0
+require (
+	github.com/godbus/dbus/v5 v5.2.2
+	sigs.k8s.io/yaml v1.6.0
+)
 
-require go.yaml.in/yaml/v2 v2.4.2 // indirect
+require (
+	go.yaml.in/yaml/v2 v2.4.2 // indirect
+	golang.org/x/sys v0.27.0 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,9 +1,13 @@
+github.com/godbus/dbus/v5 v5.2.2 h1:TUR3TgtSVDmjiXOgAAyaZbYmIeP3DPkld3jgKGV8mXQ=
+github.com/godbus/dbus/v5 v5.2.2/go.mod h1:3AAv2+hPq5rdnr5txxxRwiGjPXamgoIHgz9FPBfOp3c=
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
 github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 go.yaml.in/yaml/v2 v2.4.2 h1:DzmwEr2rDGHl7lsFgAHxmNz/1NlQ7xLIrlN2h5d1eGI=
 go.yaml.in/yaml/v2 v2.4.2/go.mod h1:081UH+NErpNdqlCXm3TtEran0rJZGxAYx9hb/ELlsPU=
 go.yaml.in/yaml/v3 v3.0.3 h1:bXOww4E/J3f66rav3pX3m8w6jDE4knZjGOw8b5Y6iNE=
 go.yaml.in/yaml/v3 v3.0.3/go.mod h1:tBHosrYAkRZjRAOREWbDnBXUf08JOwYq++0QNwQiWzI=
+golang.org/x/sys v0.27.0 h1:wBqf8DvsY9Y/2P8gAfPDEYNuS30J4lPHJxXSb/nJZ+s=
+golang.org/x/sys v0.27.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 sigs.k8s.io/yaml v1.6.0 h1:G8fkbMSAFqgEFgh4b1wmtzDnioxFCUgTZhlbj5P9QYs=

--- a/internal/secret/keychain_other.go
+++ b/internal/secret/keychain_other.go
@@ -1,12 +1,13 @@
-//go:build !darwin
+//go:build !darwin && !linux
 
 package secret
 
 import "fmt"
 
 // open reports the platform rather than failing later and vaguely. The Store
-// interface is what makes a second backend an addition here; until one
-// exists, saying so plainly is the whole implementation.
+// interface is what makes a second backend an addition here; darwin has the
+// keychain and linux the Secret Service, so this file is now every other
+// platform, where saying so plainly is the whole implementation.
 func open() (Store, error) {
-	return nil, fmt.Errorf("%w: brig secret needs the macOS keychain so far", ErrUnsupported)
+	return nil, fmt.Errorf("%w: brig secret needs the macOS keychain or a Linux Secret Service keyring so far", ErrUnsupported)
 }

--- a/internal/secret/secretservice_linux.go
+++ b/internal/secret/secretservice_linux.go
@@ -53,13 +53,10 @@ const (
 	propModified   = itemIface + ".Modified"
 )
 
-// defaultAlias is the collection brig stores into: whichever one the keyring
-// has aliased as the user's default (gnome-keyring calls it "login"). The alias
-// path is where ReadAlias points when a default is set.
-const (
-	defaultAlias     = "default"
-	defaultAliasPath = dbus.ObjectPath("/org/freedesktop/secrets/aliases/default")
-)
+// defaultAlias is the alias brig reads to find the collection it stores into:
+// whichever one the keyring has aliased as the user's default (gnome-keyring
+// calls it "login").
+const defaultAlias = "default"
 
 // noObject is the object path the Secret Service returns to mean "none": no
 // prompt is needed, or no default collection exists. It is a bare "/".
@@ -91,9 +88,10 @@ type dbusSecret struct {
 
 // secretService is the Store backed by the freedesktop Secret Service.
 type secretService struct {
-	service string
-	conn    *dbus.Conn
-	session dbus.ObjectPath
+	service    string
+	conn       *dbus.Conn
+	session    dbus.ObjectPath
+	collection dbus.ObjectPath
 }
 
 // Caught at build time rather than wherever a secretService first gets assigned
@@ -131,6 +129,18 @@ var (
 		}
 		return slices.Contains(names, secretsName)
 	}
+
+	// readDefaultAlias resolves the "default" alias to the collection brig
+	// stores into, held as a variable for the same reason as the two above: the
+	// executor has no bus, so a test forces the answer -- in particular the
+	// noObject a keyring with no default collection returns.
+	readDefaultAlias = func(s *secretService) (dbus.ObjectPath, error) {
+		var path dbus.ObjectPath
+		if err := s.service0().Call(methodReadAlias, 0, defaultAlias).Store(&path); err != nil {
+			return noObject, fmt.Errorf("finding the default keyring collection: %w", err)
+		}
+		return path, nil
+	}
 )
 
 func open() (Store, error) { return openService(service) }
@@ -148,6 +158,9 @@ func openService(service string) (*secretService, error) {
 	}
 	s := &secretService{service: service, conn: conn}
 	if err := s.openSession(); err != nil {
+		return nil, err
+	}
+	if err := s.resolveCollection(); err != nil {
 		return nil, err
 	}
 	return s, nil
@@ -171,6 +184,22 @@ func errNoService() error {
 		"Install a keyring (gnome-keyring or KWallet, both speak the Secret Service API) and log in "+
 		"to a session that starts it, or bind the secret to a command instead with "+
 		"`brig secret import <profile> --from-command '<sh>'`, which holds no plaintext at rest",
+		ErrUnsupported)
+}
+
+// errNoDefaultCollection is the third shape of the same refusal: a keyring is
+// running and answering, but ReadAlias("default") resolves to noObject, which
+// is the service saying plainly that no default collection exists yet -- not
+// that the default sits at some well-known path. Nothing has created it: a
+// headless or freshly provisioned session never unlocked a login keyring, so
+// brig has nowhere to store into. Both ways out again, in the voice of the two
+// above: an unlock from a desktop session is what creates the default, or bind
+// the secret to a command that holds no plaintext at rest.
+func errNoDefaultCollection() error {
+	return fmt.Errorf("%w: a keyring is running but has no default collection to store into. "+
+		"Unlock your keyring once from a desktop session, which is what creates it, or bind the "+
+		"secret to a command instead with `brig secret import <profile> --from-command '<sh>'`, "+
+		"which holds no plaintext at rest",
 		ErrUnsupported)
 }
 
@@ -244,10 +273,7 @@ func (s *secretService) Write(name string, value []byte, p Provenance, update bo
 // name is what keeps an update in place -- and never the delete-then-create
 // shape secretimport.go warns against.
 func (s *secretService) write(name string, value []byte, p Provenance, update bool) error {
-	collPath, err := s.defaultCollection()
-	if err != nil {
-		return err
-	}
+	collPath := s.collection
 	if err := s.unlock(collPath); err != nil {
 		return err
 	}
@@ -432,18 +458,23 @@ func (s *secretService) modified(item dbus.ObjectPath) time.Time {
 	return time.Unix(int64(secs), 0)
 }
 
-// defaultCollection is the path of the collection brig stores into: the alias
-// the keyring points at, or the well-known alias path when ReadAlias reports
-// none, which is the path the keyring will have created the default under.
-func (s *secretService) defaultCollection() (dbus.ObjectPath, error) {
-	var path dbus.ObjectPath
-	if err := s.service0().Call(methodReadAlias, 0, defaultAlias).Store(&path); err != nil {
-		return noObject, fmt.Errorf("finding the default keyring collection: %w", err)
+// resolveCollection finds the collection brig stores into and holds it on s, so
+// the write path reaches for a path already known good rather than resolving it
+// mid-write. A ReadAlias of noObject is not "the default is at the well-known
+// path" but the service saying plainly that no default collection exists yet --
+// nothing has created it -- so it is a refusal in the shape of errNoBus and
+// errNoService, surfaced here at open() time, before a value is read from
+// stdin, rather than as a CreateItem failure halfway through a write.
+func (s *secretService) resolveCollection() error {
+	path, err := readDefaultAlias(s)
+	if err != nil {
+		return err
 	}
 	if path == noObject {
-		return defaultAliasPath, nil
+		return errNoDefaultCollection()
 	}
-	return path, nil
+	s.collection = path
+	return nil
 }
 
 // unlock unlocks an object if it is locked, prompting the user through their

--- a/internal/secret/secretservice_linux.go
+++ b/internal/secret/secretservice_linux.go
@@ -1,0 +1,531 @@
+//go:build linux
+
+package secret
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/godbus/dbus/v5"
+)
+
+// service is brig's own namespace in the keyring. Every item this package
+// touches carries it as an attribute, so brig never reaches outside its own
+// namespace and List can search by it and find nothing else.
+//
+// That is the same narrow guarantee the keychain's service name buys, and the
+// difference matters to anyone building a trust decision on it: it is a label,
+// not an authenticity check. Any process on the session bus can add an item
+// under it, and brig would then read, update and delete that item as if it
+// were its own. What the namespace buys is containment of brig, not provenance
+// of what it finds there.
+const service = "sh.brig.secret"
+
+// The Secret Service lives at a well-known name and path on the session bus.
+const (
+	secretsName = "org.freedesktop.secrets"
+	secretsPath = dbus.ObjectPath("/org/freedesktop/secrets")
+)
+
+// The interfaces and members this backend speaks, named as constants so a typo
+// is a build error at the const rather than a runtime "unknown method" from the
+// far side of the bus.
+const (
+	serviceIface = "org.freedesktop.Secret.Service"
+	collIface    = "org.freedesktop.Secret.Collection"
+	itemIface    = "org.freedesktop.Secret.Item"
+	promptIface  = "org.freedesktop.Secret.Prompt"
+
+	methodOpenSession = serviceIface + ".OpenSession"
+	methodReadAlias   = serviceIface + ".ReadAlias"
+	methodSearchItems = serviceIface + ".SearchItems"
+	methodUnlock      = serviceIface + ".Unlock"
+	methodCreateItem  = collIface + ".CreateItem"
+	methodGetSecret   = itemIface + ".GetSecret"
+	methodSetSecret   = itemIface + ".SetSecret"
+	methodDeleteItem  = itemIface + ".Delete"
+	methodPrompt      = promptIface + ".Prompt"
+	memberCompleted   = "Completed"
+
+	propAttributes = itemIface + ".Attributes"
+	propModified   = itemIface + ".Modified"
+)
+
+// defaultAlias is the collection brig stores into: whichever one the keyring
+// has aliased as the user's default (gnome-keyring calls it "login"). The alias
+// path is where ReadAlias points when a default is set.
+const (
+	defaultAlias     = "default"
+	defaultAliasPath = dbus.ObjectPath("/org/freedesktop/secrets/aliases/default")
+)
+
+// noObject is the object path the Secret Service returns to mean "none": no
+// prompt is needed, or no default collection exists. It is a bare "/".
+const noObject = dbus.ObjectPath("/")
+
+// The item attribute keys brig writes. service and name identify an item as
+// brig's and are what List and the existence checks search on; provenance
+// carries the encoded document provenance.go already defines, so a re-import's
+// expiry survives exactly as it does in the keychain comment on macOS.
+const (
+	attrKeyService    = "service"
+	attrKeyName       = "name"
+	attrKeyProvenance = "provenance"
+)
+
+// contentType labels the stored bytes on the wire. Values are arbitrary bytes
+// -- an SSH key, a binary blob -- so it is octet-stream rather than text.
+const contentType = "application/octet-stream"
+
+// dbusSecret is the (oayays) struct the Secret Service passes values in: the
+// session the value is (un)encrypted against, the algorithm parameters (empty
+// for the plain session brig opens), the value itself, and its content type.
+type dbusSecret struct {
+	Session     dbus.ObjectPath
+	Parameters  []byte
+	Value       []byte
+	ContentType string
+}
+
+// secretService is the Store backed by the freedesktop Secret Service.
+type secretService struct {
+	service string
+	conn    *dbus.Conn
+	session dbus.ObjectPath
+}
+
+// Caught at build time rather than wherever a secretService first gets assigned
+// to a Store: a method that stops matching the interface fails here, in the
+// file that has to change. Sizer is deliberately absent -- the value travels
+// over D-Bus, not on a command line, so there is no line-length ceiling to
+// price against, and secretimport.go falls back cleanly when a backend is not a
+// Sizer.
+var (
+	_ Store     = (*secretService)(nil)
+	_ Annotator = (*secretService)(nil)
+)
+
+// dialBus and hasSecretService are the two steps open() can fail at, held as
+// variables so a test can force either failure. The executor these tests run on
+// has no session bus, so open() could otherwise never reach its own error
+// messages.
+var (
+	dialBus = func() (*dbus.Conn, error) { return dbus.SessionBus() }
+
+	hasSecretService = func(conn *dbus.Conn) bool {
+		var has bool
+		if err := conn.BusObject().Call("org.freedesktop.DBus.NameHasOwner", 0, secretsName).Store(&has); err != nil {
+			return false
+		}
+		if has {
+			return true
+		}
+		// A keyring can be installed and D-Bus-activatable without being
+		// running yet; the daemon will start it on first use. Treat that as
+		// present so brig prompts rather than declines.
+		var names []string
+		if err := conn.BusObject().Call("org.freedesktop.DBus.ListActivatableNames", 0).Store(&names); err != nil {
+			return false
+		}
+		return slices.Contains(names, secretsName)
+	}
+)
+
+func open() (Store, error) { return openService(service) }
+
+// openService is open() with the namespace as an argument, so the integration
+// test can run under a service value of its own and never touch a real brig
+// secret.
+func openService(service string) (*secretService, error) {
+	conn, err := dialBus()
+	if err != nil {
+		return nil, errNoBus(err)
+	}
+	if !hasSecretService(conn) {
+		return nil, errNoService()
+	}
+	s := &secretService{service: service, conn: conn}
+	if err := s.openSession(); err != nil {
+		return nil, err
+	}
+	return s, nil
+}
+
+// errNoBus and errNoService are the two shapes of the same refusal, and each
+// says which half is missing and both ways out: install a keyring, or bind the
+// secret to a command that holds no plaintext at rest. Both fixes appear in one
+// message the way the darwin messages read, because a user who cannot install a
+// keyring still has the second door.
+func errNoBus(err error) error {
+	return fmt.Errorf("%w: no D-Bus session bus to reach a keyring on. Install a keyring "+
+		"(gnome-keyring or KWallet, both speak the Secret Service API) and log in to a session "+
+		"that starts it, or bind the secret to a command instead with "+
+		"`brig secret import <profile> --from-command '<sh>'`, which holds no plaintext at rest: %v",
+		ErrUnsupported, err)
+}
+
+func errNoService() error {
+	return fmt.Errorf("%w: a D-Bus session bus is running but no Secret Service answers on it. "+
+		"Install a keyring (gnome-keyring or KWallet, both speak the Secret Service API) and log in "+
+		"to a session that starts it, or bind the secret to a command instead with "+
+		"`brig secret import <profile> --from-command '<sh>'`, which holds no plaintext at rest",
+		ErrUnsupported)
+}
+
+func (s *secretService) Kind() string { return "secret-service" }
+
+// openSession opens a plain (unencrypted) transport session. brig is a local
+// process talking to a local keyring over the user's own session bus, so the
+// DH-encrypted session the API also offers guards a channel that is already
+// inside the trust boundary; the plain session keeps the code the value round
+// trips through small, which is the property that matters for a credential.
+func (s *secretService) openSession() error {
+	var output dbus.Variant
+	var session dbus.ObjectPath
+	err := s.service0().Call(methodOpenSession, 0, "plain", dbus.MakeVariant("")).Store(&output, &session)
+	if err != nil {
+		return fmt.Errorf("opening a Secret Service session: %w", err)
+	}
+	s.session = session
+	return nil
+}
+
+// service0 is the Secret Service object; item0 and collection0 are an item and
+// a collection by path. The names keep the call sites reading as the interface
+// they speak rather than as bus plumbing.
+func (s *secretService) service0() dbus.BusObject {
+	return s.conn.Object(secretsName, secretsPath)
+}
+
+func (s *secretService) object(path dbus.ObjectPath) dbus.BusObject {
+	return s.conn.Object(secretsName, path)
+}
+
+// Create stores a new secret with no provenance, and returns ErrExists if the
+// name is taken.
+func (s *secretService) Create(name string, value []byte) error {
+	if err := ValidName(name); err != nil {
+		return err
+	}
+	return s.write(name, value, Provenance{}, false)
+}
+
+// Update replaces an existing value, keeping no provenance, and returns
+// ErrNotFound rather than creating: an update naming a secret that is not there
+// is a typo, and creating it silently would hide that.
+func (s *secretService) Update(name string, value []byte) error {
+	if err := ValidName(name); err != nil {
+		return err
+	}
+	return s.write(name, value, Provenance{}, true)
+}
+
+// Write is the Annotator arm: create or update carrying provenance, so an
+// imported credential's source and expiry ride on the item's attributes the way
+// they ride in the keychain comment on macOS. A zero Provenance writes no
+// provenance attribute, which is how a hand-created secret reads back as absent.
+func (s *secretService) Write(name string, value []byte, p Provenance, update bool) error {
+	if err := ValidName(name); err != nil {
+		return err
+	}
+	return s.write(name, value, p, update)
+}
+
+// write is the shared create/update path: unlock the collection, decide against
+// what is already there, then either create a fresh item or set the value and
+// attributes of the existing one.
+//
+// Create and Update are separate calls rather than one CreateItem(replace)
+// because the Secret Service matches "the same item" on the whole attribute
+// set: an update that changed the provenance would not match the old item and
+// would leave two behind. Setting the value and attributes of the item found by
+// name is what keeps an update in place -- and never the delete-then-create
+// shape secretimport.go warns against.
+func (s *secretService) write(name string, value []byte, p Provenance, update bool) error {
+	collPath, err := s.defaultCollection()
+	if err != nil {
+		return err
+	}
+	if err := s.unlock(collPath); err != nil {
+		return err
+	}
+	existing, err := s.find(name)
+	if err != nil {
+		return err
+	}
+	switch {
+	case update && existing == noObject:
+		return ErrNotFound
+	case !update && existing != noObject:
+		return ErrExists
+	}
+	attrs, err := attributes(s.service, name, p)
+	if err != nil {
+		return err
+	}
+	sec := dbusSecret{Session: s.session, Parameters: []byte{}, Value: value, ContentType: contentType}
+	if update {
+		return s.replace(existing, attrs, sec)
+	}
+	return s.create(collPath, name, attrs, sec)
+}
+
+func (s *secretService) create(collPath dbus.ObjectPath, name string, attrs map[string]string, sec dbusSecret) error {
+	props := map[string]dbus.Variant{
+		// The label is what a keyring UI shows, so say whose item it is.
+		itemIface + ".Label":      dbus.MakeVariant("brig: " + name),
+		itemIface + ".Attributes": dbus.MakeVariant(attrs),
+	}
+	var item, prompt dbus.ObjectPath
+	// replace=false: the collision has already been ruled out above, and a
+	// concurrent create racing this one should surface rather than clobber.
+	err := s.object(collPath).Call(methodCreateItem, 0, props, sec, false).Store(&item, &prompt)
+	if err != nil {
+		return fmt.Errorf("storing %q: %w", name, err)
+	}
+	return s.await(prompt)
+}
+
+// replace sets the value and rewrites the whole attribute set of an existing
+// item. Rewriting all the attributes -- not only the value -- is what clears a
+// stale provenance on a hand update: attrs omits the provenance key when the
+// Provenance is zero, so the old expiry does not outlive the value it described,
+// matching the keychain's clear-on-update behaviour.
+func (s *secretService) replace(item dbus.ObjectPath, attrs map[string]string, sec dbusSecret) error {
+	obj := s.object(item)
+	if err := obj.Call(methodSetSecret, 0, sec).Err; err != nil {
+		return fmt.Errorf("updating the value: %w", err)
+	}
+	if err := obj.SetProperty(propAttributes, dbus.MakeVariant(attrs)); err != nil {
+		return fmt.Errorf("updating the attributes: %w", err)
+	}
+	return nil
+}
+
+// Read returns the value, or ErrNotFound.
+func (s *secretService) Read(name string) ([]byte, error) {
+	if err := ValidName(name); err != nil {
+		return nil, err
+	}
+	item, err := s.find(name)
+	if err != nil {
+		return nil, err
+	}
+	if item == noObject {
+		return nil, ErrNotFound
+	}
+	if err := s.unlock(item); err != nil {
+		return nil, err
+	}
+	var sec dbusSecret
+	if err := s.object(item).Call(methodGetSecret, 0, s.session).Store(&sec); err != nil {
+		return nil, fmt.Errorf("reading %q: %w", name, err)
+	}
+	return sec.Value, nil
+}
+
+// Delete removes a secret, or returns ErrNotFound.
+func (s *secretService) Delete(name string) error {
+	if err := ValidName(name); err != nil {
+		return err
+	}
+	item, err := s.find(name)
+	if err != nil {
+		return err
+	}
+	if item == noObject {
+		return ErrNotFound
+	}
+	var prompt dbus.ObjectPath
+	if err := s.object(item).Call(methodDeleteItem, 0).Store(&prompt); err != nil {
+		return fmt.Errorf("deleting %q: %w", name, err)
+	}
+	return s.await(prompt)
+}
+
+// List returns every secret in brig's namespace, sorted by name. It searches on
+// the service attribute alone, reads each item's attributes and Modified
+// property -- which need no unlock, so listing raises no prompt -- and never
+// reads a value.
+func (s *secretService) List() ([]Secret, error) {
+	items, err := s.search(map[string]string{attrKeyService: s.service})
+	if err != nil {
+		return nil, err
+	}
+	var list []Secret
+	for _, path := range items {
+		attrs, err := s.attributes(path)
+		if err != nil {
+			return nil, err
+		}
+		name := attrs[attrKeyName]
+		// A name outside brig's grammar is one brig did not write, and one it
+		// would refuse to read or remove. Listing it would offer the reader a
+		// secret every other verb then declines to touch.
+		if ValidName(name) != nil {
+			continue
+		}
+		list = append(list, Secret{
+			Name:       name,
+			Modified:   s.modified(path),
+			Provenance: provenanceFromAttributes(attrs),
+		})
+	}
+	slices.SortFunc(list, func(a, b Secret) int { return strings.Compare(a.Name, b.Name) })
+	return list, nil
+}
+
+// find returns the item matching brig's service and this name, or noObject when
+// there is none. A name is unique within the namespace, so the first match is
+// the answer.
+func (s *secretService) find(name string) (dbus.ObjectPath, error) {
+	items, err := s.search(map[string]string{attrKeyService: s.service, attrKeyName: name})
+	if err != nil {
+		return noObject, err
+	}
+	if len(items) == 0 {
+		return noObject, nil
+	}
+	return items[0], nil
+}
+
+// search returns every item, locked or not, matching the given attributes.
+// Locked items count: existence and listing must not depend on the collection
+// being unlocked, or a locked keyring would read as empty.
+func (s *secretService) search(attrs map[string]string) ([]dbus.ObjectPath, error) {
+	var unlocked, locked []dbus.ObjectPath
+	if err := s.service0().Call(methodSearchItems, 0, attrs).Store(&unlocked, &locked); err != nil {
+		return nil, fmt.Errorf("searching the keyring: %w", err)
+	}
+	return append(unlocked, locked...), nil
+}
+
+// attributes reads an item's attribute map through the Properties interface,
+// which does not decrypt the value and raises no prompt.
+func (s *secretService) attributes(item dbus.ObjectPath) (map[string]string, error) {
+	v, err := s.object(item).GetProperty(propAttributes)
+	if err != nil {
+		return nil, fmt.Errorf("reading item attributes: %w", err)
+	}
+	attrs, ok := v.Value().(map[string]string)
+	if !ok {
+		return map[string]string{}, nil
+	}
+	return attrs, nil
+}
+
+// modified reads the item's Modified property -- Unix seconds -- and answers the
+// zero time for an item that carries none. A backend that cannot supply a
+// modification time returns the zero value rather than inventing one; see
+// Secret.Modified.
+func (s *secretService) modified(item dbus.ObjectPath) time.Time {
+	v, err := s.object(item).GetProperty(propModified)
+	if err != nil {
+		return time.Time{}
+	}
+	secs, ok := v.Value().(uint64)
+	if !ok || secs == 0 {
+		return time.Time{}
+	}
+	return time.Unix(int64(secs), 0)
+}
+
+// defaultCollection is the path of the collection brig stores into: the alias
+// the keyring points at, or the well-known alias path when ReadAlias reports
+// none, which is the path the keyring will have created the default under.
+func (s *secretService) defaultCollection() (dbus.ObjectPath, error) {
+	var path dbus.ObjectPath
+	if err := s.service0().Call(methodReadAlias, 0, defaultAlias).Store(&path); err != nil {
+		return noObject, fmt.Errorf("finding the default keyring collection: %w", err)
+	}
+	if path == noObject {
+		return defaultAliasPath, nil
+	}
+	return path, nil
+}
+
+// unlock unlocks an object if it is locked, prompting the user through their
+// keyring UI when the service asks for one. Unlock on an already-unlocked
+// object is a no-op that returns no prompt, so this is safe to call before
+// every operation.
+func (s *secretService) unlock(obj dbus.ObjectPath) error {
+	var unlocked []dbus.ObjectPath
+	var prompt dbus.ObjectPath
+	if err := s.service0().Call(methodUnlock, 0, []dbus.ObjectPath{obj}).Store(&unlocked, &prompt); err != nil {
+		return fmt.Errorf("unlocking the keyring: %w", err)
+	}
+	return s.await(prompt)
+}
+
+// await drives a prompt to completion when the service returns one, and is a
+// no-op for noObject. The prompt is where the keyring UI asks the user to
+// unlock or to confirm; brig waits on its Completed signal rather than
+// returning while the dialog is still open, because the operation that asked
+// for the prompt has not happened until it closes.
+func (s *secretService) await(prompt dbus.ObjectPath) error {
+	if prompt == noObject {
+		return nil
+	}
+	if err := s.conn.AddMatchSignal(
+		dbus.WithMatchObjectPath(prompt),
+		dbus.WithMatchInterface(promptIface),
+		dbus.WithMatchMember(memberCompleted),
+	); err != nil {
+		return fmt.Errorf("watching the keyring prompt: %w", err)
+	}
+	ch := make(chan *dbus.Signal, 1)
+	s.conn.Signal(ch)
+	defer s.conn.RemoveSignal(ch)
+
+	if err := s.object(prompt).Call(methodPrompt, 0, "").Err; err != nil {
+		return fmt.Errorf("showing the keyring prompt: %w", err)
+	}
+	for sig := range ch {
+		if sig.Path != prompt || sig.Name != promptIface+"."+memberCompleted {
+			continue
+		}
+		// Completed carries (dismissed bool, result Variant). A dismissed
+		// prompt is the user declining, which is a refusal rather than a
+		// backend error.
+		if len(sig.Body) > 0 {
+			if dismissed, ok := sig.Body[0].(bool); ok && dismissed {
+				return fmt.Errorf("the keyring prompt was dismissed, so the keyring stayed locked")
+			}
+		}
+		return nil
+	}
+	return nil
+}
+
+// attributes maps a secret's name and provenance to the item attribute map, and
+// back. Kept a free function, and tested both ways without a bus, because the
+// mapping is the part a keyring never sees change but every verb depends on.
+func attributes(service, name string, p Provenance) (map[string]string, error) {
+	attrs := map[string]string{
+		attrKeyService: service,
+		attrKeyName:    name,
+	}
+	if !p.IsZero() {
+		encoded, err := p.Encode()
+		if err != nil {
+			return nil, err
+		}
+		attrs[attrKeyProvenance] = encoded
+	}
+	return attrs, nil
+}
+
+// provenanceFromAttributes reads the provenance attribute back through
+// DecodeProvenance, which answers false for anything brig did not write -- an
+// item another process planted in the namespace, or one written before this
+// field existed. Either way the zero value is what callers see, the same
+// contract Modified follows.
+func provenanceFromAttributes(attrs map[string]string) Provenance {
+	p, ok := DecodeProvenance(attrs[attrKeyProvenance])
+	if !ok {
+		return Provenance{}
+	}
+	return p
+}

--- a/internal/secret/secretservice_linux_test.go
+++ b/internal/secret/secretservice_linux_test.go
@@ -129,6 +129,29 @@ func TestOpenReportsNoService(t *testing.T) {
 	}
 }
 
+// A keyring that is running but has no default collection: ReadAlias("default")
+// returns noObject ("/"), which the service means as "there is no default", not
+// "the default is at the well-known path". resolveCollection turns that into a
+// refusal in the shape of the other two -- wrapping ErrUnsupported, naming the
+// missing default collection and both ways out -- rather than letting a write
+// fall through to a CreateItem that fails halfway with a raw D-Bus string.
+func TestResolveCollectionReportsNoDefaultCollection(t *testing.T) {
+	orig := readDefaultAlias
+	readDefaultAlias = func(*secretService) (dbus.ObjectPath, error) { return noObject, nil }
+	defer func() { readDefaultAlias = orig }()
+
+	s := &secretService{service: service}
+	err := s.resolveCollection()
+	if !errors.Is(err, ErrUnsupported) {
+		t.Fatalf("resolveCollection() = %v, want it to wrap ErrUnsupported", err)
+	}
+	for _, want := range []string{"default collection", "desktop session", "--from-command"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("resolveCollection() = %v, want it to mention %q", err, want)
+		}
+	}
+}
+
 // swapSeams replaces dialBus and hasSecretService for a test and returns a
 // function that puts the originals back. A nil hasSecretService leaves the real
 // one, which the no-bus test never reaches anyway.

--- a/internal/secret/secretservice_linux_test.go
+++ b/internal/secret/secretservice_linux_test.go
@@ -1,0 +1,309 @@
+//go:build linux
+
+package secret
+
+import (
+	"bytes"
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/godbus/dbus/v5"
+)
+
+// The attribute mapping is the part that never touches a bus and every verb
+// depends on: a secret's name and provenance to the item attributes and back.
+
+func TestAttributesRoundTripWithProvenance(t *testing.T) {
+	want := Provenance{V: ProvenanceVersion, From: "keychain:Claude Code-credentials", ExpiresAt: 1755436980000}
+	attrs, err := attributes("sh.brig.test", "gh-token", want)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if attrs[attrKeyService] != "sh.brig.test" {
+		t.Errorf("service attribute = %q, want the namespace", attrs[attrKeyService])
+	}
+	if attrs[attrKeyName] != "gh-token" {
+		t.Errorf("name attribute = %q, want the secret name", attrs[attrKeyName])
+	}
+	if got := provenanceFromAttributes(attrs); got != want {
+		t.Errorf("provenance round trip = %+v, want %+v", got, want)
+	}
+}
+
+// A zero Provenance writes no provenance attribute at all, and reads back as
+// absent -- the same contract a hand-created secret carries.
+func TestAttributesOmitZeroProvenance(t *testing.T) {
+	attrs, err := attributes("sh.brig.test", "plain", Provenance{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := attrs[attrKeyProvenance]; ok {
+		t.Errorf("a zero provenance still wrote an attribute: %q", attrs[attrKeyProvenance])
+	}
+	if got := provenanceFromAttributes(attrs); !got.IsZero() {
+		t.Errorf("provenance = %+v, want the zero value", got)
+	}
+}
+
+// An attribute another process planted -- not brig's encoding -- reads back as
+// absent rather than as a provenance brig trusts, the same way DecodeProvenance
+// answers false for it on macOS.
+func TestProvenanceFromForeignAttributesIsAbsent(t *testing.T) {
+	for _, attrs := range []map[string]string{
+		{attrKeyProvenance: "not brig's encoding"},
+		{}, // no attribute at all
+	} {
+		if got := provenanceFromAttributes(attrs); !got.IsZero() {
+			t.Errorf("provenance from %v = %+v, want the zero value", attrs, got)
+		}
+	}
+}
+
+// The grammar belongs to the store: a name past maxName is refused before
+// anything reaches the bus, so this holds with no keyring at all.
+func TestNameValidationAgainstMaxName(t *testing.T) {
+	ok := strings.Repeat("a", maxName)
+	if err := ValidName(ok); err != nil {
+		t.Errorf("a name of exactly %d characters was refused: %v", maxName, err)
+	}
+	tooLong := strings.Repeat("a", maxName+1)
+	if err := ValidName(tooLong); err == nil {
+		t.Errorf("a name of %d characters was accepted", maxName+1)
+	}
+	// And every verb refuses it at the boundary, before dereferencing a
+	// connection -- the store has none here on purpose.
+	s := &secretService{service: service}
+	if err := s.Create(tooLong, []byte("v")); err == nil {
+		t.Error("Create accepted an over-long name")
+	}
+	if _, err := s.Read(tooLong); err == nil {
+		t.Error("Read accepted an over-long name")
+	}
+	if err := s.Update(tooLong, []byte("v")); err == nil {
+		t.Error("Update accepted an over-long name")
+	}
+	if err := s.Delete(tooLong); err == nil {
+		t.Error("Delete accepted an over-long name")
+	}
+}
+
+// open()'s two failure branches, forced through the injectable seams, because
+// the executor has no session bus to reach either of them naturally. Both wrap
+// ErrUnsupported and both name the two ways out, so a caller can tell the
+// platform-unsupported case apart and a reader is told how to fix it.
+
+func TestOpenReportsNoBus(t *testing.T) {
+	restore := swapSeams(func() (*dbus.Conn, error) { return nil, errors.New("dial refused") }, nil)
+	defer restore()
+
+	_, err := open()
+	if !errors.Is(err, ErrUnsupported) {
+		t.Fatalf("open() = %v, want it to wrap ErrUnsupported", err)
+	}
+	for _, want := range []string{"session bus", "gnome-keyring", "--from-command"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("open() = %v, want it to mention %q", err, want)
+		}
+	}
+}
+
+func TestOpenReportsNoService(t *testing.T) {
+	restore := swapSeams(
+		func() (*dbus.Conn, error) { return nil, nil },
+		func(*dbus.Conn) bool { return false },
+	)
+	defer restore()
+
+	_, err := open()
+	if !errors.Is(err, ErrUnsupported) {
+		t.Fatalf("open() = %v, want it to wrap ErrUnsupported", err)
+	}
+	for _, want := range []string{"Secret Service", "gnome-keyring", "--from-command"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("open() = %v, want it to mention %q", err, want)
+		}
+	}
+}
+
+// swapSeams replaces dialBus and hasSecretService for a test and returns a
+// function that puts the originals back. A nil hasSecretService leaves the real
+// one, which the no-bus test never reaches anyway.
+func swapSeams(dial func() (*dbus.Conn, error), has func(*dbus.Conn) bool) func() {
+	origDial, origHas := dialBus, hasSecretService
+	dialBus = dial
+	if has != nil {
+		hasSecretService = has
+	}
+	return func() { dialBus, hasSecretService = origDial, origHas }
+}
+
+// The integration test runs only against a real keyring: DBUS_SESSION_BUS_ADDRESS
+// set and a Secret Service answering. It stays under a service attribute value
+// of its own so it never touches a real brig secret, and it removes what it
+// creates.
+
+// testService prefixes every service value the integration test invents, so a
+// run that died before cleanup is distinguishable from a real brig namespace.
+const testService = "sh.brig.secret.test."
+
+func integrationStore(t *testing.T) *secretService {
+	t.Helper()
+	if os.Getenv("DBUS_SESSION_BUS_ADDRESS") == "" {
+		t.Skip("no session bus: set DBUS_SESSION_BUS_ADDRESS and run a Secret Service keyring to exercise the backend")
+	}
+	var b [8]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		t.Fatal(err)
+	}
+	s, err := openService(testService + hex.EncodeToString(b[:]))
+	if err != nil {
+		if errors.Is(err, ErrUnsupported) {
+			t.Skipf("no Secret Service on the session bus: %v", err)
+		}
+		t.Fatalf("openService: %v", err)
+	}
+	return s
+}
+
+// cleanup deletes a name at test end, ignoring an already-absent one.
+func cleanup(t *testing.T, s *secretService, name string) {
+	t.Helper()
+	t.Cleanup(func() {
+		if err := s.Delete(name); err != nil && !errors.Is(err, ErrNotFound) {
+			t.Logf("cleanup of %q: %v", name, err)
+		}
+	})
+}
+
+func TestIntegrationCreateReadUpdateDelete(t *testing.T) {
+	s := integrationStore(t)
+	cleanup(t, s, "roundtrip")
+
+	value := []byte("-----BEGIN KEY-----\nline two\n\x00\xff\xfe")
+	if err := s.Create("roundtrip", value); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	got, err := s.Read("roundtrip")
+	if err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+	if !bytes.Equal(got, value) {
+		t.Errorf("Read = %q, want %q", got, value)
+	}
+
+	updated := []byte("second value")
+	if err := s.Update("roundtrip", updated); err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	if got, err := s.Read("roundtrip"); err != nil || !bytes.Equal(got, updated) {
+		t.Errorf("Read after Update = %q, %v; want %q", got, err, updated)
+	}
+
+	if err := s.Delete("roundtrip"); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	if _, err := s.Read("roundtrip"); !errors.Is(err, ErrNotFound) {
+		t.Errorf("Read after Delete = %v, want ErrNotFound", err)
+	}
+}
+
+func TestIntegrationReadAndDeleteReportAbsence(t *testing.T) {
+	s := integrationStore(t)
+	if _, err := s.Read("ghost"); !errors.Is(err, ErrNotFound) {
+		t.Errorf("Read of an absent secret = %v, want ErrNotFound", err)
+	}
+	if err := s.Delete("ghost"); !errors.Is(err, ErrNotFound) {
+		t.Errorf("Delete of an absent secret = %v, want ErrNotFound", err)
+	}
+}
+
+func TestIntegrationCreateRefusesACollision(t *testing.T) {
+	s := integrationStore(t)
+	cleanup(t, s, "dup")
+	if err := s.Create("dup", []byte("first")); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if err := s.Create("dup", []byte("second")); !errors.Is(err, ErrExists) {
+		t.Fatalf("second Create = %v, want ErrExists", err)
+	}
+	if got, err := s.Read("dup"); err != nil || string(got) != "first" {
+		t.Errorf("Read = %q, %v; want the first value left intact", got, err)
+	}
+}
+
+func TestIntegrationUpdateNeverCreates(t *testing.T) {
+	s := integrationStore(t)
+	if err := s.Update("absent", []byte("v")); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("Update of an absent secret = %v, want ErrNotFound", err)
+	}
+	if _, err := s.Read("absent"); !errors.Is(err, ErrNotFound) {
+		t.Error("Update created a secret it should have refused")
+	}
+}
+
+func TestIntegrationListReturnsOnlyOurNamespace(t *testing.T) {
+	s := integrationStore(t)
+	for _, n := range []string{"beta", "alpha", "gamma"} {
+		cleanup(t, s, n)
+		if err := s.Create(n, []byte("v-"+n)); err != nil {
+			t.Fatalf("Create %q: %v", n, err)
+		}
+	}
+	list, err := s.List()
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(list) != 3 {
+		t.Fatalf("List returned %d secrets, want 3: %+v", len(list), list)
+	}
+	// Sorted by name, so the output is stable between runs.
+	for i, want := range []string{"alpha", "beta", "gamma"} {
+		if list[i].Name != want {
+			t.Errorf("list[%d] = %q, want %q", i, list[i].Name, want)
+		}
+	}
+}
+
+func TestIntegrationProvenanceRoundTrip(t *testing.T) {
+	s := integrationStore(t)
+	cleanup(t, s, "prov")
+
+	want := Provenance{V: ProvenanceVersion, From: "keychain:Claude Code-credentials", ExpiresAt: 1755436980000}
+	if err := s.Write("prov", []byte("value"), want, false); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	if got := findSecret(t, s, "prov").Provenance; got != want {
+		t.Errorf("provenance after Write = %+v, want %+v", got, want)
+	}
+
+	// A hand update carries no provenance, and the old one must not outlive the
+	// value it described.
+	if err := s.Update("prov", []byte("renewed-by-hand")); err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	if got := findSecret(t, s, "prov").Provenance; !got.IsZero() {
+		t.Errorf("provenance after a hand Update = %+v, want the zero value", got)
+	}
+}
+
+// findSecret is List filtered to one name, for a test that wants a secret's
+// metadata rather than its value: Read returns neither Provenance nor Modified,
+// and List is the only path that does.
+func findSecret(t *testing.T, s *secretService, name string) Secret {
+	t.Helper()
+	list, err := s.List()
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	for _, sec := range list {
+		if sec.Name == name {
+			return sec
+		}
+	}
+	t.Fatalf("List did not include %q: %+v", name, list)
+	return Secret{}
+}


### PR DESCRIPTION
`brig secret` worked on macOS only, so a Linux user kept credentials in environment variables, the path `brig secret import` exists to replace, on the platform where brig has the container runtime story.

Linux now stores into a Secret Service keyring on the session bus, which is what `gnome-keyring` and KWallet both speak. One item per secret in the default collection, tagged with a `service` attribute of brig's own so `List` searches by attribute and touches nothing else in the keyring. Provenance goes in item attributes with the encoding `provenance.go` already defines; `Modified` comes from the item. The collection is unlocked through the keyring's own prompt when locked. `Kind()` is `secret-service`. The `Store` interface is unchanged and `Annotator` is implemented; `keychain_other.go` keeps every other non-darwin platform.

When there is no session bus, or no service answers on it, `open()` says which of the two is missing and both ways out: install a keyring and log in to a session that starts it, or bind the secret to a command with `brig secret import <profile> --from-command`, which holds no plaintext at rest. No file fallback, on purpose.

New dependency: `github.com/godbus/dbus/v5`, and nothing else.

Two commits: the backend, then the two README rows and the two `docs/secrets.md` passages that said "macOS only".

**Testing.** Unit tests cover the attribute mapping both ways, name validation and the two error shapes. The integration test runs create, read, update, delete, list, provenance round-trip and `ErrExists` under a test-only `service` value, and skips unless `DBUS_SESSION_BUS_ADDRESS` names a bus with a service on it. Neither the fleet executor that wrote this nor this Mac has one, so **the backend has not yet been exercised against a live keyring**; a reviewer on a Linux desktop running `go test ./internal/secret/` would close that gap. Builds and vets on darwin and linux; `go vet ./...`, `go test -race ./...` and `./script/smoke.sh` pass here.

Fixes: #16