### PR TITLE
ci: refuse a change that removes a test without saying so

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,23 @@ jobs:
       - name: cross-compile linux/amd64
         run: GOOS=linux GOARCH=amd64 go build ./...
 
+  tests-kept:
+    name: tests kept
+    runs-on: ubuntu-latest
+    # Only a pull request has a base to compare against, and only a pull
+    # request can carry the label that says a removal was meant.
+    if: >-
+      github.event_name == 'pull_request' &&
+      !contains(github.event.pull_request.labels.*.name, 'removes-tests')
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          # The merge base has to be in the clone for the comparison to have
+          # anything to compare with.
+          fetch-depth: 0
+      - name: Check that no test disappeared
+        run: ./script/check-tests-kept.sh "origin/${{ github.base_ref }}"
+
   release-config:
     name: release config
     runs-on: ubuntu-latest

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -232,6 +232,12 @@ Signed-off-by: Jane Doe <jane@nofire.ai>
 - **Complete the PR template** (where one exists) and write a meaningful PR
   title and description: what the change does, why, how it was tested, and
   anything reviewers should pay particular attention to.
+- **A test that disappears is a claim.** CI refuses a pull request that
+  removes a test, because a change which reverts more than it meant to takes
+  the failing tests with it and every other check stays green. A rename or a
+  deliberate removal is ordinary work: label the pull request
+  `removes-tests` and say why in the description. See
+  `script/check-tests-kept.sh`.
 - **Test locally before opening.** The build should not break, all tests
   should pass, and new functionality should come with new or updated tests.
 - **Use draft PRs** for work in progress or early feedback. Mark the PR ready

--- a/script/check-tests-kept.sh
+++ b/script/check-tests-kept.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# Refuse a change that removes a test without saying so.
+#
+# A revert of a feature takes that feature's tests with it, so the tree that
+# remains is an older codebase that passes its own suite: nothing fails, and
+# `go test` reports success on a repository that has quietly lost work. That
+# is not a hypothetical. brig lost the content of four merged pull requests
+# this way, and the branch, the merge and every CI run were green throughout
+# (see PR #155). No test can catch its own deletion; only a comparison across
+# revisions can.
+#
+# So compare the test names the base has with the test names the head has, and
+# fail on any that vanished. Names, read out of the source, rather than
+# `go test -list`: the base of a rebase does not always compile, and a check
+# meant to run when something is wrong must not need a working build.
+#
+# Renaming or deleting a test on purpose is ordinary work. Say so with the
+# `removes-tests` label on the pull request, and this step is skipped.
+#
+# Usage: check-tests-kept.sh <base-ref> [head-ref]
+set -euo pipefail
+
+base=${1:?usage: check-tests-kept.sh <base-ref> [head-ref]}
+head=${2:-HEAD}
+
+# The merge base, not the base branch's tip: what matters is the tests this
+# change started from, not the ones another change has landed since.
+fork=$(git merge-base "$base" "$head")
+
+names() {
+	# `func TestFoo(` and its Benchmark, Fuzz and Example siblings, in test
+	# files only. -h because the file a test lives in is free to change.
+	git grep -h -E '^func (Test|Benchmark|Fuzz|Example)[A-Za-z0-9_]*\(' "$1" -- '*_test.go' 2>/dev/null |
+		sed -E 's/^func ([A-Za-z0-9_]+).*/\1/' | sort -u
+}
+
+removed=$(comm -23 <(names "$fork") <(names "$head"))
+
+if [ -z "$removed" ]; then
+	printf 'every test present at %s is still here\n' "$(git rev-parse --short "$fork")"
+	exit 0
+fi
+
+count=$(printf '%s\n' "$removed" | wc -l | tr -d ' ')
+cat >&2 <<MSG
+$count test(s) present at $(git rev-parse --short "$fork") are gone at $(git rev-parse --short "$head"):
+
+$(printf '%s\n' "$removed" | sed 's/^/  /')
+
+A test that disappears is either a rename, a deliberate removal, or a change
+that reverted more than it meant to -- and the third kind is invisible to
+every other check, because the tests that would have failed went with it.
+
+If the removal is intended, label the pull request 'removes-tests'.
+Otherwise compare against the merge base and look at what else went with them:
+
+  git diff --stat $(git rev-parse --short "$fork") $(git rev-parse --short "$head")
+MSG
+exit 1


### PR DESCRIPTION
A revert takes the reverted feature's tests with it, so what remains is an older codebase that passes its own suite. Nothing fails. That is how brig lost the content of #130, #131, #132 and #135 with the branch, the merge and every CI run green throughout — see #155.

No test can catch its own deletion. Only a comparison across revisions can. `script/check-tests-kept.sh` lists the test, benchmark, fuzz and example names at the merge base and at the head, and fails on any that vanished.

Two deliberate choices:

- **Names are read out of the source**, not from `go test -list`. The base of a rebase does not always compile, and a check meant to run when something is wrong must not need a working build.
- **The merge base is the reference**, not the base branch's tip, so a change is judged against what it started from rather than against what landed beside it. That is the same comparison that catches a branch rewritten onto a new base while carrying an old tree, which is the mistake behind #155.

Renaming or removing a test on purpose is ordinary work: the `removes-tests` label skips the step, and `CONTRIBUTING.md` says so.

**Verification.** Against `1fb3036` and `7da1279`, the two commits that caused the regression, it reports 78 and 12 removed tests and exits 1 — it would have stopped both. It passes on every branch open today: #137, #141, #153, #154 and this one. It flags exactly one open PR, #155, for three tests that #130 and #132 renamed:

| flagged | successor it was renamed to |
| --- | --- |
| `TestBrigFlagsOverlapWithClaudeCodeOnlyWhereKnown` | `TestBrigFlagsOverlapWithShippedAgentsOnlyWhereKnown` |
| `TestAttachSaysThePolicyIsNotEnforcedYet` | `TestAttachSaysWhereThePolicyIsEnforced` |
| `TestCheckSaysThePolicyIsNotEnforcedYet` | `TestCheckSaysWhereThePolicyIsEnforced` |

All three successors are present on that branch, so the label is the right answer there rather than a change to the script. I have labelled #155 accordingly.

This targets `main` directly and touches nothing else in flight: one new script, one CI job, four lines of CONTRIBUTING.

Refs: #155