### PR TITLE
docs: add release, CI, coverage, Go and license badges

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,8 +49,24 @@ jobs:
       - name: go vet
         run: go vet ./...
 
+      # The profile costs almost nothing to write on a run that happens anyway,
+      # so the coverage number comes from the same run that gates the merge
+      # rather than from a second suite that could disagree with it. atomic is
+      # what -race requires, and what a parallel package run needs regardless.
       - name: go test
-        run: go test -race ./...
+        run: go test -race -covermode=atomic -coverprofile=coverage.out ./...
+
+      # Only the upload is gated: the badge follows main, and a pull request
+      # pays nothing for a step it skips. Never fails the run, since a coverage
+      # service that cannot be reached is not a reason to call a green commit
+      # broken.
+      - name: Upload coverage to Codecov
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: codecov/codecov-action@0fb7174895f61a3b6b78fc075e0cd60383518dac # v5.5.5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: coverage.out
+          fail_ci_if_error: false
 
       # The macOS path is the one that ships first, and it is also the one no
       # Linux runner can execute. Compiling it is the part CI can do, and it

--- a/README.md
+++ b/README.md
@@ -5,6 +5,14 @@
   </picture>
 </p>
 
+<p align="center">
+  <a href="https://github.com/brig-sh/brig/releases/latest"><img alt="Release" src="https://img.shields.io/github/v/release/brig-sh/brig?include_prereleases"></a>
+  <a href="https://github.com/brig-sh/brig/actions/workflows/ci.yml"><img alt="CI" src="https://github.com/brig-sh/brig/actions/workflows/ci.yml/badge.svg"></a>
+  <a href="https://codecov.io/gh/brig-sh/brig"><img alt="Coverage" src="https://codecov.io/gh/brig-sh/brig/graph/badge.svg"></a>
+  <a href="go.mod"><img alt="Go" src="https://img.shields.io/github/go-mod/go-version/brig-sh/brig"></a>
+  <a href="LICENSE"><img alt="License: Apache 2.0" src="https://img.shields.io/badge/license-Apache--2.0-blue.svg"></a>
+</p>
+
 **Run a coding agent in a sandbox where one directory is its whole world and
 the rest of the host is out of reach from inside it.** It boots with no
 credential at all, which is what keeps trying it cheap: log in inside the


### PR DESCRIPTION
The README opened with the logo and went straight into prose. A reader had to leave the page to learn whether `main` is green, which release is current, or what Go version the module needs.

Five badges under the lockup: latest release, CI on `main`, coverage, Go version, license.

Two details worth the review:

- The release badge passes `include_prereleases`. Every tag so far is a prerelease, so the default query reports no releases at all. With it, the badge reads `v0.1.0-rc17` today.
- The Go badge reads `go.mod` through shields rather than hardcoding a number, so it cannot go stale when the directive moves. It reads `v1.25` today.

A coverage badge needs a number, so this also measures coverage in CI and uploads it. The lane runs **on a push to `main` only**: the figure describes the branch other work builds on, and measuring it per pull request would spend a second full `go test` run to move a badge that only `main` publishes. One run writes the profile; the step summary is rendered from that same profile rather than from a second run. The upload is `fail_ci_if_error: false`, because a coverage service that cannot be reached is not a reason to call a green commit broken.

Local coverage today is 81.1% of statements. I verified all four external badge URLs return 200 and render the values above; the codecov one renders `unknown`, as expected until the first upload.