### PR TITLE
feat(cli): add shell completion for bash, zsh and fish

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -73,6 +73,15 @@ archives:
     files:
       - README.md
       - LICENSE
+      # The completion scripts, verbatim: these are the bytes `brig completion
+      # <shell>` prints, so the archive and the command cannot disagree about
+      # what a shell is asked to source. The cask below installs them.
+      - src: cmd/brig/completions/brig.bash
+        dst: completions/brig.bash
+      - src: cmd/brig/completions/brig.zsh
+        dst: completions/brig.zsh
+      - src: cmd/brig/completions/brig.fish
+        dst: completions/brig.fish
 
 checksum:
   name_template: checksums.txt
@@ -185,6 +194,14 @@ homebrew_casks:
       token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
     homepage: https://github.com/brig-sh/brig
     description: Run a coding agent in a sandbox, with the credentials it needs and none of the ones it does not
+    # Paths inside the archive above. brew puts each one where its shell reads
+    # completions from, so a cask install has completion without a second step
+    # -- which is the whole point of the closed flag sets: they only help a
+    # reader who can discover them.
+    completions:
+      bash: completions/brig.bash
+      zsh: completions/brig.zsh
+      fish: completions/brig.fish
     dependencies:
       # Guest-image signature verification degrades to a warning without it,
       # so ship it rather than let the check quietly do nothing.

--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ separate Linux re-implementation of it.
 | `brig secret create\|read\|update\|delete\|ls` | keep secrets in your keyring. macOS only for now |
 | `brig secret import <profile>` | fill that profile's secrets from your host, once. macOS only for now |
 | `brig telemetry status\|on\|off` | report what is counted, or turn the counting on or off. See [Telemetry](#telemetry) |
+| `brig completion bash\|zsh\|fish` | print a completion script for your shell. A cask install already has it; see [completions.md](docs/completions.md) |
 | `brig version` | |
 
 A `<ref>` is the session: `claude` is that agent's default session, and
@@ -657,6 +658,7 @@ The README is the overview. The details live in [docs/](docs/):
 - [profiles.md](docs/profiles.md) -- writing an agent profile, field by field
 - [policies.md](docs/policies.md) -- writing an egress policy, verb by verb, with a worked example
 - [secrets.md](docs/secrets.md) -- `brig secret`, verb by verb, with a worked example
+- [completions.md](docs/completions.md) -- shell completion: installing it, and what completes where
 - [security.md](docs/security.md) -- what the boundary is, and what it is not
 - [non-goals.md](docs/non-goals.md) -- what brig will not do, with the reason
   and what would reopen each one

--- a/cmd/brig/completion.go
+++ b/cmd/brig/completion.go
@@ -1,0 +1,694 @@
+package main
+
+import (
+	"embed"
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+
+	"github.com/brig-sh/brig/internal/policy"
+	"github.com/brig-sh/brig/internal/profile"
+	"github.com/brig-sh/brig/internal/wrap"
+)
+
+// Shell completion, in two commands.
+//
+// `brig completion <shell>` writes a script to stdout and installs nothing.
+// Where that script belongs differs per shell and per host, and a command that
+// edits a startup file has a blast radius nothing else here has; the docs say
+// the line to add.
+//
+// The scripts carry none of brig's vocabulary. Each one collects the words left
+// of the cursor, hands them to `brig __complete`, and renders what comes back.
+// So the verbs, the flags and where each flag is legal are declared once, in
+// Go, beside the table that already decides them -- and the three shells cannot
+// come to disagree about what brig accepts, because none of them knows.
+//
+// __complete answers on stdout and says nothing anywhere else. It is an ABI
+// between a script and the binary that generated it, so it is in no help text.
+
+//go:embed completions/brig.bash completions/brig.zsh completions/brig.fish
+var completionScripts embed.FS
+
+// completeVerb is the hidden engine's name. Two underscores, because it is not
+// a word anyone types and it must not read like one.
+const completeVerb = "__complete"
+
+const completionUsage = `brig completion -- print a shell completion script
+
+usage:
+  brig completion bash    print the bash script
+  brig completion zsh     print the zsh script
+  brig completion fish    print the fish script
+
+Nothing is installed for you. Write the script where your shell reads
+completions from, or source it from your startup file:
+
+  bash    brig completion bash >/usr/local/etc/bash_completion.d/brig
+          (or: eval "$(brig completion bash)" in ~/.bashrc)
+  zsh     brig completion zsh >"${fpath[1]}/_brig"
+          then start a new shell, or run: compinit
+  fish    brig completion fish >~/.config/fish/completions/brig.fish
+
+Completion offers the verbs, the refs ` + "`brig ls`" + ` prints, and the flags that are
+legal where the cursor is. Right of the ref the arguments are the agent's, so
+brig completes nothing there -- with one exception: on run the first word after
+the ref is the project directory brig mounts, and directories are offered for
+it.
+`
+
+// completionCmd prints the script for one shell.
+func completionCmd(out io.Writer, args []string) error {
+	if len(args) == 0 {
+		return usagef("completion needs a shell: bash, zsh or fish")
+	}
+	switch args[0] {
+	case "-h", "--help", "help":
+		_, err := io.WriteString(out, completionUsage)
+		return err
+	}
+	if len(args) > 1 {
+		return usagef("unexpected argument %q; `brig completion` takes one shell", args[1])
+	}
+	shell := args[0]
+	switch shell {
+	case "bash", "zsh", "fish":
+	default:
+		return usagef("no completion script for %q; brig has bash, zsh and fish", shell)
+	}
+	script, err := completionScripts.ReadFile("completions/brig." + shell)
+	if err != nil {
+		return err
+	}
+	_, err = out.Write(script)
+	return err
+}
+
+// The directive is the first line of an answer, and it says what the lines
+// under it are -- or, where a candidate list cannot say it, what the shell
+// should do instead.
+const (
+	// dirNames: candidates follow, already matched against the current word.
+	dirNames = ":names"
+	// dirDirs: complete directories. No candidates follow.
+	dirDirs = ":dirs"
+	// dirFiles: complete paths. No candidates follow.
+	dirFiles = ":files"
+	// dirNone: brig owns nothing at this position, so offer nothing. It has to
+	// be distinguishable from a failure: a shell that reads "brig had no
+	// answer" falls back to filenames, and the tail right of the ref is the one
+	// place brig has to stay silent rather than guess.
+	dirNone = ":none"
+)
+
+// completeCmd answers one completion request. It writes candidates to out and
+// nothing to stderr, ever, and returns no error: a notice or a failure printed
+// on a keystroke lands in the middle of the line the reader is typing.
+func completeCmd(out io.Writer, words []string) {
+	// The profile directory is read here rather than by the dispatcher, so that
+	// a file that will not parse costs a candidate rather than a line of
+	// diagnostics across the prompt. What loaded is completed; what did not is
+	// not, and the next real command says why.
+	_ = profile.Load(profile.Dir())
+	// Nothing below prints a notice, and this is the belt to that braces: a
+	// warning added anywhere the engine reaches stays silent on a keystroke.
+	verbosity = wrap.Quiet
+
+	directive, candidates := complete(words)
+	fmt.Fprintln(out, directive)
+	for _, c := range candidates {
+		fmt.Fprintln(out, c)
+	}
+}
+
+// verbs are the commands completion offers: the taught vocabulary, and only it.
+//
+// The retired spellings brig still answers to -- exec, shell, env, create,
+// reset, profiles, policies -- are deliberately absent. They keep working and
+// they say what replaced them; completing them would teach a word that is
+// leaving, to the one reader who has not typed it yet.
+var verbs = []string{
+	"agent",
+	"completion",
+	"doctor",
+	"info",
+	"ls",
+	"policy",
+	"rm",
+	"run",
+	"secret",
+	"sh",
+	"stop",
+	"telemetry",
+	"version",
+}
+
+// refVerbs are the verbs whose operand is a session ref.
+var refVerbs = map[string]bool{
+	"run":  true,
+	"sh":   true,
+	"stop": true,
+	"rm":   true,
+	"info": true,
+}
+
+// complete is the whole decision: which words are already on the line, and what
+// may stand where the cursor is.
+//
+// words is the line with `brig` dropped, and the word under the cursor is the
+// last of them -- empty when the cursor sits on fresh whitespace. That the
+// current word is always present, even empty, is what lets one function serve
+// both "finish this token" and "what can come next".
+func complete(words []string) (string, []string) {
+	if len(words) == 0 {
+		words = []string{""}
+	}
+	cur := words[len(words)-1]
+	before := words[:len(words)-1]
+
+	// The verb, and what stands between it and the cursor. Everything left of
+	// the verb is a global flag or a mistake, and both are skipped: a token brig
+	// would refuse is not a verb, so reading on is what keeps the rest of the
+	// line completable.
+	verb := ""
+	var rest []string
+	for i := 0; i < len(before); i++ {
+		a := before[i]
+		if strings.HasPrefix(a, "-") {
+			if mine, takesValue := ours(a, posGlobal); mine && takesValue && !strings.Contains(a, "=") {
+				i++
+			}
+			continue
+		}
+		verb, rest = a, before[i+1:]
+		break
+	}
+
+	if verb == "" {
+		if strings.HasPrefix(cur, "-") {
+			return names(cur, flagSpellings(posGlobal, ""))
+		}
+		// Only the verbs. `brig claude@refactor` with no verb works, and is in
+		// no help text on purpose; completing it would teach the second
+		// spelling that the taught line already covers.
+		return names(cur, verbs)
+	}
+
+	switch {
+	case verb == "completion":
+		if len(rest) > 0 {
+			return dirNone, nil
+		}
+		return names(cur, []string{"bash", "fish", "zsh"})
+	case verb == "ls":
+		// One flag, no operand.
+		if strings.HasPrefix(cur, "-") {
+			return names(cur, []string{"--quiet", "-q"})
+		}
+		return dirNone, nil
+	case verb == "doctor":
+		if strings.HasPrefix(cur, "-") {
+			return names(cur, []string{"--json"})
+		}
+		if len(bareWords(rest, posRun)) > 0 {
+			return dirNone, nil
+		}
+		return names(cur, agentNames())
+	case groups[verb] != nil:
+		return completeGroup(verb, rest, cur)
+	case refVerbs[verb]:
+		return completeRunLine(verb, rest, cur)
+	}
+	return dirNone, nil
+}
+
+// completeRunLine answers between a lifecycle verb and the end of the line.
+//
+// The three positions a brig line has are the whole of the logic here: brig's
+// own flags up to the ref, the ref, and then the agent's own vocabulary, which
+// brig does not complete because it does not own it.
+func completeRunLine(verb string, rest []string, cur string) (string, []string) {
+	// `--` is the reader saying the rest is the agent's. Nothing after it is
+	// brig's to complete, whatever it looks like.
+	for _, a := range rest {
+		if a == "--" {
+			return dirNone, nil
+		}
+	}
+
+	// The value of one of brig's own flags, when that is what the cursor is on.
+	if kind, ok := pendingValue(rest, cur); ok {
+		return operandCandidates(kind, cur)
+	}
+
+	bare := bareWords(rest, posRun)
+	refGiven := len(bare) > 0
+
+	if strings.HasPrefix(cur, "-") {
+		if refGiven {
+			// Right of the ref a flag is the agent's. brig has no list of
+			// another program's flags and should not pretend to.
+			return dirNone, nil
+		}
+		flags := flagSpellings(posRun, verb)
+		if verb == "rm" {
+			// --all names no session, so it is read before the run line rather
+			// than on it, and it is not in the table the line is built from.
+			flags = append(flags, "--all")
+			sort.Strings(flags)
+		}
+		return names(cur, flags)
+	}
+
+	if !refGiven {
+		return names(cur, refsFor(verb))
+	}
+	// On run the first bare word after the ref is the project brig mounts, and
+	// a project is a directory. Every other verb, and every word after that
+	// one, is the agent's.
+	if verb == "run" && len(bare) == 1 {
+		return dirDirs, nil
+	}
+	return dirNone, nil
+}
+
+// sessionVerbs act on a sandbox that already exists, so they are completed
+// from the sessions there are rather than from the agents there could be.
+//
+// run and sh both start one, and info reads a profile without booting
+// anything, so all three take an agent that has never run. stop and rm do not:
+// offering every agent there would offer a session that is not there, and on a
+// host with nothing running the honest answer is nothing.
+var sessionVerbs = map[string]bool{
+	"stop": true,
+	"rm":   true,
+}
+
+func refsFor(verb string) []string {
+	if sessionVerbs[verb] {
+		return wrap.SessionRefs()
+	}
+	return refCandidates()
+}
+
+// operand is what a word or a flag's value names.
+type operand int
+
+const (
+	// opNothing: brig has no list for this. A session label, a new agent's
+	// name, a secret's value -- words brig cannot enumerate, or should not.
+	opNothing operand = iota
+	opAgent
+	// opFileAgent is an agent with a file of its own. edit opens that file and
+	// rm removes it, so a built-in is a candidate both commands refuse.
+	opFileAgent
+	opPolicy
+	opRef
+	opDir
+	opFile
+	// opNetwork is the posture set --network takes.
+	opNetwork
+)
+
+func operandCandidates(kind operand, cur string) (string, []string) {
+	switch kind {
+	case opAgent:
+		return names(cur, agentNames())
+	case opFileAgent:
+		return names(cur, fileAgentNames())
+	case opPolicy:
+		return names(cur, policyNames())
+	case opRef:
+		return names(cur, refCandidates())
+	case opDir:
+		return dirDirs, nil
+	case opFile:
+		return dirFiles, nil
+	case opNetwork:
+		return names(cur, networkModes)
+	}
+	return dirNone, nil
+}
+
+// sub is one subcommand of a noun group: its flags, the flags that take a
+// value, and what its bare words name, in order.
+//
+// The noun groups build their arguments with a flag.FlagSet of their own,
+// inside the function that runs them, so there is no table to read them off.
+// This is that table, for completion only. A subcommand missing from here
+// completes nothing, which is the safe direction to be wrong in.
+type sub struct {
+	name string
+	// flags take no value.
+	flags []string
+	// values are the flags that do, and what the value names.
+	values map[string]operand
+	// operands is what the bare words after the subcommand name are. A word
+	// past the last slot completes nothing.
+	operands []operand
+}
+
+// groups is the noun commands and what stands under each.
+//
+// Secret names are absent on purpose. Listing them opens the store -- on macOS
+// that is `security dump-keychain`, and a secret-service backend can put an
+// unlock prompt on the screen -- and a keystroke must not do either. The
+// subcommands complete; their operands do not.
+var groups = map[string][]sub{
+	"agent": {
+		{name: "ls"},
+		{name: "show", flags: []string{"--json"}, operands: []operand{opAgent}},
+		{
+			name:     "new",
+			flags:    []string{"--json", "--force", "-f"},
+			values:   map[string]operand{"--from": opAgent},
+			operands: []operand{opNothing},
+		},
+		{name: "edit", operands: []operand{opFileAgent}},
+		{name: "rm", flags: []string{"--yes", "-y"}, operands: []operand{opFileAgent}},
+		{name: "import", operands: []operand{opFile}},
+		{
+			name:     "export",
+			flags:    []string{"--json", "--force", "-f"},
+			operands: []operand{opAgent, opFile},
+		},
+	},
+	"policy": {
+		{name: "ls"},
+		{name: "create", operands: []operand{opNothing}},
+		{name: "edit", operands: []operand{opPolicy}},
+		{name: "show", flags: []string{"--json"}, operands: []operand{opPolicy}},
+		{name: "rm", flags: []string{"--force", "-f"}, operands: []operand{opPolicy}},
+		{
+			name:     "attach",
+			values:   map[string]operand{"--name": opNothing, "-n": opNothing},
+			operands: []operand{opPolicy, opAgent},
+		},
+		{
+			name:     "detach",
+			values:   map[string]operand{"--name": opNothing, "-n": opNothing},
+			operands: []operand{opPolicy, opAgent},
+		},
+		{
+			name:     "check",
+			values:   map[string]operand{"--name": opNothing, "-n": opNothing},
+			operands: []operand{opAgent},
+		},
+	},
+	"secret": {
+		{name: "create", operands: []operand{opNothing}},
+		{name: "read", operands: []operand{opNothing}},
+		{name: "update", operands: []operand{opNothing}},
+		{name: "delete", flags: []string{"--yes", "-y"}, operands: []operand{opNothing}},
+		{name: "ls"},
+		{
+			name:     "import",
+			flags:    []string{"--dry-run", "--yes", "-y"},
+			values:   map[string]operand{"--from-command": opNothing},
+			operands: []operand{opAgent},
+		},
+	},
+	"telemetry": {
+		{name: "status"},
+		{name: "on"},
+		{name: "off"},
+	},
+}
+
+// completeGroup answers under a noun command: the subcommand, then whatever
+// that subcommand takes.
+func completeGroup(verb string, rest []string, cur string) (string, []string) {
+	subs := groups[verb]
+	name := ""
+	var words []string
+	for i := 0; i < len(rest); i++ {
+		a := rest[i]
+		if strings.HasPrefix(a, "-") {
+			if takesGroupValue(subs, name, a) && !strings.Contains(a, "=") {
+				i++
+			}
+			continue
+		}
+		if name == "" {
+			name = a
+			continue
+		}
+		words = append(words, a)
+	}
+
+	if name == "" {
+		if strings.HasPrefix(cur, "-") {
+			// A flag before the subcommand belongs to no subcommand yet.
+			return dirNone, nil
+		}
+		return names(cur, subNames(subs))
+	}
+	s, ok := findSub(subs, name)
+	if !ok {
+		return dirNone, nil
+	}
+
+	// The value of a flag that takes one.
+	if len(rest) > 0 && !strings.HasPrefix(cur, "-") {
+		if kind, ok := s.values[lastFlag(rest)]; ok {
+			return operandCandidates(kind, cur)
+		}
+	}
+	if strings.HasPrefix(cur, "-") {
+		spellings := append([]string{}, s.flags...)
+		for f := range s.values {
+			spellings = append(spellings, f)
+		}
+		sort.Strings(spellings)
+		return names(cur, spellings)
+	}
+	if len(words) >= len(s.operands) {
+		return dirNone, nil
+	}
+	return operandCandidates(s.operands[len(words)], cur)
+}
+
+func findSub(subs []sub, name string) (sub, bool) {
+	for _, s := range subs {
+		if s.name == name {
+			return s, true
+		}
+	}
+	return sub{}, false
+}
+
+func subNames(subs []sub) []string {
+	out := make([]string, 0, len(subs))
+	for _, s := range subs {
+		out = append(out, s.name)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// takesGroupValue reports whether a token is a flag of this subcommand that
+// consumes the argument after it, so that walking a group's line does not read
+// a flag's value as one of its bare words.
+func takesGroupValue(subs []sub, name, arg string) bool {
+	s, ok := findSub(subs, name)
+	if !ok {
+		return false
+	}
+	spelling, _, _ := strings.Cut(arg, "=")
+	_, takes := s.values[spelling]
+	return takes
+}
+
+// lastFlag is the flag spelling the cursor may be completing the value of: the
+// token immediately left of the cursor, with the `=` a shell may have split out
+// of an inline value stepped over.
+//
+// bash breaks words on `=`, so `--network=sh` reaches here as three tokens.
+// Reading past the separator is what makes the inline spelling of a flag
+// complete the same way the spaced one does.
+func lastFlag(rest []string) string {
+	last := rest[len(rest)-1]
+	if last == "=" && len(rest) > 1 {
+		last = rest[len(rest)-2]
+	}
+	return last
+}
+
+// pendingValue reports whether the cursor is on the value of one of brig's own
+// run-line flags, and what that value names.
+func pendingValue(rest []string, cur string) (operand, bool) {
+	if len(rest) == 0 || strings.HasPrefix(cur, "-") {
+		return opNothing, false
+	}
+	flag := lastFlag(rest)
+	mine, takesValue := ours(flag, posRun)
+	if !mine || !takesValue || strings.Contains(flag, "=") {
+		return opNothing, false
+	}
+	return flagValue(flag), true
+}
+
+// flagValue is what a run-line flag's value names.
+//
+// A closed set is the payoff here: --network has three postures and nothing
+// else, and a reader who cannot remember them is exactly who completion is for.
+// The rest name a host path, or a number brig cannot guess.
+func flagValue(flag string) operand {
+	switch flag {
+	case "--home", "-w", "--workspace":
+		return opDir
+	case "--image", "-t":
+		return opFile
+	case "--network":
+		return opNetwork
+	}
+	return opNothing
+}
+
+// networkModes is the posture set --network takes. Spelled here rather than
+// read from wrap because the parser there maps words onto values and does not
+// enumerate them.
+var networkModes = []string{"isolated", "offline", "shared"}
+
+// flagSpellings is what brig owns at one position, as a reader types it.
+//
+// Read off the position table, so a flag added there is completed without
+// anything here changing. What is left out is what the help text leaves out: a
+// spelling on its way out, and a position on its way out, are not words to
+// teach a reader who has not typed them yet.
+func flagSpellings(at position, verb string) []string {
+	var out []string
+	for _, f := range brigFlags {
+		if f.position != at || f.retiredAs != "" || f.undocumented {
+			continue
+		}
+		if deprecatedFlags["--"+f.long] != "" {
+			continue
+		}
+		if at == posRun && verb != "" && !honorsRunLine(verb, f.long) {
+			continue
+		}
+		out = append(out, "--"+f.long)
+		if f.short != "" && deprecatedFlags["-"+f.short] == "" {
+			out = append(out, "-"+f.short)
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+// bareWords are the words at one position that are not flags and not a flag's
+// value. On a run line the first of them is the ref.
+func bareWords(args []string, at position) []string {
+	var out []string
+	for i := 0; i < len(args); i++ {
+		a := args[i]
+		if strings.HasPrefix(a, "-") {
+			if mine, takesValue := ours(a, at); mine && takesValue && !strings.Contains(a, "=") {
+				i++
+			}
+			continue
+		}
+		if a == "=" {
+			// The separator a shell split out of an inline flag value, and the
+			// value after it. Neither is a word of brig's own.
+			i++
+			continue
+		}
+		out = append(out, a)
+	}
+	return out
+}
+
+// agentNames is every spelling that reaches an agent: the profile names and the
+// short forms that stand for them.
+func agentNames() []string {
+	var out []string
+	for _, name := range profile.Names() {
+		out = append(out, name)
+		out = append(out, profile.Aliases(name)...)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// fileAgentNames is every spelling that reaches an agent brig loaded from a
+// file. A built-in has no file to open or remove.
+func fileAgentNames() []string {
+	var out []string
+	for _, name := range profile.Names() {
+		if _, ok := profile.Path(name); !ok {
+			continue
+		}
+		out = append(out, name)
+		out = append(out, profile.Aliases(name)...)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// refCandidates is what a lifecycle verb takes: every agent, and every session
+// that exists under one.
+//
+// Both, and in one list, because they are one grammar: `claude` is that agent's
+// default session and `claude@refactor` is a session of its own. Offering the
+// agents alone would answer half the question, and offering the labelled refs
+// alone would hide the session most lines mean.
+func refCandidates() []string {
+	seen := map[string]bool{}
+	var out []string
+	add := func(s string) {
+		if s == "" || seen[s] {
+			return
+		}
+		seen[s] = true
+		out = append(out, s)
+	}
+	for _, name := range agentNames() {
+		add(name)
+	}
+	for _, ref := range wrap.SessionRefs() {
+		add(ref)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// policyNames is every policy that loads, and nothing about the ones that do
+// not: a name completion offers has to be a name the next command accepts.
+func policyNames() []string {
+	entries, _ := policy.LoadAll(policy.Dir())
+	out := make([]string, 0, len(entries))
+	for name := range entries {
+		out = append(out, name)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// names matches candidates against the word being typed.
+//
+// Matched here rather than left to the shell so that one Go test is the whole
+// truth about what a keystroke offers. The shells filter again; agreeing with
+// them costs nothing.
+//
+// A long spelling under the cursor drops the short forms: someone who has typed
+// two dashes has said which spelling they want, and offering `-q` against `--`
+// is a candidate that cannot be completed.
+func names(cur string, candidates []string) (string, []string) {
+	long := strings.HasPrefix(cur, "--")
+	var out []string
+	for _, c := range candidates {
+		if long && !strings.HasPrefix(c, "--") {
+			continue
+		}
+		if strings.HasPrefix(c, cur) {
+			out = append(out, c)
+		}
+	}
+	if len(out) == 0 {
+		return dirNone, nil
+	}
+	return dirNames, out
+}

--- a/cmd/brig/completion.go
+++ b/cmd/brig/completion.go
@@ -14,25 +14,21 @@ import (
 
 // Shell completion, in two commands.
 //
-// `brig completion <shell>` writes a script to stdout and installs nothing.
-// Where that script belongs differs per shell and per host, and a command that
-// edits a startup file has a blast radius nothing else here has; the docs say
-// the line to add.
+// `brig completion <shell>` prints a script to stdout. It installs nothing:
+// the install path differs per shell and per host, and the docs give the line.
 //
-// The scripts carry none of brig's vocabulary. Each one collects the words left
-// of the cursor, hands them to `brig __complete`, and renders what comes back.
-// So the verbs, the flags and where each flag is legal are declared once, in
-// Go, beside the table that already decides them -- and the three shells cannot
-// come to disagree about what brig accepts, because none of them knows.
+// The scripts hold no brig vocabulary. Each collects the words left of the
+// cursor, passes them to `brig __complete`, and renders the reply. Verbs, flags
+// and flag positions are therefore declared once, in Go, next to brigFlags.
 //
-// __complete answers on stdout and says nothing anywhere else. It is an ABI
-// between a script and the binary that generated it, so it is in no help text.
+// __complete is an ABI between a script and the binary that printed it, so it
+// is in no help text.
 
 //go:embed completions/brig.bash completions/brig.zsh completions/brig.fish
 var completionScripts embed.FS
 
-// completeVerb is the hidden engine's name. Two underscores, because it is not
-// a word anyone types and it must not read like one.
+// completeVerb is the engine's name. Underscore-prefixed: it is not a command
+// anyone types.
 const completeVerb = "__complete"
 
 const completionUsage = `brig completion -- print a shell completion script
@@ -62,11 +58,10 @@ brig mounts, and directories are offered for it.
 // completionCmd prints the script for one shell.
 func completionCmd(out io.Writer, args []string) error {
 	if len(args) == 0 {
-		// An agent can be called completion, and the verb wins: dispatch reads
-		// a verb before it reads a ref, deliberately, so that brig's own
-		// vocabulary does not depend on which agents a host happens to have.
-		// The agent is still reachable under run, so name that reading rather
-		// than answer with a list of shells the reader did not ask about.
+		// Verb dispatch precedes the ref fallback, so an agent named
+		// "completion" is not reachable as `brig completion`. That applies to
+		// every verb and is intentional: the command set must not depend on
+		// which agents are installed. Point at the spelling that still works.
 		if _, known := profile.Lookup("completion"); known {
 			return usagef("completion needs a shell: bash, zsh or fish. " +
 				"The agent of that name is reached as `brig run completion`")
@@ -95,9 +90,8 @@ func completionCmd(out io.Writer, args []string) error {
 	return err
 }
 
-// The directive is the first line of an answer, and it says what the lines
-// under it are -- or, where a candidate list cannot say it, what the shell
-// should do instead.
+// The directive is the first line of a reply. It says what the lines below it
+// are, or what the shell should do when a candidate list cannot express it.
 const (
 	// dirNames: candidates follow, already matched against the current word.
 	dirNames = ":names"
@@ -105,24 +99,20 @@ const (
 	dirDirs = ":dirs"
 	// dirFiles: complete paths. No candidates follow.
 	dirFiles = ":files"
-	// dirNone: brig owns nothing at this position, so offer nothing. It has to
-	// be distinguishable from a failure: a shell that reads "brig had no
-	// answer" falls back to filenames, and the tail right of the ref is the one
-	// place brig has to stay silent rather than guess.
+	// dirNone: offer nothing. Distinct from a failed call, which the scripts
+	// treat as "fall back to filenames" -- wrong inside the agent's argv.
 	dirNone = ":none"
 )
 
-// completeCmd answers one completion request. It writes candidates to out and
-// nothing to stderr, ever, and returns no error: a notice or a failure printed
-// on a keystroke lands in the middle of the line the reader is typing.
+// completeCmd answers one completion request. It writes only candidates to out,
+// never to stderr, and returns no error. Anything on stderr would print over
+// the line the user is typing.
 func completeCmd(out io.Writer, words []string) {
-	// The profile directory is read here rather than by the dispatcher, so that
-	// a file that will not parse costs a candidate rather than a line of
-	// diagnostics across the prompt. What loaded is completed; what did not is
-	// not, and the next real command says why.
+	// Loaded here rather than by the dispatcher, which warns about files that
+	// will not parse. Profiles that load are completed; the rest are skipped,
+	// and the next real command reports them.
 	_ = profile.Load(profile.Dir())
-	// Nothing below prints a notice, and this is the belt to that braces: a
-	// warning added anywhere the engine reaches stays silent on a keystroke.
+	// Suppresses any warning added later in a path the engine reaches.
 	verbosity = wrap.Quiet
 
 	directive, candidates := complete(words)
@@ -132,12 +122,11 @@ func completeCmd(out io.Writer, words []string) {
 	}
 }
 
-// verbs are the commands completion offers: the taught vocabulary, and only it.
+// verbs are the commands completion offers: the documented set only.
 //
-// The retired spellings brig still answers to -- exec, shell, env, create,
-// reset, profiles, policies -- are deliberately absent. They keep working and
-// they say what replaced them; completing them would teach a word that is
-// leaving, to the one reader who has not typed it yet.
+// The retired spellings -- exec, shell, env, create, reset, profiles, policies
+// -- are excluded. They still work and print what replaced them, but they are
+// removed in v0.3, so completion does not teach them.
 var verbs = []string{
 	"agent",
 	"completion",
@@ -163,32 +152,28 @@ var refVerbs = map[string]bool{
 	"info": true,
 }
 
-// complete is the whole decision: which words are already on the line, and what
-// may stand where the cursor is.
+// complete decides what may stand where the cursor is.
 //
-// words is the line with `brig` dropped, and the word under the cursor is the
-// last of them -- empty when the cursor sits on fresh whitespace. That the
-// current word is always present, even empty, is what lets one function serve
-// both "finish this token" and "what can come next".
+// words is the line with `brig` dropped; the last element is the word under the
+// cursor, empty when the cursor is on fresh whitespace. Always passing that
+// element, even empty, is what lets one function serve both "finish this token"
+// and "what comes next".
 func complete(words []string) (string, []string) {
 	if len(words) == 0 {
 		words = []string{""}
 	}
 	cur := words[len(words)-1]
 	before := words[:len(words)-1]
-	// bash breaks a word on '=', so `--network=<cursor>` arrives with the
-	// separator as the current word rather than as part of the flag. It is not
-	// something the reader is trying to complete, so it reads as the empty
-	// start of the value -- the normalisation _init_completion makes, for the
-	// same reason.
+	// bash splits on '=', so `--network=<cursor>` arrives with "=" as the
+	// current word. Treat it as an empty value prefix, as _init_completion
+	// does.
 	if cur == "=" {
 		cur = ""
 	}
 
-	// The verb, and what stands between it and the cursor. Everything left of
-	// the verb is a global flag or a mistake, and both are skipped: a token brig
-	// would refuse is not a verb, so reading on is what keeps the rest of the
-	// line completable.
+	// Find the verb and the tokens between it and the cursor. Tokens left of
+	// the verb are global flags, or typos; both are skipped, so a typo does not
+	// make the rest of the line uncompletable.
 	verb := ""
 	var rest []string
 	for i := 0; i < len(before); i++ {
@@ -207,9 +192,8 @@ func complete(words []string) (string, []string) {
 		if strings.HasPrefix(cur, "-") {
 			return names(cur, flagSpellings(posGlobal, ""))
 		}
-		// Only the verbs. `brig claude@refactor` with no verb works, and is in
-		// no help text on purpose; completing it would teach the second
-		// spelling that the taught line already covers.
+		// Verbs only. A bare ref with no verb also works but is undocumented,
+		// and `brig run <ref>` already covers it.
 		return names(cur, verbs)
 	}
 
@@ -241,42 +225,34 @@ func complete(words []string) (string, []string) {
 	return dirNone, nil
 }
 
-// completeRunLine answers between a lifecycle verb and the end of the line.
-//
-// The three positions a brig line has are the whole of the logic here: brig's
-// own flags up to the ref, the ref, and then the agent's own vocabulary, which
-// brig does not complete because it does not own it.
+// completeRunLine answers for a lifecycle verb: flags, then the ref, then
+// run's project directory. Past that the tokens are the agent's.
 func completeRunLine(verb string, rest []string, cur string) (string, []string) {
-	// --all is read before the run line, removes every sandbox and refuses any
-	// argument at all, so a line carrying it names no session and there is
-	// nothing further to offer. See removeAll.
+	// takeAll strips --all before the run line is parsed, and removeAll then
+	// rejects every remaining argument. Nothing else can appear on this line.
 	if hasSpelling(rest, "--all") {
 		return dirNone, nil
 	}
 
 	line := walkRunLine(verb, rest)
 	if line.tailBegun {
-		// The vocabulary from here is the agent's. brig has no list of another
-		// program's flags and must not guess at one -- not for a flag name, and
-		// not for a flag's value either.
+		// Inside the agent's argv. brig has no list of another program's flags,
+		// so it offers neither names nor values here.
 		return dirNone, nil
 	}
 
-	// The value of one of brig's own flags, when that is what the cursor is on.
 	if line.pending != "" && !strings.HasPrefix(cur, "-") {
 		return operandCandidates(flagValue(line.pending), cur)
 	}
 
 	if strings.HasPrefix(cur, "-") {
-		// Brig's own flags stand on either side of the ref: split reads them
-		// wherever they are on the run line, and stops only at a flag brig does
-		// not own. Offering them only up to the ref would leave completion
-		// silent about `brig run claude --mem`, a line brig reads.
+		// split() reads brig's own flags on both sides of the ref, stopping
+		// only at a flag brig does not own, so offer them on both sides too.
+		// `brig run claude --mem 4096` is a line brig parses.
 		flags := flagSpellings(posRun, verb)
 		if verb == "rm" && !line.refGiven {
-			// --all is not on the run line and not in the table it is built
-			// from. It replaces the ref rather than joining it, so it is
-			// offered only where the ref would have gone.
+			// --all is not in brigFlags: it is read before the run line, and it
+			// replaces the ref rather than accompanying it.
 			flags = append(flags, "--all")
 			sort.Strings(flags)
 		}
@@ -286,24 +262,20 @@ func completeRunLine(verb string, rest []string, cur string) (string, []string) 
 	if !line.refGiven {
 		return names(cur, refsFor(verb))
 	}
-	// On run the first bare word after the ref is the project brig mounts, and
-	// a project is a directory. Every other verb, and every word after that
-	// one, begins the agent's own arguments.
+	// On run the first bare word after the ref is the project directory. On
+	// every other verb, and for later words, the agent's argv starts here.
 	if verb == "run" && !line.projectTaken {
 		return dirDirs, nil
 	}
 	return dirNone, nil
 }
 
-// runLine is how far a lifecycle line has got by the time the cursor is
-// reached.
+// runLine is how far a lifecycle line has been parsed at the cursor.
 //
-// It answers the same question split answers, and deliberately in the same
-// order, because the two must agree about where brig's arguments stop. Where
-// they disagree, completion either withholds a flag brig would have read or
-// offers one into the agent's argv -- and the second is the worse of the two,
-// since it puts brig's vocabulary in front of a reader who is typing another
-// program's.
+// It resolves the same boundary split() resolves, in the same order, because
+// the two must agree on where brig's arguments end. If completion stops early
+// it withholds a flag brig accepts; if it stops late it offers brig's flags
+// inside the agent's argv.
 type runLine struct {
 	// refGiven: the session ref has been named.
 	refGiven bool
@@ -345,18 +317,17 @@ func walkRunLine(verb string, args []string) runLine {
 					line.tailBegun = true
 					return line
 				}
-				// Before the ref, a flag brig does not have is a mistake the
-				// run itself names. Reading past it keeps the rest of the line
-				// completable, which is what someone fixing the typo wants.
+				// Before the ref, an unknown flag is a typo, which the run
+				// itself reports. Skip it so the rest of the line still
+				// completes.
 				continue
 			}
 			if !takesValue || strings.Contains(a, "=") {
 				continue
 			}
-			// The flag's value, which a shell that breaks words on '=' hands
-			// over as a separator token and then the value itself. Consuming
-			// only one of the two would leave the value standing where a bare
-			// word goes, and be read as the ref.
+			// Consume the value. A shell that splits on '=' delivers it as two
+			// tokens ("=" then the value); consuming only the "=" would leave
+			// the value to be counted as a positional, i.e. as the ref.
 			i++
 			if i < len(args) && args[i] == "=" {
 				i++
@@ -367,11 +338,9 @@ func walkRunLine(verb string, args []string) runLine {
 	return line
 }
 
-// pendingFlag is the brig flag the cursor's word would be the value of: the
-// last token on the line, when that is a flag of brig's that takes one.
-//
-// The `=` a shell may have split out of an inline value is stepped over, so
-// `--network=<cursor>` completes the postures the spaced spelling does.
+// pendingFlag returns the flag whose value the cursor is on: the last token,
+// when it is a brig flag that takes a value. A trailing "=" is skipped, so
+// `--network=<cursor>` completes like `--network <cursor>`.
 func pendingFlag(args []string) string {
 	if len(args) == 0 {
 		return ""
@@ -387,7 +356,7 @@ func pendingFlag(args []string) string {
 	return last
 }
 
-// hasSpelling reports whether a line carries one exact flag spelling.
+// hasSpelling reports whether args contains this exact token.
 func hasSpelling(args []string, spelling string) bool {
 	for _, a := range args {
 		if a == spelling {
@@ -397,13 +366,12 @@ func hasSpelling(args []string, spelling string) bool {
 	return false
 }
 
-// sessionVerbs act on a sandbox that already exists, so they are completed
-// from the sessions there are rather than from the agents there could be.
+// sessionVerbs require an existing sandbox, so they complete from the session
+// index rather than from the profile registry.
 //
-// run and sh both start one, and info reads a profile without booting
-// anything, so all three take an agent that has never run. stop and rm do not:
-// offering every agent there would offer a session that is not there, and on a
-// host with nothing running the honest answer is nothing.
+// run and sh create one, and info reads a profile without booting, so those
+// three accept an agent that has never run. stop and rm do not: offering every
+// agent would offer sessions that do not exist.
 var sessionVerbs = map[string]bool{
 	"stop": true,
 	"rm":   true,
@@ -420,12 +388,12 @@ func refsFor(verb string) []string {
 type operand int
 
 const (
-	// opNothing: brig has no list for this. A session label, a new agent's
-	// name, a secret's value -- words brig cannot enumerate, or should not.
+	// opNothing: no candidate list. A new agent's name, a session label, a
+	// secret name -- values brig cannot enumerate, or must not.
 	opNothing operand = iota
 	opAgent
-	// opFileAgent is an agent with a file of its own. edit opens that file and
-	// rm removes it, so a built-in is a candidate both commands refuse.
+	// opFileAgent is an agent backed by a file. `agent edit` opens that file
+	// and `agent rm` deletes it; both reject a built-in.
 	opFileAgent
 	opPolicy
 	opRef
@@ -455,13 +423,13 @@ func operandCandidates(kind operand, cur string) (string, []string) {
 	return dirNone, nil
 }
 
-// sub is one subcommand of a noun group: its flags, the flags that take a
-// value, and what its bare words name, in order.
+// sub is one subcommand of a noun group: its boolean flags, its value-taking
+// flags, and what its positional arguments name, in order.
 //
-// The noun groups build their arguments with a flag.FlagSet of their own,
-// inside the function that runs them, so there is no table to read them off.
-// This is that table, for completion only. A subcommand missing from here
-// completes nothing, which is the safe direction to be wrong in.
+// Each noun subcommand builds a flag.FlagSet inside the function that runs it,
+// so there is nothing for completion to read. This table duplicates that, for
+// completion only; TestGroupsTableCoversEveryGroupFlag guards the drift. A
+// subcommand missing here completes nothing rather than something wrong.
 type sub struct {
 	name string
 	// flags take no value.
@@ -473,12 +441,12 @@ type sub struct {
 	operands []operand
 }
 
-// groups is the noun commands and what stands under each.
+// groups is the noun commands and their subcommands.
 //
-// Secret names are absent on purpose. Listing them opens the store -- on macOS
-// that is `security dump-keychain`, and a secret-service backend can put an
-// unlock prompt on the screen -- and a keystroke must not do either. The
-// subcommands complete; their operands do not.
+// Secret names are deliberately absent: listing them opens the store, which on
+// macOS runs `security dump-keychain`, and on Linux can raise an unlock prompt
+// from the secret-service backend. Subcommands complete; their name operands
+// do not.
 var groups = map[string][]sub{
 	"agent": {
 		{name: "ls"},
@@ -560,10 +528,10 @@ func completeGroup(verb string, rest []string, cur string) (string, []string) {
 		a := rest[i]
 		if strings.HasPrefix(a, "-") {
 			if takesGroupValue(subs, name, a) && !strings.Contains(a, "=") {
-				// The value, and the separator before it when a shell has
-				// broken the inline spelling into tokens. Consuming only the
-				// separator would leave the value standing where an operand
-				// goes and shift every slot after it by one.
+				// Consume the value, plus the "=" when a shell split the
+				// inline spelling into tokens. Consuming only the "=" leaves
+				// the value to be counted as a positional, shifting every
+				// operand index by one.
 				i++
 				if i < len(rest) && rest[i] == "=" {
 					i++
@@ -580,7 +548,7 @@ func completeGroup(verb string, rest []string, cur string) (string, []string) {
 
 	if name == "" {
 		if strings.HasPrefix(cur, "-") {
-			// A flag before the subcommand belongs to no subcommand yet.
+			// No subcommand yet, so there is no flag set to draw from.
 			return dirNone, nil
 		}
 		return names(cur, subNames(subs))
@@ -590,7 +558,7 @@ func completeGroup(verb string, rest []string, cur string) (string, []string) {
 		return dirNone, nil
 	}
 
-	// The value of a flag that takes one.
+	// The cursor is on a value-taking flag's value.
 	if len(rest) > 0 && !strings.HasPrefix(cur, "-") {
 		if kind, ok := s.values[lastFlag(rest)]; ok {
 			return operandCandidates(kind, cur)
@@ -628,9 +596,9 @@ func subNames(subs []sub) []string {
 	return out
 }
 
-// takesGroupValue reports whether a token is a flag of this subcommand that
-// consumes the argument after it, so that walking a group's line does not read
-// a flag's value as one of its bare words.
+// takesGroupValue reports whether arg is a flag of this subcommand that
+// consumes the next token, so the walk does not count a value as a
+// positional.
 func takesGroupValue(subs []sub, name, arg string) bool {
 	s, ok := findSub(subs, name)
 	if !ok {
@@ -641,13 +609,9 @@ func takesGroupValue(subs []sub, name, arg string) bool {
 	return takes
 }
 
-// lastFlag is the flag spelling the cursor may be completing the value of: the
-// token immediately left of the cursor, with the `=` a shell may have split out
-// of an inline value stepped over.
-//
-// bash breaks words on `=`, so `--network=sh` reaches here as three tokens.
-// Reading past the separator is what makes the inline spelling of a flag
-// complete the same way the spaced one does.
+// lastFlag returns the token left of the cursor, skipping a trailing "=" so
+// that `--file=<cursor>` resolves to `--file`. bash splits on "=", so the
+// inline spelling arrives as three tokens.
 func lastFlag(rest []string) string {
 	last := rest[len(rest)-1]
 	if last == "=" && len(rest) > 1 {
@@ -656,11 +620,8 @@ func lastFlag(rest []string) string {
 	return last
 }
 
-// flagValue is what a run-line flag's value names.
-//
-// A closed set is the payoff here: --network has three postures and nothing
-// else, and a reader who cannot remember them is exactly who completion is for.
-// The rest name a host path, or a number brig cannot guess.
+// flagValue maps a run-line flag to what its value names. --network is the
+// only closed set; the rest take a host path or a number.
 func flagValue(flag string) operand {
 	switch flag {
 	case "--home", "-w", "--workspace":
@@ -673,17 +634,15 @@ func flagValue(flag string) operand {
 	return opNothing
 }
 
-// networkModes is the posture set --network takes. Spelled here rather than
-// read from wrap because the parser there maps words onto values and does not
-// enumerate them.
+// networkModes is the value set --network accepts. Duplicated from
+// wrap.ParseNetwork, which maps strings to values without exposing the list.
 var networkModes = []string{"isolated", "offline", "shared"}
 
-// flagSpellings is what brig owns at one position, as a reader types it.
+// flagSpellings returns brig's own flags legal at one position, as typed.
 //
-// Read off the position table, so a flag added there is completed without
-// anything here changing. What is left out is what the help text leaves out: a
-// spelling on its way out, and a position on its way out, are not words to
-// teach a reader who has not typed them yet.
+// Read from brigFlags, so a flag added there needs no change here. Excluded:
+// deprecated spellings, positions being retired (retiredAs), and undocumented
+// spellings -- all still accepted, none of them taught.
 func flagSpellings(at position, verb string) []string {
 	var out []string
 	for _, f := range brigFlags {
@@ -705,8 +664,8 @@ func flagSpellings(at position, verb string) []string {
 	return out
 }
 
-// bareWords are the words at one position that are not flags and not a flag's
-// value. On a run line the first of them is the ref.
+// bareWords returns the positional arguments at one position: tokens that are
+// neither a flag nor a flag's value.
 func bareWords(args []string, at position) []string {
 	var out []string
 	for i := 0; i < len(args); i++ {
@@ -721,8 +680,7 @@ func bareWords(args []string, at position) []string {
 			continue
 		}
 		if a == "=" {
-			// A separator with no flag of brig's before it. Neither it nor the
-			// value after it is a word of brig's own.
+			// A "=" with no brig flag before it. Skip it and its value.
 			i++
 			continue
 		}
@@ -743,8 +701,8 @@ func agentNames() []string {
 	return out
 }
 
-// fileAgentNames is every spelling that reaches an agent brig loaded from a
-// file. A built-in has no file to open or remove.
+// fileAgentNames returns the spellings of file-backed agents only. A built-in
+// has no file to open or delete.
 func fileAgentNames() []string {
 	var out []string
 	for _, name := range profile.Names() {
@@ -758,13 +716,9 @@ func fileAgentNames() []string {
 	return out
 }
 
-// refCandidates is what a lifecycle verb takes: every agent, and every session
-// that exists under one.
-//
-// Both, and in one list, because they are one grammar: `claude` is that agent's
-// default session and `claude@refactor` is a session of its own. Offering the
-// agents alone would answer half the question, and offering the labelled refs
-// alone would hide the session most lines mean.
+// refCandidates returns every agent plus every existing session, in one list.
+// They are one grammar: `claude` is that agent's default session,
+// `claude@refactor` is a labelled one.
 func refCandidates() []string {
 	seen := map[string]bool{}
 	var out []string
@@ -785,8 +739,8 @@ func refCandidates() []string {
 	return out
 }
 
-// policyNames is every policy that loads, and nothing about the ones that do
-// not: a name completion offers has to be a name the next command accepts.
+// policyNames returns the policies that load. One that does not load is
+// omitted: every command that takes a policy name would reject it.
 func policyNames() []string {
 	entries, _ := policy.LoadAll(policy.Dir())
 	out := make([]string, 0, len(entries))
@@ -797,15 +751,12 @@ func policyNames() []string {
 	return out
 }
 
-// names matches candidates against the word being typed.
+// names filters candidates by the word being typed.
 //
-// Matched here rather than left to the shell so that one Go test is the whole
-// truth about what a keystroke offers. The shells filter again; agreeing with
-// them costs nothing.
+// Filtered here rather than in the shells so the Go tests cover exactly what a
+// keystroke offers; the shells filter again, harmlessly.
 //
-// A long spelling under the cursor drops the short forms: someone who has typed
-// two dashes has said which spelling they want, and offering `-q` against `--`
-// is a candidate that cannot be completed.
+// A "--" prefix drops the short forms, which cannot match it anyway.
 func names(cur string, candidates []string) (string, []string) {
 	long := strings.HasPrefix(cur, "--")
 	var out []string

--- a/cmd/brig/completion.go
+++ b/cmd/brig/completion.go
@@ -52,15 +52,25 @@ completions from, or source it from your startup file:
   fish    brig completion fish >~/.config/fish/completions/brig.fish
 
 Completion offers the verbs, the refs ` + "`brig ls`" + ` prints, and the flags that are
-legal where the cursor is. Right of the ref the arguments are the agent's, so
-brig completes nothing there -- with one exception: on run the first word after
-the ref is the project directory brig mounts, and directories are offered for
-it.
+legal where the cursor is. brig's own flags stand on either side of the ref,
+and are offered on both. What brig does not own it does not complete: once a
+word or a flag it does not recognise has begun the agent's own arguments,
+completion stops. On run the first word after the ref is the project directory
+brig mounts, and directories are offered for it.
 `
 
 // completionCmd prints the script for one shell.
 func completionCmd(out io.Writer, args []string) error {
 	if len(args) == 0 {
+		// An agent can be called completion, and the verb wins: dispatch reads
+		// a verb before it reads a ref, deliberately, so that brig's own
+		// vocabulary does not depend on which agents a host happens to have.
+		// The agent is still reachable under run, so name that reading rather
+		// than answer with a list of shells the reader did not ask about.
+		if _, known := profile.Lookup("completion"); known {
+			return usagef("completion needs a shell: bash, zsh or fish. " +
+				"The agent of that name is reached as `brig run completion`")
+		}
 		return usagef("completion needs a shell: bash, zsh or fish")
 	}
 	switch args[0] {
@@ -166,6 +176,14 @@ func complete(words []string) (string, []string) {
 	}
 	cur := words[len(words)-1]
 	before := words[:len(words)-1]
+	// bash breaks a word on '=', so `--network=<cursor>` arrives with the
+	// separator as the current word rather than as part of the flag. It is not
+	// something the reader is trying to complete, so it reads as the empty
+	// start of the value -- the normalisation _init_completion makes, for the
+	// same reason.
+	if cur == "=" {
+		cur = ""
+	}
 
 	// The verb, and what stands between it and the cursor. Everything left of
 	// the verb is a global flag or a mistake, and both are skipped: a token brig
@@ -229,48 +247,154 @@ func complete(words []string) (string, []string) {
 // own flags up to the ref, the ref, and then the agent's own vocabulary, which
 // brig does not complete because it does not own it.
 func completeRunLine(verb string, rest []string, cur string) (string, []string) {
-	// `--` is the reader saying the rest is the agent's. Nothing after it is
-	// brig's to complete, whatever it looks like.
-	for _, a := range rest {
-		if a == "--" {
-			return dirNone, nil
-		}
+	// --all is read before the run line, removes every sandbox and refuses any
+	// argument at all, so a line carrying it names no session and there is
+	// nothing further to offer. See removeAll.
+	if hasSpelling(rest, "--all") {
+		return dirNone, nil
+	}
+
+	line := walkRunLine(verb, rest)
+	if line.tailBegun {
+		// The vocabulary from here is the agent's. brig has no list of another
+		// program's flags and must not guess at one -- not for a flag name, and
+		// not for a flag's value either.
+		return dirNone, nil
 	}
 
 	// The value of one of brig's own flags, when that is what the cursor is on.
-	if kind, ok := pendingValue(rest, cur); ok {
-		return operandCandidates(kind, cur)
+	if line.pending != "" && !strings.HasPrefix(cur, "-") {
+		return operandCandidates(flagValue(line.pending), cur)
 	}
 
-	bare := bareWords(rest, posRun)
-	refGiven := len(bare) > 0
-
 	if strings.HasPrefix(cur, "-") {
-		if refGiven {
-			// Right of the ref a flag is the agent's. brig has no list of
-			// another program's flags and should not pretend to.
-			return dirNone, nil
-		}
+		// Brig's own flags stand on either side of the ref: split reads them
+		// wherever they are on the run line, and stops only at a flag brig does
+		// not own. Offering them only up to the ref would leave completion
+		// silent about `brig run claude --mem`, a line brig reads.
 		flags := flagSpellings(posRun, verb)
-		if verb == "rm" {
-			// --all names no session, so it is read before the run line rather
-			// than on it, and it is not in the table the line is built from.
+		if verb == "rm" && !line.refGiven {
+			// --all is not on the run line and not in the table it is built
+			// from. It replaces the ref rather than joining it, so it is
+			// offered only where the ref would have gone.
 			flags = append(flags, "--all")
 			sort.Strings(flags)
 		}
 		return names(cur, flags)
 	}
 
-	if !refGiven {
+	if !line.refGiven {
 		return names(cur, refsFor(verb))
 	}
 	// On run the first bare word after the ref is the project brig mounts, and
 	// a project is a directory. Every other verb, and every word after that
-	// one, is the agent's.
-	if verb == "run" && len(bare) == 1 {
+	// one, begins the agent's own arguments.
+	if verb == "run" && !line.projectTaken {
 		return dirDirs, nil
 	}
 	return dirNone, nil
+}
+
+// runLine is how far a lifecycle line has got by the time the cursor is
+// reached.
+//
+// It answers the same question split answers, and deliberately in the same
+// order, because the two must agree about where brig's arguments stop. Where
+// they disagree, completion either withholds a flag brig would have read or
+// offers one into the agent's argv -- and the second is the worse of the two,
+// since it puts brig's vocabulary in front of a reader who is typing another
+// program's.
+type runLine struct {
+	// refGiven: the session ref has been named.
+	refGiven bool
+	// projectTaken: run's one project word has been given.
+	projectTaken bool
+	// tailBegun: brig's parsing has ended and the rest is the agent's -- `--`,
+	// a flag brig does not own once the ref is named, or a bare word past the
+	// project.
+	tailBegun bool
+	// pending is the brig flag whose value the cursor's word would be, when the
+	// line ends on one. Empty when it does not.
+	pending string
+}
+
+func walkRunLine(verb string, args []string) runLine {
+	var line runLine
+	takesProject := verb == "run"
+	for i := 0; i < len(args); i++ {
+		a := args[i]
+		switch {
+		case a == "--":
+			line.tailBegun = true
+			return line
+		case !strings.HasPrefix(a, "-"):
+			if !line.refGiven {
+				line.refGiven = true
+				continue
+			}
+			if takesProject && !line.projectTaken {
+				line.projectTaken = true
+				continue
+			}
+			line.tailBegun = true
+			return line
+		default:
+			mine, takesValue := ours(a, posRun)
+			if !mine {
+				if line.refGiven {
+					line.tailBegun = true
+					return line
+				}
+				// Before the ref, a flag brig does not have is a mistake the
+				// run itself names. Reading past it keeps the rest of the line
+				// completable, which is what someone fixing the typo wants.
+				continue
+			}
+			if !takesValue || strings.Contains(a, "=") {
+				continue
+			}
+			// The flag's value, which a shell that breaks words on '=' hands
+			// over as a separator token and then the value itself. Consuming
+			// only one of the two would leave the value standing where a bare
+			// word goes, and be read as the ref.
+			i++
+			if i < len(args) && args[i] == "=" {
+				i++
+			}
+		}
+	}
+	line.pending = pendingFlag(args)
+	return line
+}
+
+// pendingFlag is the brig flag the cursor's word would be the value of: the
+// last token on the line, when that is a flag of brig's that takes one.
+//
+// The `=` a shell may have split out of an inline value is stepped over, so
+// `--network=<cursor>` completes the postures the spaced spelling does.
+func pendingFlag(args []string) string {
+	if len(args) == 0 {
+		return ""
+	}
+	last := args[len(args)-1]
+	if last == "=" && len(args) > 1 {
+		last = args[len(args)-2]
+	}
+	mine, takesValue := ours(last, posRun)
+	if !mine || !takesValue || strings.Contains(last, "=") {
+		return ""
+	}
+	return last
+}
+
+// hasSpelling reports whether a line carries one exact flag spelling.
+func hasSpelling(args []string, spelling string) bool {
+	for _, a := range args {
+		if a == spelling {
+			return true
+		}
+	}
+	return false
 }
 
 // sessionVerbs act on a sandbox that already exists, so they are completed
@@ -397,9 +521,19 @@ var groups = map[string][]sub{
 		},
 	},
 	"secret": {
-		{name: "create", operands: []operand{opNothing}},
+		{
+			name:     "create",
+			flags:    []string{"--stdin"},
+			values:   map[string]operand{"--file": opFile, "-f": opFile},
+			operands: []operand{opNothing},
+		},
 		{name: "read", operands: []operand{opNothing}},
-		{name: "update", operands: []operand{opNothing}},
+		{
+			name:     "update",
+			flags:    []string{"--stdin"},
+			values:   map[string]operand{"--file": opFile, "-f": opFile},
+			operands: []operand{opNothing},
+		},
 		{name: "delete", flags: []string{"--yes", "-y"}, operands: []operand{opNothing}},
 		{name: "ls"},
 		{
@@ -426,7 +560,14 @@ func completeGroup(verb string, rest []string, cur string) (string, []string) {
 		a := rest[i]
 		if strings.HasPrefix(a, "-") {
 			if takesGroupValue(subs, name, a) && !strings.Contains(a, "=") {
+				// The value, and the separator before it when a shell has
+				// broken the inline spelling into tokens. Consuming only the
+				// separator would leave the value standing where an operand
+				// goes and shift every slot after it by one.
 				i++
+				if i < len(rest) && rest[i] == "=" {
+					i++
+				}
 			}
 			continue
 		}
@@ -515,20 +656,6 @@ func lastFlag(rest []string) string {
 	return last
 }
 
-// pendingValue reports whether the cursor is on the value of one of brig's own
-// run-line flags, and what that value names.
-func pendingValue(rest []string, cur string) (operand, bool) {
-	if len(rest) == 0 || strings.HasPrefix(cur, "-") {
-		return opNothing, false
-	}
-	flag := lastFlag(rest)
-	mine, takesValue := ours(flag, posRun)
-	if !mine || !takesValue || strings.Contains(flag, "=") {
-		return opNothing, false
-	}
-	return flagValue(flag), true
-}
-
 // flagValue is what a run-line flag's value names.
 //
 // A closed set is the payoff here: --network has three postures and nothing
@@ -587,12 +714,15 @@ func bareWords(args []string, at position) []string {
 		if strings.HasPrefix(a, "-") {
 			if mine, takesValue := ours(a, at); mine && takesValue && !strings.Contains(a, "=") {
 				i++
+				if i < len(args) && args[i] == "=" {
+					i++
+				}
 			}
 			continue
 		}
 		if a == "=" {
-			// The separator a shell split out of an inline flag value, and the
-			// value after it. Neither is a word of brig's own.
+			// A separator with no flag of brig's before it. Neither it nor the
+			// value after it is a word of brig's own.
 			i++
 			continue
 		}

--- a/cmd/brig/completion.go
+++ b/cmd/brig/completion.go
@@ -245,6 +245,18 @@ func completeRunLine(verb string, rest []string, cur string) (string, []string) 
 		return operandCandidates(flagValue(line.pending), cur)
 	}
 
+	// `--flag=value` with the cursor inside the value. Only bash splits on
+	// "=", so in zsh and fish the whole thing is the current word and would
+	// otherwise be matched against flag names, which it cannot match.
+	if flag, prefix, ok := inlineValue(cur); ok {
+		mine, takesValue := ours(flag, posRun)
+		if !mine || !takesValue {
+			return dirNone, nil
+		}
+		directive, candidates := operandCandidates(flagValue(flag), prefix)
+		return qualify(flag, directive, candidates)
+	}
+
 	if strings.HasPrefix(cur, "-") {
 		// split() reads brig's own flags on both sides of the ref, stopping
 		// only at a flag brig does not own, so offer them on both sides too.
@@ -564,6 +576,14 @@ func completeGroup(verb string, rest []string, cur string) (string, []string) {
 			return operandCandidates(kind, cur)
 		}
 	}
+	if flag, prefix, ok := inlineValue(cur); ok {
+		kind, takesValue := s.values[flag]
+		if !takesValue {
+			return dirNone, nil
+		}
+		directive, candidates := operandCandidates(kind, prefix)
+		return qualify(flag, directive, candidates)
+	}
 	if strings.HasPrefix(cur, "-") {
 		spellings := append([]string{}, s.flags...)
 		for f := range s.values {
@@ -618,6 +638,41 @@ func lastFlag(rest []string) string {
 		last = rest[len(rest)-2]
 	}
 	return last
+}
+
+// inlineValue splits a `--flag=value` token: the flag, and the part of the
+// value typed so far.
+//
+// bash has "=" in COMP_WORDBREAKS and sends the two halves as separate tokens,
+// which lastFlag handles. zsh and fish send one token, which arrives as the
+// current word and reaches here.
+func inlineValue(cur string) (flag, prefix string, ok bool) {
+	if !strings.HasPrefix(cur, "-") {
+		return "", "", false
+	}
+	flag, prefix, found := strings.Cut(cur, "=")
+	if !found {
+		return "", "", false
+	}
+	return flag, prefix, true
+}
+
+// qualify rewrites value candidates as `--flag=value`.
+//
+// The shell replaces the whole current word, and that word includes the flag,
+// so a bare value would replace `--network=is` with `isolated`. Directives that
+// hand the slot to the shell cannot be qualified this way -- the shell would
+// complete a path against the flag text -- so they become dirNone. That leaves
+// an inline path uncompleted in zsh and fish, which is what it already was.
+func qualify(flag string, directive string, candidates []string) (string, []string) {
+	if directive != dirNames {
+		return dirNone, nil
+	}
+	out := make([]string, 0, len(candidates))
+	for _, c := range candidates {
+		out = append(out, flag+"="+c)
+	}
+	return dirNames, out
 }
 
 // flagValue maps a run-line flag to what its value names. --network is the

--- a/cmd/brig/completion_test.go
+++ b/cmd/brig/completion_test.go
@@ -15,12 +15,12 @@ import (
 	"github.com/brig-sh/brig/internal/profile"
 )
 
-// completionHost gives the engine a host to answer about: two profiles of its
-// own, two sessions in the index, and two policies. Every case below reads the
-// same fixture, so what changes between them is only where the cursor is.
+// completionHost sets up the state the engine reads: one file-backed profile,
+// two sessions in the index, one policy. Every case below shares it, so the
+// only variable is where the cursor is.
 //
-// The built-in profiles are there too -- Load adds to the registry rather than
-// replacing it -- which is what the cases matching on a prefix rely on.
+// The built-ins are present too, since Load adds to the registry rather than
+// replacing it; the prefix-matching cases rely on that.
 func completionHost(t *testing.T) {
 	t.Helper()
 
@@ -66,8 +66,7 @@ func write(t *testing.T, path, body string) {
 	}
 }
 
-// Where the cursor is decides what may stand there. One table, because that is
-// what the engine is: a line, a position, and the vocabulary legal in it.
+// One table: a line, a cursor position, and what is legal there.
 func TestCompletePositions(t *testing.T) {
 	completionHost(t)
 
@@ -86,8 +85,8 @@ func TestCompletePositions(t *testing.T) {
 		words:     []string{""},
 		directive: dirNames,
 		want:      []string{"run", "sh", "stop", "rm", "ls", "info", "agent", "completion"},
-		// The retired spellings still work and say what replaced them. None of
-		// them is a word to teach a reader who has not typed it yet.
+		// The retired spellings still work and print what replaced them, but
+		// they are removed in v0.3, so completion does not offer them.
 		absent: []string{"exec", "shell", "env", "create", "reset", "profiles", "policies", completeVerb},
 	}, {
 		name:      "left of the verb the flags are the global ones",
@@ -119,9 +118,8 @@ func TestCompletePositions(t *testing.T) {
 		words:     []string{"run", "--"},
 		directive: dirNames,
 		want:      []string{"--home", "--image", "--mem", "--cpus", "--network", "--skills", "--detach", "--no-project", "--offline"},
-		// --name and --workspace are retiring onto other spellings; --memory is
-		// the older name of --mem and is in no help text; -q on the run line is
-		// the position that is retiring, not the flag.
+		// --name and --workspace are deprecated; --memory is undocumented; -q
+		// on the run line is the retiring position, not the flag.
 		absent: []string{"--name", "--workspace", "--memory", "--quiet", "--verbose"},
 	}, {
 		name:      "a flag only run acts on is not offered by a verb that continues a session",
@@ -143,7 +141,7 @@ func TestCompletePositions(t *testing.T) {
 		words:     []string{"run", "--home", ""},
 		directive: dirDirs,
 	}, {
-		// bash breaks a word on '=', so the inline spelling arrives split.
+		// bash splits on '=', so the inline spelling arrives as three tokens.
 		name:      "the inline spelling of a flag completes like the spaced one",
 		words:     []string{"run", "--network", "=", "off"},
 		directive: dirNames,
@@ -161,10 +159,8 @@ func TestCompletePositions(t *testing.T) {
 		words:     []string{"sh", "claude", ""},
 		directive: dirNone,
 	}, {
-		// A flag under the cursor right of the ref is brig's if brig has it:
-		// split reads its own flags on either side of the ref, and stops only
-		// at one it does not own. An unknown flag there is still the agent's,
-		// and brig has no list of another program's to offer for it.
+		// A flag right of the ref is brig's if brigFlags has it. An unknown
+		// one belongs to the agent, and brig has no list for that.
 		name:      "brig's own flags stand on either side of the ref",
 		words:     []string{"run", "claude", "--"},
 		directive: dirNames,
@@ -247,10 +243,8 @@ func TestCompletePositions(t *testing.T) {
 		words:     []string{"bogus", ""},
 		directive: dirNone,
 	}, {
-		// bash breaks a word on '=', so the inline spelling of a flag arrives
-		// as three tokens and the separator lands under the cursor. Reading it
-		// as the empty start of the value is what makes the two spellings of
-		// one flag complete alike.
+		// With the cursor straight after '=', the separator is the current
+		// word. It reads as an empty value prefix.
 		name:      "the separator under the cursor starts the value",
 		words:     []string{"run", "--network", "="},
 		directive: dirNames,
@@ -266,16 +260,16 @@ func TestCompletePositions(t *testing.T) {
 		directive: dirNames,
 		exactly:   []string{"no-net"},
 	}, {
-		// brig's own flags stand on either side of the ref: split reads them
-		// wherever they are on the run line. Completion withholding them right
-		// of the ref left it silent about a line brig reads.
+		// split() reads brig's flags on both sides of the ref, so completion
+		// offers them on both sides. Withholding them after the ref left
+		// `brig run claude --mem` uncompletable.
 		name:      "brig's own flag is offered right of the ref",
 		words:     []string{"run", "claude", "--m"},
 		directive: dirNames,
 		exactly:   []string{"--mem"},
 	}, {
-		// And stops where split stops. A bare word past the project begins the
-		// agent's argv, so a flag of brig's after it is the agent's word.
+		// And stops where split() stops: a second positional starts the
+		// agent's argv, so a brig flag after it belongs to the agent.
 		name:      "but not once the agent's arguments have begun",
 		words:     []string{"run", "claude", "./project", "npm", "--m"},
 		directive: dirNone,
@@ -293,8 +287,7 @@ func TestCompletePositions(t *testing.T) {
 		words:     []string{"stop", "claude-code", "extra", "--m"},
 		directive: dirNone,
 	}, {
-		// --all replaces the ref rather than joining it, and removeAll refuses
-		// every argument, so a line carrying it has nothing left to offer.
+		// --all replaces the ref, and removeAll rejects every argument.
 		name:      "rm --all completes nothing further",
 		words:     []string{"rm", "--all", ""},
 		directive: dirNone,
@@ -304,9 +297,8 @@ func TestCompletePositions(t *testing.T) {
 		directive: dirNames,
 		exactly:   []string{"--all"},
 	}, {
-		// --all replaces the ref, so once a ref is named it is gone from the
-		// offer -- and no other flag of brig's starts "--a", which is why the
-		// honest answer here is nothing at all.
+		// Once a ref is named, --all is not offered. No other brig flag starts
+		// "--a", so the correct answer is nothing.
 		name:      "a ref named, --all is not on offer",
 		words:     []string{"rm", "claude-code", "--a"},
 		directive: dirNone,
@@ -348,9 +340,8 @@ func TestCompletePositions(t *testing.T) {
 	}
 }
 
-// A directive that says "nothing here" never carries candidates, and one that
-// says "candidates follow" never comes back empty. A shell reads the first line
-// and stops; the two halves of an answer have to agree.
+// :none, :dirs and :files never carry candidates; :names is never empty. The
+// scripts read the first line and branch on it, so the two must agree.
 func TestCompleteAnswersAreWellFormed(t *testing.T) {
 	completionHost(t)
 
@@ -376,9 +367,9 @@ func TestCompleteAnswersAreWellFormed(t *testing.T) {
 	}
 }
 
-// The engine is asked on a keystroke, so it says nothing a reader did not ask
-// for. A profile that will not parse is the case that would otherwise print:
-// every other verb warns about it, and here it costs a candidate instead.
+// The engine runs on a keystroke, so it must write nothing to stderr. A
+// profile that will not parse is the case that would otherwise print: every
+// other verb warns about it. Here it costs a candidate instead.
 func TestCompleteIsSilentAboutABrokenProfile(t *testing.T) {
 	dir := t.TempDir()
 	t.Setenv("BRIG_PROFILE_DIR", dir)
@@ -396,8 +387,8 @@ func TestCompleteIsSilentAboutABrokenProfile(t *testing.T) {
 	}
 }
 
-// The answer is a directive line and then the candidates, one per line. This is
-// the whole of what the three scripts parse, so it is a test of its own.
+// A directive line, then one candidate per line. This is all the scripts
+// parse, so it gets its own test.
 func TestCompleteWireFormat(t *testing.T) {
 	completionHost(t)
 
@@ -407,8 +398,7 @@ func TestCompleteWireFormat(t *testing.T) {
 		t.Errorf("answer %q, want %q", got, want)
 	}
 
-	// A directive with nothing under it, so the two shapes of an answer are
-	// both covered: past `--` the line is the agent's and brig offers nothing.
+	// A directive with no candidates: past `--` the line is the agent's.
 	out.Reset()
 	completeCmd(&out, []string{"run", "claude", "--", "-"})
 	if got, want := out.String(), ":none\n"; got != want {
@@ -441,8 +431,8 @@ func TestCompleteThroughTheDispatcher(t *testing.T) {
 	}
 }
 
-// Every shell brig names in its own usage has a script to print, and every
-// script is registered for the command that runs it.
+// Every shell named in the usage text has a script, and every script handles
+// every directive the engine emits.
 func TestCompletionScripts(t *testing.T) {
 	for _, shell := range []string{"bash", "zsh", "fish"} {
 		var out bytes.Buffer
@@ -453,9 +443,8 @@ func TestCompletionScripts(t *testing.T) {
 		if !strings.Contains(script, completeVerb) {
 			t.Errorf("the %s script asks brig nothing", shell)
 		}
-		// A script that knows a directive brig does not emit, or misses one it
-		// does, is a script that will fall back to filenames where brig asked
-		// for silence.
+		// A script missing a directive falls back to filenames where the
+		// engine asked for silence.
 		for _, directive := range []string{dirNames, dirDirs, dirFiles} {
 			if !strings.Contains(script, directive) {
 				t.Errorf("the %s script does not handle %s", shell, directive)
@@ -493,32 +482,28 @@ func equal(got, want []string) bool {
 	return true
 }
 
-// The groups table is a second spelling of what the noun commands accept, and a
-// second spelling is a thing that drifts. Each subcommand registers its flags
-// with a flag.FlagSet of its own, inside the function that runs it, so there is
-// no table for completion to read -- which is exactly why this test reads the
-// registrations themselves.
+// The groups table duplicates what the noun subcommands accept, so it can
+// drift. Each subcommand registers its flags on a flag.FlagSet inside the
+// function that runs it, leaving nothing for completion to read, so this test
+// reads the registrations from the source instead.
 //
-// The invariant is one direction and deliberately loose: every flag name
-// registered by a noun-group parser must appear somewhere in the groups table.
-// It does not check which subcommand a flag landed on, because the parsers are
-// shared -- nameAndYes serves `secret delete` and `agent rm` both. What it does
-// catch is the drift that actually happens: a flag added to a subcommand and
-// forgotten here, which no other test would notice because completion failing
-// to offer something is silent.
+// The check is one-directional: every flag name registered by a noun-group
+// parser must appear somewhere in the table. It does not verify which
+// subcommand a flag belongs to, because the parsers are shared -- nameAndYes
+// serves both `secret delete` and `agent rm`. It catches the case that matters:
+// a flag added to a subcommand and not added here, which nothing else would
+// catch because a missing candidate is silent.
 func TestGroupsTableCoversEveryGroupFlag(t *testing.T) {
-	// The parsers that serve positions the groups table does not describe. Each
-	// is named rather than pattern-matched, and each is checked below to still
-	// register something, so this list cannot quietly rot into an excuse.
+	// Parsers serving positions the groups table does not describe. Listed by
+	// name, and each is checked below to still register something, so an entry
+	// cannot outlive what it excuses.
 	//
-	// It is short because most of brig's parsers are invisible to the scan
-	// below: it reads a flag name only where it is a string literal, and the
-	// run line registers its own through a closure over the spelling
-	// (`func(n string) { fs.StringVar(..., n, ...) }`), while doctor and ls
-	// hand-parse with no FlagSet at all. That is a real limit -- a group flag
-	// registered through a variable would go unseen here -- and it is worth
-	// naming rather than papering over: every group flag is a literal today,
-	// and one that stops being a literal loses this guard.
+	// The list is short because the scan below only sees a flag name written as
+	// a string literal. The run line registers through a closure over the
+	// spelling (`func(n string) { fs.StringVar(..., n, ...) }`), and doctor and
+	// ls hand-parse with no FlagSet. That is a real limit: a group flag
+	// registered through a variable would not be seen. All of them are literals
+	// today.
 	elsewhere := map[string]string{
 		"parseGlobal": "the global position, left of the verb; see brigFlags",
 	}
@@ -559,9 +544,8 @@ func TestGroupsTableCoversEveryGroupFlag(t *testing.T) {
 		}
 	}
 
-	// Every excuse still earns its place. A parser that has been renamed, or
-	// that no longer registers a flag, would otherwise leave a line here
-	// excusing something that cannot happen.
+	// A renamed parser, or one that no longer registers a flag, would leave a
+	// stale entry excusing something that cannot occur.
 	for fn, why := range elsewhere {
 		if !seen[fn] {
 			t.Errorf("`elsewhere` excuses %s (%s), but it registers no flag any more. Drop the line", fn, why)
@@ -569,9 +553,8 @@ func TestGroupsTableCoversEveryGroupFlag(t *testing.T) {
 	}
 }
 
-// registeredFlag reports the flag name a call registers, for the
-// fs.BoolVar/StringVar/... shape the noun groups use: the name is the second
-// argument, after the pointer it writes through.
+// registeredFlag returns the flag name from an fs.BoolVar/StringVar/... call:
+// the second argument, after the pointer.
 func registeredFlag(n ast.Node) (string, bool) {
 	call, ok := n.(*ast.CallExpr)
 	if !ok || len(call.Args) < 2 {
@@ -592,8 +575,8 @@ func registeredFlag(n ast.Node) (string, bool) {
 	return name, true
 }
 
-// groupFlagNames is every flag the groups table offers, by bare name, so a
-// registration can be looked up whichever way it is spelled.
+// groupFlagNames returns every flag in the groups table by bare name, so a
+// registration matches whichever way it is spelled.
 func groupFlagNames() map[string]bool {
 	out := map[string]bool{}
 	for _, subs := range groups {

--- a/cmd/brig/completion_test.go
+++ b/cmd/brig/completion_test.go
@@ -3,8 +3,12 @@ package main
 import (
 	"bytes"
 	"encoding/json"
+	"go/ast"
+	"go/parser"
+	"go/token"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -157,9 +161,14 @@ func TestCompletePositions(t *testing.T) {
 		words:     []string{"sh", "claude", ""},
 		directive: dirNone,
 	}, {
-		name:      "right of the ref a flag is the agent's",
+		// A flag under the cursor right of the ref is brig's if brig has it:
+		// split reads its own flags on either side of the ref, and stops only
+		// at one it does not own. An unknown flag there is still the agent's,
+		// and brig has no list of another program's to offer for it.
+		name:      "brig's own flags stand on either side of the ref",
 		words:     []string{"run", "claude", "--"},
-		directive: dirNone,
+		directive: dirNames,
+		want:      []string{"--mem", "--home"},
 	}, {
 		name:      "and everything past the end of brig's parsing is",
 		words:     []string{"run", "claude", "--", "-"},
@@ -237,6 +246,79 @@ func TestCompletePositions(t *testing.T) {
 		name:      "a verb brig does not have completes nothing",
 		words:     []string{"bogus", ""},
 		directive: dirNone,
+	}, {
+		// bash breaks a word on '=', so the inline spelling of a flag arrives
+		// as three tokens and the separator lands under the cursor. Reading it
+		// as the empty start of the value is what makes the two spellings of
+		// one flag complete alike.
+		name:      "the separator under the cursor starts the value",
+		words:     []string{"run", "--network", "="},
+		directive: dirNames,
+		exactly:   []string{"isolated", "offline", "shared"},
+	}, {
+		name:      "an inline value is consumed with its separator, not read as the ref",
+		words:     []string{"run", "--mem", "=", "4096", ""},
+		directive: dirNames,
+		want:      []string{"claude-code", "claude-code@refactor"},
+	}, {
+		name:      "and it does not shift a group's operand slots",
+		words:     []string{"policy", "attach", "--name", "=", "x", ""},
+		directive: dirNames,
+		exactly:   []string{"no-net"},
+	}, {
+		// brig's own flags stand on either side of the ref: split reads them
+		// wherever they are on the run line. Completion withholding them right
+		// of the ref left it silent about a line brig reads.
+		name:      "brig's own flag is offered right of the ref",
+		words:     []string{"run", "claude", "--m"},
+		directive: dirNames,
+		exactly:   []string{"--mem"},
+	}, {
+		// And stops where split stops. A bare word past the project begins the
+		// agent's argv, so a flag of brig's after it is the agent's word.
+		name:      "but not once the agent's arguments have begun",
+		words:     []string{"run", "claude", "./project", "npm", "--m"},
+		directive: dirNone,
+	}, {
+		name:      "nor is a flag's value completed into the agent's argv",
+		words:     []string{"sh", "claude", "npm", "--network", ""},
+		directive: dirNone,
+	}, {
+		name:      "a continuing verb reads brig's flags after its ref too",
+		words:     []string{"stop", "claude-code", "--m"},
+		directive: dirNames,
+		exactly:   []string{"--mem"},
+	}, {
+		name:      "and the tail begins at its first bare word past the ref",
+		words:     []string{"stop", "claude-code", "extra", "--m"},
+		directive: dirNone,
+	}, {
+		// --all replaces the ref rather than joining it, and removeAll refuses
+		// every argument, so a line carrying it has nothing left to offer.
+		name:      "rm --all completes nothing further",
+		words:     []string{"rm", "--all", ""},
+		directive: dirNone,
+	}, {
+		name:      "and --all is offered only where the ref would have gone",
+		words:     []string{"rm", "--a"},
+		directive: dirNames,
+		exactly:   []string{"--all"},
+	}, {
+		// --all replaces the ref, so once a ref is named it is gone from the
+		// offer -- and no other flag of brig's starts "--a", which is why the
+		// honest answer here is nothing at all.
+		name:      "a ref named, --all is not on offer",
+		words:     []string{"rm", "claude-code", "--a"},
+		directive: dirNone,
+	}, {
+		name:      "a secret write takes a file, and says so",
+		words:     []string{"secret", "create", "gh-token", "-"},
+		directive: dirNames,
+		exactly:   []string{"--file", "--stdin", "-f"},
+	}, {
+		name:      "and the file is the shell's to complete",
+		words:     []string{"secret", "create", "gh-token", "-f", ""},
+		directive: dirFiles,
 	}}
 
 	for _, tc := range cases {
@@ -325,8 +407,10 @@ func TestCompleteWireFormat(t *testing.T) {
 		t.Errorf("answer %q, want %q", got, want)
 	}
 
+	// A directive with nothing under it, so the two shapes of an answer are
+	// both covered: past `--` the line is the agent's and brig offers nothing.
 	out.Reset()
-	completeCmd(&out, []string{"run", "claude", "-"})
+	completeCmd(&out, []string{"run", "claude", "--", "-"})
 	if got, want := out.String(), ":none\n"; got != want {
 		t.Errorf("answer %q, want %q", got, want)
 	}
@@ -407,4 +491,120 @@ func equal(got, want []string) bool {
 		}
 	}
 	return true
+}
+
+// The groups table is a second spelling of what the noun commands accept, and a
+// second spelling is a thing that drifts. Each subcommand registers its flags
+// with a flag.FlagSet of its own, inside the function that runs it, so there is
+// no table for completion to read -- which is exactly why this test reads the
+// registrations themselves.
+//
+// The invariant is one direction and deliberately loose: every flag name
+// registered by a noun-group parser must appear somewhere in the groups table.
+// It does not check which subcommand a flag landed on, because the parsers are
+// shared -- nameAndYes serves `secret delete` and `agent rm` both. What it does
+// catch is the drift that actually happens: a flag added to a subcommand and
+// forgotten here, which no other test would notice because completion failing
+// to offer something is silent.
+func TestGroupsTableCoversEveryGroupFlag(t *testing.T) {
+	// The parsers that serve positions the groups table does not describe. Each
+	// is named rather than pattern-matched, and each is checked below to still
+	// register something, so this list cannot quietly rot into an excuse.
+	//
+	// It is short because most of brig's parsers are invisible to the scan
+	// below: it reads a flag name only where it is a string literal, and the
+	// run line registers its own through a closure over the spelling
+	// (`func(n string) { fs.StringVar(..., n, ...) }`), while doctor and ls
+	// hand-parse with no FlagSet at all. That is a real limit -- a group flag
+	// registered through a variable would go unseen here -- and it is worth
+	// naming rather than papering over: every group flag is a literal today,
+	// and one that stops being a literal loses this guard.
+	elsewhere := map[string]string{
+		"parseGlobal": "the global position, left of the verb; see brigFlags",
+	}
+	seen := map[string]bool{}
+
+	fset := token.NewFileSet()
+	pkg, err := parser.ParseDir(fset, ".", func(fi os.FileInfo) bool {
+		return !strings.HasSuffix(fi.Name(), "_test.go")
+	}, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	table := groupFlagNames()
+
+	for _, f := range pkg["main"].Files {
+		for _, decl := range f.Decls {
+			fn, ok := decl.(*ast.FuncDecl)
+			if !ok {
+				continue
+			}
+			ast.Inspect(fn, func(n ast.Node) bool {
+				name, ok := registeredFlag(n)
+				if !ok {
+					return true
+				}
+				if _, excused := elsewhere[fn.Name.Name]; excused {
+					seen[fn.Name.Name] = true
+					return true
+				}
+				if !table[name] {
+					t.Errorf("%s registers the flag %q, and the groups table does not offer it. "+
+						"Add it to the subcommand's entry, or -- if it belongs to a position the "+
+						"table does not describe -- name that parser in `elsewhere` with the reason",
+						fn.Name.Name, spell(name))
+				}
+				return true
+			})
+		}
+	}
+
+	// Every excuse still earns its place. A parser that has been renamed, or
+	// that no longer registers a flag, would otherwise leave a line here
+	// excusing something that cannot happen.
+	for fn, why := range elsewhere {
+		if !seen[fn] {
+			t.Errorf("`elsewhere` excuses %s (%s), but it registers no flag any more. Drop the line", fn, why)
+		}
+	}
+}
+
+// registeredFlag reports the flag name a call registers, for the
+// fs.BoolVar/StringVar/... shape the noun groups use: the name is the second
+// argument, after the pointer it writes through.
+func registeredFlag(n ast.Node) (string, bool) {
+	call, ok := n.(*ast.CallExpr)
+	if !ok || len(call.Args) < 2 {
+		return "", false
+	}
+	sel, ok := call.Fun.(*ast.SelectorExpr)
+	if !ok || !strings.HasSuffix(sel.Sel.Name, "Var") {
+		return "", false
+	}
+	lit, ok := call.Args[1].(*ast.BasicLit)
+	if !ok || lit.Kind != token.STRING {
+		return "", false
+	}
+	name, err := strconv.Unquote(lit.Value)
+	if err != nil {
+		return "", false
+	}
+	return name, true
+}
+
+// groupFlagNames is every flag the groups table offers, by bare name, so a
+// registration can be looked up whichever way it is spelled.
+func groupFlagNames() map[string]bool {
+	out := map[string]bool{}
+	for _, subs := range groups {
+		for _, s := range subs {
+			for _, f := range s.flags {
+				out[strings.TrimLeft(f, "-")] = true
+			}
+			for f := range s.values {
+				out[strings.TrimLeft(f, "-")] = true
+			}
+		}
+	}
+	return out
 }

--- a/cmd/brig/completion_test.go
+++ b/cmd/brig/completion_test.go
@@ -1,0 +1,410 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/brig-sh/brig/internal/profile"
+)
+
+// completionHost gives the engine a host to answer about: two profiles of its
+// own, two sessions in the index, and two policies. Every case below reads the
+// same fixture, so what changes between them is only where the cursor is.
+//
+// The built-in profiles are there too -- Load adds to the registry rather than
+// replacing it -- which is what the cases matching on a prefix rely on.
+func completionHost(t *testing.T) {
+	t.Helper()
+
+	profiles := t.TempDir()
+	t.Setenv("BRIG_PROFILE_DIR", profiles)
+	write(t, filepath.Join(profiles, "mine.yaml"), `name: mine
+kind: shell
+image: docker.io/library/ubuntu:24.04
+guestHome: /root
+mem: 2048
+cpus: 2
+`)
+	if err := profile.Load(profile.Dir()); err != nil {
+		t.Fatal(err)
+	}
+
+	state := t.TempDir()
+	t.Setenv("BRIG_STATE_DIR", state)
+	index := map[string]map[string]string{
+		"claude-code":          {"home": "/tmp/one", "sandbox": "brig-claude-code"},
+		"claude-code@refactor": {"home": "/tmp/two", "sandbox": "brig-claude-code-refactor"},
+	}
+	blob, err := json.Marshal(index)
+	if err != nil {
+		t.Fatal(err)
+	}
+	write(t, filepath.Join(state, "sessions.json"), string(blob))
+
+	policies := t.TempDir()
+	t.Setenv("BRIG_POLICY_DIR", policies)
+	write(t, filepath.Join(policies, "no-net.yaml"), `apiVersion: brig.sh/v1alpha1
+name: no-net
+desc: nothing leaves
+egress:
+  default: deny
+`)
+}
+
+func write(t *testing.T, path, body string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// Where the cursor is decides what may stand there. One table, because that is
+// what the engine is: a line, a position, and the vocabulary legal in it.
+func TestCompletePositions(t *testing.T) {
+	completionHost(t)
+
+	cases := []struct {
+		name string
+		// words is the line with `brig` dropped; the last of them is the word
+		// under the cursor, empty when the cursor is on fresh whitespace.
+		words     []string
+		directive string
+		// want are candidates that must be offered, absent ones that must not.
+		want    []string
+		absent  []string
+		exactly []string
+	}{{
+		name:      "a bare line offers the verbs",
+		words:     []string{""},
+		directive: dirNames,
+		want:      []string{"run", "sh", "stop", "rm", "ls", "info", "agent", "completion"},
+		// The retired spellings still work and say what replaced them. None of
+		// them is a word to teach a reader who has not typed it yet.
+		absent: []string{"exec", "shell", "env", "create", "reset", "profiles", "policies", completeVerb},
+	}, {
+		name:      "left of the verb the flags are the global ones",
+		words:     []string{"-"},
+		directive: dirNames,
+		exactly:   []string{"--quiet", "--verbose", "-q"},
+	}, {
+		name:      "a global flag does not hide the verb after it",
+		words:     []string{"-q", "r"},
+		directive: dirNames,
+		exactly:   []string{"rm", "run"},
+	}, {
+		name:      "the ref position offers agents and the sessions under them",
+		words:     []string{"run", "claude-code"},
+		directive: dirNames,
+		exactly:   []string{"claude-code", "claude-code@refactor"},
+	}, {
+		name:      "the separator narrows to that agent's sessions",
+		words:     []string{"run", "claude-code@"},
+		directive: dirNames,
+		exactly:   []string{"claude-code@refactor"},
+	}, {
+		name:      "a profile of your own is a ref like any other",
+		words:     []string{"run", "mi"},
+		directive: dirNames,
+		exactly:   []string{"mine"},
+	}, {
+		name:      "run-line flags are brig's own, up to the ref",
+		words:     []string{"run", "--"},
+		directive: dirNames,
+		want:      []string{"--home", "--image", "--mem", "--cpus", "--network", "--skills", "--detach", "--no-project", "--offline"},
+		// --name and --workspace are retiring onto other spellings; --memory is
+		// the older name of --mem and is in no help text; -q on the run line is
+		// the position that is retiring, not the flag.
+		absent: []string{"--name", "--workspace", "--memory", "--quiet", "--verbose"},
+	}, {
+		name:      "a flag only run acts on is not offered by a verb that continues a session",
+		words:     []string{"sh", "--"},
+		directive: dirNames,
+		absent:    []string{"--detach", "--no-project"},
+	}, {
+		name:      "rm offers the flag that names no session",
+		words:     []string{"rm", "--a"},
+		directive: dirNames,
+		exactly:   []string{"--all"},
+	}, {
+		name:      "a closed set completes its own words",
+		words:     []string{"run", "claude", "--network", ""},
+		directive: dirNames,
+		exactly:   []string{"isolated", "offline", "shared"},
+	}, {
+		name:      "a flag naming a host directory hands the slot to the shell",
+		words:     []string{"run", "--home", ""},
+		directive: dirDirs,
+	}, {
+		// bash breaks a word on '=', so the inline spelling arrives split.
+		name:      "the inline spelling of a flag completes like the spaced one",
+		words:     []string{"run", "--network", "=", "off"},
+		directive: dirNames,
+		exactly:   []string{"offline"},
+	}, {
+		name:      "on run the word after the ref is the project brig mounts",
+		words:     []string{"run", "claude", ""},
+		directive: dirDirs,
+	}, {
+		name:      "and only the first one",
+		words:     []string{"run", "claude", "./project", ""},
+		directive: dirNone,
+	}, {
+		name:      "no other verb has a project slot",
+		words:     []string{"sh", "claude", ""},
+		directive: dirNone,
+	}, {
+		name:      "right of the ref a flag is the agent's",
+		words:     []string{"run", "claude", "--"},
+		directive: dirNone,
+	}, {
+		name:      "and everything past the end of brig's parsing is",
+		words:     []string{"run", "claude", "--", "-"},
+		directive: dirNone,
+	}, {
+		name:      "stop offers the sessions there are, not the agents there could be",
+		words:     []string{"stop", ""},
+		directive: dirNames,
+		exactly:   []string{"claude-code", "claude-code@refactor"},
+	}, {
+		name:      "info reads a profile without booting one, so it takes any agent",
+		words:     []string{"info", "mi"},
+		directive: dirNames,
+		exactly:   []string{"mine"},
+	}, {
+		name:      "ls takes one flag and no operand",
+		words:     []string{"ls", ""},
+		directive: dirNone,
+	}, {
+		name:      "a noun command offers its subcommands",
+		words:     []string{"agent", ""},
+		directive: dirNames,
+		exactly:   []string{"edit", "export", "import", "ls", "new", "rm", "show"},
+		// list, save and load still work and are in no help text.
+	}, {
+		name:      "a subcommand that opens a file offers only agents that have one",
+		words:     []string{"agent", "edit", ""},
+		directive: dirNames,
+		exactly:   []string{"mine"},
+	}, {
+		name:      "a subcommand that reads an agent offers the built-ins too",
+		words:     []string{"agent", "show", "claude-c"},
+		directive: dirNames,
+		want:      []string{"claude-code"},
+	}, {
+		name:      "a flag's value is completed by what the flag names",
+		words:     []string{"agent", "new", "ours", "--from", "claude-c"},
+		directive: dirNames,
+		want:      []string{"claude-code"},
+	}, {
+		name:      "a subcommand taking a file hands the slot to the shell",
+		words:     []string{"agent", "import", ""},
+		directive: dirFiles,
+	}, {
+		name:      "policies are completed where a policy goes",
+		words:     []string{"policy", "attach", ""},
+		directive: dirNames,
+		exactly:   []string{"no-net"},
+	}, {
+		name:      "and the profile it binds to, in the slot after it",
+		words:     []string{"policy", "attach", "no-net", "mi"},
+		directive: dirNames,
+		exactly:   []string{"mine"},
+	}, {
+		// Listing them opens the store, and a keystroke must not.
+		name:      "secret names are not offered",
+		words:     []string{"secret", "read", ""},
+		directive: dirNone,
+	}, {
+		name:      "the store's own subcommands are",
+		words:     []string{"secret", ""},
+		directive: dirNames,
+		exactly:   []string{"create", "delete", "import", "ls", "read", "update"},
+	}, {
+		name:      "telemetry is three words",
+		words:     []string{"telemetry", ""},
+		directive: dirNames,
+		exactly:   []string{"off", "on", "status"},
+	}, {
+		name:      "completion offers the shells it has",
+		words:     []string{"completion", ""},
+		directive: dirNames,
+		exactly:   []string{"bash", "fish", "zsh"},
+	}, {
+		name:      "a verb brig does not have completes nothing",
+		words:     []string{"bogus", ""},
+		directive: dirNone,
+	}}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			directive, got := complete(tc.words)
+			if directive != tc.directive {
+				t.Errorf("brig %s: directive %q, want %q (candidates %v)",
+					strings.Join(tc.words, " "), directive, tc.directive, got)
+			}
+			if tc.exactly != nil && !equal(got, tc.exactly) {
+				t.Errorf("brig %s: candidates %v, want exactly %v",
+					strings.Join(tc.words, " "), got, tc.exactly)
+			}
+			for _, want := range tc.want {
+				if !has(got, want) {
+					t.Errorf("brig %s: %q is not offered (got %v)",
+						strings.Join(tc.words, " "), want, got)
+				}
+			}
+			for _, absent := range tc.absent {
+				if has(got, absent) {
+					t.Errorf("brig %s: %q is offered and should not be",
+						strings.Join(tc.words, " "), absent)
+				}
+			}
+		})
+	}
+}
+
+// A directive that says "nothing here" never carries candidates, and one that
+// says "candidates follow" never comes back empty. A shell reads the first line
+// and stops; the two halves of an answer have to agree.
+func TestCompleteAnswersAreWellFormed(t *testing.T) {
+	completionHost(t)
+
+	lines := [][]string{
+		{""}, {"-"}, {"run", ""}, {"run", "--"}, {"run", "claude", ""},
+		{"run", "claude", "-"}, {"stop", ""}, {"agent", ""}, {"agent", "import", ""},
+		{"policy", "show", ""}, {"secret", "read", ""}, {"bogus", ""}, {},
+	}
+	for _, words := range lines {
+		directive, candidates := complete(words)
+		switch directive {
+		case dirNames:
+			if len(candidates) == 0 {
+				t.Errorf("brig %s: %s with nothing to offer", strings.Join(words, " "), directive)
+			}
+		case dirNone, dirDirs, dirFiles:
+			if len(candidates) > 0 {
+				t.Errorf("brig %s: %s carrying candidates %v", strings.Join(words, " "), directive, candidates)
+			}
+		default:
+			t.Errorf("brig %s: unknown directive %q", strings.Join(words, " "), directive)
+		}
+	}
+}
+
+// The engine is asked on a keystroke, so it says nothing a reader did not ask
+// for. A profile that will not parse is the case that would otherwise print:
+// every other verb warns about it, and here it costs a candidate instead.
+func TestCompleteIsSilentAboutABrokenProfile(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("BRIG_PROFILE_DIR", dir)
+	t.Setenv("BRIG_STATE_DIR", t.TempDir())
+	write(t, filepath.Join(dir, "broken.yaml"), "name: [unclosed\n")
+
+	var out bytes.Buffer
+	noise := captureStderr(t, func() { completeCmd(&out, []string{"run", ""}) })
+
+	if noise != "" {
+		t.Errorf("completion wrote %q to stderr; a keystroke prints nothing", noise)
+	}
+	if !strings.HasPrefix(out.String(), dirNames+"\n") {
+		t.Errorf("completion answered %q, want candidates for the ref position", out.String())
+	}
+}
+
+// The answer is a directive line and then the candidates, one per line. This is
+// the whole of what the three scripts parse, so it is a test of its own.
+func TestCompleteWireFormat(t *testing.T) {
+	completionHost(t)
+
+	var out bytes.Buffer
+	completeCmd(&out, []string{"telemetry", ""})
+	if got, want := out.String(), ":names\noff\non\nstatus\n"; got != want {
+		t.Errorf("answer %q, want %q", got, want)
+	}
+
+	out.Reset()
+	completeCmd(&out, []string{"run", "claude", "-"})
+	if got, want := out.String(), ":none\n"; got != want {
+		t.Errorf("answer %q, want %q", got, want)
+	}
+}
+
+// The hidden verb is reached the way a script reaches it: the guard `--` and
+// then the words. It answers before the dispatcher's own notices, so nothing a
+// keystroke did not ask for reaches the terminal.
+func TestCompleteThroughTheDispatcher(t *testing.T) {
+	completionHost(t)
+
+	var out string
+	noise := captureStderr(t, func() {
+		got, err := captureStdout(t, func() error {
+			return run([]string{completeVerb, "--", "telemetry", ""})
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		out = got
+	})
+
+	if want := ":names\noff\non\nstatus\n"; out != want {
+		t.Errorf("brig %s -- telemetry '': %q, want %q", completeVerb, out, want)
+	}
+	if noise != "" {
+		t.Errorf("brig %s wrote %q to stderr", completeVerb, noise)
+	}
+}
+
+// Every shell brig names in its own usage has a script to print, and every
+// script is registered for the command that runs it.
+func TestCompletionScripts(t *testing.T) {
+	for _, shell := range []string{"bash", "zsh", "fish"} {
+		var out bytes.Buffer
+		if err := completionCmd(&out, []string{shell}); err != nil {
+			t.Fatalf("brig completion %s: %v", shell, err)
+		}
+		script := out.String()
+		if !strings.Contains(script, completeVerb) {
+			t.Errorf("the %s script asks brig nothing", shell)
+		}
+		// A script that knows a directive brig does not emit, or misses one it
+		// does, is a script that will fall back to filenames where brig asked
+		// for silence.
+		for _, directive := range []string{dirNames, dirDirs, dirFiles} {
+			if !strings.Contains(script, directive) {
+				t.Errorf("the %s script does not handle %s", shell, directive)
+			}
+		}
+	}
+
+	var out bytes.Buffer
+	if err := completionCmd(&out, []string{"tcsh"}); err == nil {
+		t.Error("brig completion tcsh: no error for a shell brig has no script for")
+	}
+	if err := completionCmd(&out, nil); err == nil {
+		t.Error("brig completion: no error with no shell named")
+	}
+}
+
+func has(list []string, want string) bool {
+	for _, s := range list {
+		if s == want {
+			return true
+		}
+	}
+	return false
+}
+
+func equal(got, want []string) bool {
+	if len(got) != len(want) {
+		return false
+	}
+	for i := range got {
+		if got[i] != want[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/cmd/brig/completion_test.go
+++ b/cmd/brig/completion_test.go
@@ -311,6 +311,49 @@ func TestCompletePositions(t *testing.T) {
 		name:      "and the file is the shell's to complete",
 		words:     []string{"secret", "create", "gh-token", "-f", ""},
 		directive: dirFiles,
+	}, {
+		// Only bash has "=" in COMP_WORDBREAKS. zsh and fish send
+		// `--network=is` as one token, so it arrives as the current word and
+		// would otherwise be matched against flag names.
+		//
+		// The candidate carries the flag because the shell replaces the whole
+		// current word: a bare "isolated" would replace `--network=is` with
+		// `isolated`.
+		name:      "an inline value under the cursor completes the value",
+		words:     []string{"run", "--network=is"},
+		directive: dirNames,
+		exactly:   []string{"--network=isolated"},
+	}, {
+		name:      "with the whole set when nothing is typed after the separator",
+		words:     []string{"run", "--network="},
+		directive: dirNames,
+		exactly:   []string{"--network=isolated", "--network=offline", "--network=shared"},
+	}, {
+		name:      "the split shape keeps its bare values, as bash needs",
+		words:     []string{"run", "--network", "=", "is"},
+		directive: dirNames,
+		exactly:   []string{"isolated"},
+	}, {
+		name:      "a group flag's value completes inline too",
+		words:     []string{"agent", "new", "ours", "--from=claude-c"},
+		directive: dirNames,
+		exactly:   []string{"--from=claude-code"},
+	}, {
+		// A path cannot be qualified this way: the shell would complete it
+		// against the flag text. Offering nothing leaves the inline spelling
+		// where it already was in these two shells.
+		name:      "an inline path is not completed",
+		words:     []string{"run", "--home=/pa"},
+		directive: dirNone,
+	}, {
+		name:      "an inline value on a flag brig does not have completes nothing",
+		words:     []string{"run", "--bogus=x"},
+		directive: dirNone,
+	}, {
+		name:      "a flag that already has its value leaves the ref next",
+		words:     []string{"run", "--network=offline", ""},
+		directive: dirNames,
+		want:      []string{"claude-code", "claude-code@refactor"},
 	}}
 
 	for _, tc := range cases {

--- a/cmd/brig/completions/brig.bash
+++ b/cmd/brig/completions/brig.bash
@@ -17,12 +17,17 @@ _brig_completion() {
 	# tells brig it is being asked "what can come next" rather than "finish
 	# this token".
 	words=("${COMP_WORDS[@]:1:COMP_CWORD-1}")
-	cur="${COMP_WORDS[COMP_CWORD]}"
+	cur="${COMP_WORDS[COMP_CWORD]-}"
 
 	COMPREPLY=()
 	# stderr is dropped rather than shown: brig writes none on this path, and a
 	# line from anywhere else would land in the middle of what is being typed.
-	out="$("${COMP_WORDS[0]}" __complete -- "${words[@]}" "$cur" 2>/dev/null)" || return
+	#
+	# ${words[@]+"${words[@]}"} rather than "${words[@]}": before bash 4.4 an
+	# empty array expanded under `set -u` is an unbound variable, so a reader
+	# with `set -u` in their shell got an error across the prompt on the very
+	# first word. macOS ships bash 3.2, which is exactly that case.
+	out="$("${COMP_WORDS[0]}" __complete -- ${words[@]+"${words[@]}"} "$cur" 2>/dev/null)" || return
 	directive="${out%%$'\n'*}"
 
 	case "$directive" in
@@ -31,7 +36,7 @@ _brig_completion() {
 		# candidate carrying a space stays one candidate.
 		local IFS=$'\n'
 		reply=(${out#*$'\n'})
-		COMPREPLY=("${reply[@]}")
+		COMPREPLY=(${reply[@]+"${reply[@]}"})
 		;;
 	:dirs)
 		# Directory names, from the shell rather than from brig: the project

--- a/cmd/brig/completions/brig.bash
+++ b/cmd/brig/completions/brig.bash
@@ -1,46 +1,43 @@
 # brig completion for bash. Printed by `brig completion bash`.
 #
-# This script knows none of brig's vocabulary. It collects the words left of
-# the cursor, asks brig what may stand there, and renders the answer -- so the
-# verbs, the refs and the flags come from the binary that is installed rather
-# than from whenever this file was written.
+# This script holds no brig vocabulary. It collects the words left of the
+# cursor, asks brig what may stand there, and renders the reply, so verbs, refs
+# and flags come from the installed binary rather than from this file.
 #
-# The answer is a directive line and then the candidates, one per line.
+# The reply is a directive line followed by the candidates, one per line.
 
 _brig_completion() {
 	local cur pre out directive
 	local -a words reply
 
-	# The words to send: everything after `brig` and left of the cursor, then
-	# the word under the cursor -- passed explicitly because it is empty when
-	# the cursor sits on fresh whitespace, and an empty last argument is what
-	# tells brig it is being asked "what can come next" rather than "finish
-	# this token".
+	# Everything after `brig` and left of the cursor, then the current word.
+	# The current word is passed separately because it is empty when the cursor
+	# is on fresh whitespace, and an empty final argument is what asks "what
+	# comes next" rather than "finish this token".
 	words=("${COMP_WORDS[@]:1:COMP_CWORD-1}")
 	cur="${COMP_WORDS[COMP_CWORD]-}"
 
 	COMPREPLY=()
-	# stderr is dropped rather than shown: brig writes none on this path, and a
-	# line from anywhere else would land in the middle of what is being typed.
+	# stderr is discarded: brig writes none here, and anything from elsewhere
+	# would print over the line being typed.
 	#
 	# ${words[@]+"${words[@]}"} rather than "${words[@]}": before bash 4.4 an
-	# empty array expanded under `set -u` is an unbound variable, so a reader
-	# with `set -u` in their shell got an error across the prompt on the very
-	# first word. macOS ships bash 3.2, which is exactly that case.
+	# empty array expanded under `set -u` is an unbound variable. macOS ships
+	# bash 3.2, so a user with `set -u` got an error on the first word.
 	out="$("${COMP_WORDS[0]}" __complete -- ${words[@]+"${words[@]}"} "$cur" 2>/dev/null)" || return
 	directive="${out%%$'\n'*}"
 
 	case "$directive" in
 	:names)
-		# Everything after the directive line, split on newlines only, so a
-		# candidate carrying a space stays one candidate.
+		# Split on newlines only, so a candidate containing a space stays one
+		# candidate.
 		local IFS=$'\n'
 		reply=(${out#*$'\n'})
 		COMPREPLY=(${reply[@]+"${reply[@]}"})
 		;;
 	:dirs)
-		# Directory names, from the shell rather than from brig: the project
-		# slot is brig's, the filesystem is not.
+		# Directories come from the shell. The project slot is brig's; the
+		# filesystem is not.
 		local IFS=$'\n'
 		COMPREPLY=($(compgen -d -- "$cur"))
 		compopt -o filenames 2>/dev/null
@@ -51,9 +48,8 @@ _brig_completion() {
 		compopt -o filenames 2>/dev/null
 		;;
 	*)
-		# :none, or an answer this script does not know. Offer nothing: right
-		# of the ref the words are the agent's, and filenames are a worse guess
-		# than silence.
+		# :none, or a directive this script does not know. Offer nothing:
+		# inside the agent's argv, filenames are worse than silence.
 		;;
 	esac
 }

--- a/cmd/brig/completions/brig.bash
+++ b/cmd/brig/completions/brig.bash
@@ -1,0 +1,56 @@
+# brig completion for bash. Printed by `brig completion bash`.
+#
+# This script knows none of brig's vocabulary. It collects the words left of
+# the cursor, asks brig what may stand there, and renders the answer -- so the
+# verbs, the refs and the flags come from the binary that is installed rather
+# than from whenever this file was written.
+#
+# The answer is a directive line and then the candidates, one per line.
+
+_brig_completion() {
+	local cur pre out directive
+	local -a words reply
+
+	# The words to send: everything after `brig` and left of the cursor, then
+	# the word under the cursor -- passed explicitly because it is empty when
+	# the cursor sits on fresh whitespace, and an empty last argument is what
+	# tells brig it is being asked "what can come next" rather than "finish
+	# this token".
+	words=("${COMP_WORDS[@]:1:COMP_CWORD-1}")
+	cur="${COMP_WORDS[COMP_CWORD]}"
+
+	COMPREPLY=()
+	# stderr is dropped rather than shown: brig writes none on this path, and a
+	# line from anywhere else would land in the middle of what is being typed.
+	out="$("${COMP_WORDS[0]}" __complete -- "${words[@]}" "$cur" 2>/dev/null)" || return
+	directive="${out%%$'\n'*}"
+
+	case "$directive" in
+	:names)
+		# Everything after the directive line, split on newlines only, so a
+		# candidate carrying a space stays one candidate.
+		local IFS=$'\n'
+		reply=(${out#*$'\n'})
+		COMPREPLY=("${reply[@]}")
+		;;
+	:dirs)
+		# Directory names, from the shell rather than from brig: the project
+		# slot is brig's, the filesystem is not.
+		local IFS=$'\n'
+		COMPREPLY=($(compgen -d -- "$cur"))
+		compopt -o filenames 2>/dev/null
+		;;
+	:files)
+		local IFS=$'\n'
+		COMPREPLY=($(compgen -f -- "$cur"))
+		compopt -o filenames 2>/dev/null
+		;;
+	*)
+		# :none, or an answer this script does not know. Offer nothing: right
+		# of the ref the words are the agent's, and filenames are a worse guess
+		# than silence.
+		;;
+	esac
+}
+
+complete -F _brig_completion brig

--- a/cmd/brig/completions/brig.fish
+++ b/cmd/brig/completions/brig.fish
@@ -2,45 +2,48 @@
 #
 # This script knows none of brig's vocabulary. It collects the words left of
 # the cursor, asks brig what may stand there, and renders the answer -- so the
-# verbs, the refs and the flags come from the binary that is installed rather
+# verbs, the flags and the refs come from the binary that is installed rather
 # than from whenever this file was written.
 #
 # The answer is a directive line and then the candidates, one per line.
 
-# __brig_ask runs the engine once per command line and caches what it said.
+# __brig_ask puts the line to brig and prints what it said.
 #
-# fish evaluates each `complete` condition below in turn, so without the cache
-# one keystroke would run brig three times to learn the same answer.
+# Asked again for every completion rather than memoized. What brig answers
+# depends on state outside the command line -- the sessions that exist, the
+# profiles and policies on disk -- and a cache keyed on the line has no way to
+# learn that any of it changed, so a session started after the first TAB would
+# never be offered again for the life of the shell. bash and zsh re-ask on
+# every keystroke; the cost is one exec of a command that reads two files.
 function __brig_ask
-	set -l line (commandline -cp)
-	if test "$__brig_line" != "$line"
-		set -l tokens (commandline -opc)
-		set -l cur (commandline -ct)
-		# The command itself is dropped; the word under the cursor is passed
-		# explicitly, because an empty last argument is what tells brig it is
-		# being asked "what can come next" rather than "finish this token".
-		if set -q tokens[1]
-			set -e tokens[1]
-		end
-		set -g __brig_line $line
-		# stderr is dropped rather than shown: brig writes none on this path,
-		# and a line from anywhere else would land in the middle of what is
-		# being typed.
-		set -g __brig_out (brig __complete -- $tokens $cur 2>/dev/null)
-	end
+    set -l tokens (commandline -opc)
+    set -l cur (commandline -ct)
+    # The command itself is dropped; the word under the cursor is passed
+    # explicitly, because an empty last argument is what tells brig it is being
+    # asked "what can come next" rather than "finish this token".
+    if set -q tokens[1]
+        set -e tokens[1]
+    end
+    # stderr is dropped rather than shown: brig writes none on this path, and a
+    # line from anywhere else would land in the middle of what is being typed.
+    brig __complete -- $tokens $cur 2>/dev/null
 end
 
-# __brig_says reports whether the engine answered with one directive.
+# __brig_says reports whether the answer carries one directive.
 function __brig_says
-	__brig_ask
-	test "$__brig_out[1]" = "$argv[1]"
+    set -l out (__brig_ask)
+    # An answer with no first line means brig could not be reached at all.
+    # Reported as "not this directive" rather than left to `test`, which would
+    # otherwise print its own complaint across the prompt.
+    set -q out[1]; or return 1
+    test "$out[1]" = "$argv[1]"
 end
 
 function __brig_candidates
-	__brig_ask
-	if set -q __brig_out[2]
-		printf '%s\n' $__brig_out[2..-1]
-	end
+    set -l out (__brig_ask)
+    if set -q out[2]
+        printf '%s\n' $out[2..-1]
+    end
 end
 
 # -f on the name and directory cases so fish offers nothing of its own: right

--- a/cmd/brig/completions/brig.fish
+++ b/cmd/brig/completions/brig.fish
@@ -1,40 +1,36 @@
 # brig completion for fish. Printed by `brig completion fish`.
 #
-# This script knows none of brig's vocabulary. It collects the words left of
-# the cursor, asks brig what may stand there, and renders the answer -- so the
-# verbs, the flags and the refs come from the binary that is installed rather
-# than from whenever this file was written.
+# This script holds no brig vocabulary. It collects the words left of the
+# cursor, asks brig what may stand there, and renders the reply, so verbs, refs
+# and flags come from the installed binary rather than from this file.
 #
-# The answer is a directive line and then the candidates, one per line.
+# The reply is a directive line followed by the candidates, one per line.
 
-# __brig_ask puts the line to brig and prints what it said.
+# __brig_ask sends the line to brig and prints the reply.
 #
-# Asked again for every completion rather than memoized. What brig answers
-# depends on state outside the command line -- the sessions that exist, the
-# profiles and policies on disk -- and a cache keyed on the line has no way to
-# learn that any of it changed, so a session started after the first TAB would
-# never be offered again for the life of the shell. bash and zsh re-ask on
-# every keystroke; the cost is one exec of a command that reads two files.
+# Not memoized. The reply also depends on state the command line does not
+# reflect -- the session index, the profile and policy directories -- and a
+# cache keyed on the line cannot detect a change in any of them, so a session
+# created after the first TAB would never appear again in that shell. bash and
+# zsh re-ask on every keystroke; the cost is one exec that reads two files.
 function __brig_ask
     set -l tokens (commandline -opc)
     set -l cur (commandline -ct)
-    # The command itself is dropped; the word under the cursor is passed
-    # explicitly, because an empty last argument is what tells brig it is being
-    # asked "what can come next" rather than "finish this token".
+    # Drop the command name. The current word is passed separately, because an
+    # empty final argument is what asks "what comes next".
     if set -q tokens[1]
         set -e tokens[1]
     end
-    # stderr is dropped rather than shown: brig writes none on this path, and a
-    # line from anywhere else would land in the middle of what is being typed.
+    # stderr is discarded: brig writes none here, and anything from elsewhere
+    # would print over the line being typed.
     brig __complete -- $tokens $cur 2>/dev/null
 end
 
-# __brig_says reports whether the answer carries one directive.
+# __brig_says reports whether the reply carries this directive.
 function __brig_says
     set -l out (__brig_ask)
-    # An answer with no first line means brig could not be reached at all.
-    # Reported as "not this directive" rather than left to `test`, which would
-    # otherwise print its own complaint across the prompt.
+    # No first line means brig could not be run. Return false rather than let
+    # `test` print its own error over the prompt.
     set -q out[1]; or return 1
     test "$out[1]" = "$argv[1]"
 end
@@ -46,9 +42,9 @@ function __brig_candidates
     end
 end
 
-# -f on the name and directory cases so fish offers nothing of its own: right
-# of the ref the words are the agent's, and filenames are a worse guess than
-# silence. -F on the path case hands the slot back to fish's own completion.
+# -f on the name and directory cases, so fish adds nothing of its own: inside
+# the agent's argv, filenames are worse than silence. -F on the path case hands
+# the slot to fish's file completion.
 complete -c brig -f
 complete -c brig -f -n '__brig_says :names' -a '(__brig_candidates)'
 complete -c brig -f -n '__brig_says :dirs' -a '(__fish_complete_directories (commandline -ct))'

--- a/cmd/brig/completions/brig.fish
+++ b/cmd/brig/completions/brig.fish
@@ -1,0 +1,52 @@
+# brig completion for fish. Printed by `brig completion fish`.
+#
+# This script knows none of brig's vocabulary. It collects the words left of
+# the cursor, asks brig what may stand there, and renders the answer -- so the
+# verbs, the refs and the flags come from the binary that is installed rather
+# than from whenever this file was written.
+#
+# The answer is a directive line and then the candidates, one per line.
+
+# __brig_ask runs the engine once per command line and caches what it said.
+#
+# fish evaluates each `complete` condition below in turn, so without the cache
+# one keystroke would run brig three times to learn the same answer.
+function __brig_ask
+	set -l line (commandline -cp)
+	if test "$__brig_line" != "$line"
+		set -l tokens (commandline -opc)
+		set -l cur (commandline -ct)
+		# The command itself is dropped; the word under the cursor is passed
+		# explicitly, because an empty last argument is what tells brig it is
+		# being asked "what can come next" rather than "finish this token".
+		if set -q tokens[1]
+			set -e tokens[1]
+		end
+		set -g __brig_line $line
+		# stderr is dropped rather than shown: brig writes none on this path,
+		# and a line from anywhere else would land in the middle of what is
+		# being typed.
+		set -g __brig_out (brig __complete -- $tokens $cur 2>/dev/null)
+	end
+end
+
+# __brig_says reports whether the engine answered with one directive.
+function __brig_says
+	__brig_ask
+	test "$__brig_out[1]" = "$argv[1]"
+end
+
+function __brig_candidates
+	__brig_ask
+	if set -q __brig_out[2]
+		printf '%s\n' $__brig_out[2..-1]
+	end
+end
+
+# -f on the name and directory cases so fish offers nothing of its own: right
+# of the ref the words are the agent's, and filenames are a worse guess than
+# silence. -F on the path case hands the slot back to fish's own completion.
+complete -c brig -f
+complete -c brig -f -n '__brig_says :names' -a '(__brig_candidates)'
+complete -c brig -f -n '__brig_says :dirs' -a '(__fish_complete_directories (commandline -ct))'
+complete -c brig -F -n '__brig_says :files'

--- a/cmd/brig/completions/brig.zsh
+++ b/cmd/brig/completions/brig.zsh
@@ -1,0 +1,51 @@
+#compdef brig
+# brig completion for zsh. Printed by `brig completion zsh`.
+#
+# This script knows none of brig's vocabulary. It collects the words left of
+# the cursor, asks brig what may stand there, and renders the answer -- so the
+# verbs, the refs and the flags come from the binary that is installed rather
+# than from whenever this file was written.
+#
+# The answer is a directive line and then the candidates, one per line.
+
+_brig_completion() {
+	local -a out reply
+	local directive cur
+
+	# words[1] is `brig` itself; CURRENT indexes the word under the cursor,
+	# which is empty when the cursor sits on fresh whitespace. It is passed
+	# explicitly, because an empty last argument is what tells brig it is being
+	# asked "what can come next" rather than "finish this token".
+	cur="${words[CURRENT]}"
+	# stderr is dropped rather than shown: brig writes none on this path, and a
+	# line from anywhere else would land in the middle of what is being typed.
+	out=("${(@f)$(${words[1]} __complete -- "${(@)words[2,CURRENT-1]}" "$cur" 2>/dev/null)}")
+	directive="${out[1]}"
+	shift out
+
+	case "$directive" in
+	:names)
+		# A ref that can continue past the agent -- `claude` and
+		# `claude@refactor` both -- comes back as two candidates, so zsh inserts
+		# the common prefix and appends nothing of its own. A unique candidate
+		# is a finished word and gets the usual space.
+		compadd -a out
+		;;
+	:dirs)
+		# Directories from zsh rather than from brig: the project slot is
+		# brig's, the filesystem is not.
+		_path_files -/
+		;;
+	:files)
+		_path_files -f
+		;;
+	*)
+		# :none, or an answer this script does not know. Offer nothing: right of
+		# the ref the words are the agent's, and filenames are a worse guess
+		# than silence.
+		return 1
+		;;
+	esac
+}
+
+_brig_completion "$@"

--- a/cmd/brig/completions/brig.zsh
+++ b/cmd/brig/completions/brig.zsh
@@ -1,48 +1,45 @@
 #compdef brig
 # brig completion for zsh. Printed by `brig completion zsh`.
 #
-# This script knows none of brig's vocabulary. It collects the words left of
-# the cursor, asks brig what may stand there, and renders the answer -- so the
-# verbs, the refs and the flags come from the binary that is installed rather
-# than from whenever this file was written.
+# This script holds no brig vocabulary. It collects the words left of the
+# cursor, asks brig what may stand there, and renders the reply, so verbs, refs
+# and flags come from the installed binary rather than from this file.
 #
-# The answer is a directive line and then the candidates, one per line.
+# The reply is a directive line followed by the candidates, one per line.
 
 _brig_completion() {
 	local -a out reply
 	local directive cur
 
-	# words[1] is `brig` itself; CURRENT indexes the word under the cursor,
-	# which is empty when the cursor sits on fresh whitespace. It is passed
-	# explicitly, because an empty last argument is what tells brig it is being
-	# asked "what can come next" rather than "finish this token".
+	# words[1] is `brig`; CURRENT indexes the current word, which is empty when
+	# the cursor is on fresh whitespace. Passed separately, because an empty
+	# final argument is what asks "what comes next".
 	cur="${words[CURRENT]}"
-	# stderr is dropped rather than shown: brig writes none on this path, and a
-	# line from anywhere else would land in the middle of what is being typed.
+	# stderr is discarded: brig writes none here, and anything from elsewhere
+	# would print over the line being typed.
 	out=("${(@f)$(${words[1]} __complete -- "${(@)words[2,CURRENT-1]}" "$cur" 2>/dev/null)}")
 	directive="${out[1]}"
 	shift out
 
 	case "$directive" in
 	:names)
-		# A ref that can continue past the agent -- `claude` and
-		# `claude@refactor` both -- comes back as two candidates, so zsh inserts
-		# the common prefix and appends nothing of its own. A unique candidate
-		# is a finished word and gets the usual space.
+		# No -S needed: a ref that can continue past the agent comes back as
+		# two candidates (`claude` and `claude@refactor`), so zsh inserts the
+		# common prefix and adds no space. A unique candidate is complete and
+		# gets the usual space.
 		compadd -a out
 		;;
 	:dirs)
-		# Directories from zsh rather than from brig: the project slot is
-		# brig's, the filesystem is not.
+		# Directories come from zsh. The project slot is brig's; the filesystem
+		# is not.
 		_path_files -/
 		;;
 	:files)
 		_path_files -f
 		;;
 	*)
-		# :none, or an answer this script does not know. Offer nothing: right of
-		# the ref the words are the agent's, and filenames are a worse guess
-		# than silence.
+		# :none, or a directive this script does not know. Offer nothing:
+		# inside the agent's argv, filenames are worse than silence.
 		return 1
 		;;
 	esac

--- a/cmd/brig/main.go
+++ b/cmd/brig/main.go
@@ -65,6 +65,7 @@ usage:
   brig telemetry status|on|off                   report what is counted, or
                                                  turn the counting on or off
   brig doctor [<agent>]                          check the host, runtime and, given an agent, its image
+  brig completion bash|zsh|fish                  a completion script for your shell
   brig version
 
 A <ref> is the session. claude is that agent's default session, and
@@ -184,6 +185,24 @@ func run(args []string) error {
 	}
 	verb, rest := verbLine[0], verbLine[1:]
 
+	// Completion is answered before the notices below, and that ordering is the
+	// whole of its output contract: a profile that would not parse, a legacy
+	// directory, a retiring key -- every one of them is a line on stderr, and a
+	// line printed on a keystroke lands in the middle of what is being typed.
+	// The engine loads the profiles it needs itself, silently.
+	if verb == completeVerb {
+		// The scripts pass `--` before the words they collected, so that a
+		// current word spelled like a flag reaches the engine as a word rather
+		// than being read as one of brig's own. It is a guard, not one of those
+		// words, so it is dropped here -- a `--` the reader actually typed
+		// stands further along the line and still ends brig's parsing.
+		if len(rest) > 0 && rest[0] == "--" {
+			rest = rest[1:]
+		}
+		completeCmd(os.Stdout, rest)
+		return nil
+	}
+
 	// Profiles are read before anything looks a name up, so a file can stand
 	// in for a built-in. A broken file is reported and skipped rather than
 	// taking down the profile you were actually asking for.
@@ -216,6 +235,8 @@ func run(args []string) error {
 		return telemetryCmd(os.Stdout, rest)
 	case "doctor":
 		return doctorCmd(os.Stdout, rest)
+	case "completion":
+		return completionCmd(os.Stdout, rest)
 	// Deprecated spellings, absent from the usage text.
 	//
 	// The three grammars this release settles are all here: a plural noun that
@@ -615,6 +636,12 @@ var brigFlags = []struct {
 	// The table already carries a position per flag, so this is a field on the
 	// row rather than a case in split.
 	retiredAs, retiredTo string
+	// undocumented marks a spelling the help text does not teach, so that
+	// completion does not offer it. It is not deprecated and not retiring:
+	// --memory is the older name of --mem and still writes the same value, and
+	// a line that has it keeps working. Offering it would put two spellings of
+	// one flag in front of a reader who has typed neither.
+	undocumented bool
 	// runOnly marks a run-line flag that only run acts on. sh, shell and exec
 	// continue a session rather than shape a fresh run, so they read such a
 	// flag in no position at all. On the row rather than in a list beside the
@@ -634,7 +661,7 @@ var brigFlags = []struct {
 	// answers, because a line that works today keeps working. Both write one
 	// value in parse, so the last one on the line wins.
 	{long: "mem", value: true, position: posRun},
-	{long: "memory", short: "m", value: true, position: posRun},
+	{long: "memory", short: "m", value: true, position: posRun, undocumented: true},
 	{long: "cpus", value: true, position: posRun},
 	// --no-project detaches the project a session is carrying. It takes no
 	// value: a directory is what the positional says, and this says the

--- a/docs/completions.md
+++ b/docs/completions.md
@@ -1,0 +1,72 @@
+# Shell completion
+
+`brig completion bash|zsh|fish` prints a completion script to stdout. Nothing
+is installed for you: where a script belongs differs per shell and per host,
+and brig does not write to your startup files.
+
+A Homebrew cask install already has completion -- the cask installs all three
+scripts where each shell reads them from. The lines below are for anyone who
+installed the binary another way.
+
+## Installing it
+
+```bash
+# bash
+brig completion bash > /usr/local/etc/bash_completion.d/brig
+# or, without a completion directory:
+echo 'eval "$(brig completion bash)"' >> ~/.bashrc
+```
+
+```zsh
+# zsh -- the file must be called _brig, and it must be on your fpath
+brig completion zsh > "${fpath[1]}/_brig"
+# then start a new shell, or:
+compinit
+```
+
+```fish
+brig completion fish > ~/.config/fish/completions/brig.fish
+```
+
+The script asks the `brig` on your `PATH` what to offer, so it does not go
+stale when brig gains a verb or a flag. Reinstalling the script is only
+necessary if the script itself changes.
+
+## What completes where
+
+A brig line has three positions, and completion follows them.
+
+| where the cursor is | what is offered |
+| --- | --- |
+| before the verb | the verbs, and the global flags (`--verbose`, `-q`) |
+| after the verb, before the ref | the flags that verb honours, and then the ref |
+| a ref | every agent, and every session under one: `claude`, `claude@refactor` |
+| `brig run <ref> …` | the project directory, for the first word only |
+| after that, on `run` and `sh` | nothing -- the arguments there are the agent's |
+
+`stop` and `rm` act on a sandbox that exists, so they offer the sessions there
+are rather than every agent there could be. `run`, `sh` and `info` take an
+agent that has never run, so they offer all of them.
+
+Under the noun commands -- `agent`, `policy`, `secret`, `telemetry` -- the
+subcommands complete, and so do the names they take: agents for `agent show`,
+policies for `policy attach`, the agents with a file of their own for `agent
+edit` and `agent rm`. `--network` completes its three postures. `--home`
+completes directories.
+
+Two things are deliberately not offered:
+
+- **Secret names.** Listing them opens your keyring -- on macOS that means
+  `security dump-keychain`, and a Linux secret-service backend can raise an
+  unlock prompt. A keystroke should do neither. `brig secret ls` lists them.
+- **The retired spellings.** `brig exec`, `brig env`, `brig create`,
+  `brig reset`, `--name`, `--workspace` and the rest still work and say what
+  replaced them. Completion teaches the spelling that stays.
+
+## Session names can be stale
+
+The labels come from brig's session index, which is a file rather than a
+question put to the runtime: completion has to answer in milliseconds, and on
+a host with no runtime installed it has to answer at all. A sandbox removed
+outside brig -- with `nerdctl rm`, say -- stays on offer until the next
+`brig ls` prunes it. The command that follows says it is gone.

--- a/docs/completions.md
+++ b/docs/completions.md
@@ -39,14 +39,23 @@ A brig line has three positions, and completion follows them.
 | where the cursor is | what is offered |
 | --- | --- |
 | before the verb | the verbs, and the global flags (`--verbose`, `-q`) |
-| after the verb, before the ref | the flags that verb honours, and then the ref |
+| a flag, either side of the ref | the flags that verb honours -- brig reads its own on both sides |
 | a ref | every agent, and every session under one: `claude`, `claude@refactor` |
 | `brig run <ref> …` | the project directory, for the first word only |
-| after that, on `run` and `sh` | nothing -- the arguments there are the agent's |
+| once the agent's arguments have begun | nothing |
+
+Completion stops exactly where brig's own parsing stops, and not a word before
+it. `brig run claude --mem 4096` is a line brig reads, so `--mem` is offered
+after the ref as readily as before it. The agent's arguments begin at the first
+word or flag brig does not own -- `--`, an unrecognised flag, or a bare word
+past the project -- and from there completion offers nothing, because the
+vocabulary is another program's and brig has no list of it.
 
 `stop` and `rm` act on a sandbox that exists, so they offer the sessions there
 are rather than every agent there could be. `run`, `sh` and `info` take an
-agent that has never run, so they offer all of them.
+agent that has never run, so they offer all of them. `brig rm --all` names no
+session and refuses every argument, so a line carrying it completes nothing
+further.
 
 Under the noun commands -- `agent`, `policy`, `secret`, `telemetry` -- the
 subcommands complete, and so do the names they take: agents for `agent show`,

--- a/internal/wrap/index.go
+++ b/internal/wrap/index.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 
 	"github.com/brig-sh/brig/internal/session"
 )
@@ -387,4 +388,24 @@ func (c *Config) rememberSession() {
 			"that names no workspace will fall back to the default one and restart "+
 			"the sandbox.", c.Workspace, c.VMName, err)
 	}
+}
+
+// SessionRefs returns the ref of every session the index holds, sorted.
+//
+// The index is keyed by ref, so this is a read of what is already there. It
+// exists for completion, which needs the labels an agent has without asking
+// the runtime: detecting a runtime and listing its sandboxes is hundreds of
+// milliseconds on a keystroke, and returns nothing at all on a host that has
+// no runtime installed. The cost of reading the index instead is bounded --
+// a sandbox removed outside brig stays listed until the next `brig ls` prunes
+// it -- and a stale candidate is a name that fails when run, not a wrong
+// action.
+func SessionRefs() []string {
+	index := readSessionIndex()
+	refs := make([]string, 0, len(index))
+	for ref := range index {
+		refs = append(refs, ref)
+	}
+	sort.Strings(refs)
+	return refs
 }

--- a/script/smoke.sh
+++ b/script/smoke.sh
@@ -1833,17 +1833,15 @@ grep -q '^  ok  runtime .*0.1.0-rc23' "$WORK/doctor.out" \
   || bad "doctor names the runtime version -- got: $(grep runtime "$WORK/doctor.out")"
 
 echo "== completion =="
-# The completion scripts are shell code, so the unit tests cannot run them: they
-# cover the engine's answers, and these cover the scripts that render them.
+# The completion scripts are shell code. The unit tests cover the engine's
+# replies; these cover the scripts that render them.
 #
-# Driven under `set -u`, which is where this went wrong once: an empty array
-# expanded under `set -u` is an unbound variable before bash 4.4, so the error
-# landed across the reader's prompt on the very first word. /bin/bash is
-# preferred over whatever `bash` resolves to for exactly that reason -- on macOS
-# it is 3.2, the version that reproduces it, while `bash` on PATH is often a
-# Homebrew 5.x that cannot. CI is Linux, where both are 5.x and this case checks
-# only that the script runs clean under `set -u`; the version that fails is on
-# the machines people develop on.
+# Driven under `set -u`, which is where this failed once: before bash 4.4 an
+# empty array expanded under `set -u` is an unbound variable, and the error
+# printed over the prompt on the first word. /bin/bash is preferred over
+# whatever `bash` resolves to because on macOS /bin/bash is 3.2, the version
+# that reproduces it, while `bash` on PATH is often a Homebrew 5.x that cannot.
+# On Linux CI both are 5.x, so there this only checks the script runs clean.
 BASH_OLDEST=bash
 [ -x /bin/bash ] && BASH_OLDEST=/bin/bash
 "$WORK/brig" completion bash > "$WORK/brig.bash" 2>/dev/null \
@@ -1858,7 +1856,7 @@ _brig_completion
 printf '%s\n' "${COMPREPLY[@]-}"
 DRIVE
 
-# The first word: the case where the array left of the cursor is empty.
+# The first word, where the array left of the cursor is empty.
 out="$("$BASH_OLDEST" "$WORK/bashdrive.sh" "$WORK/brig.bash" "$WORK/brig" "" 2>&1)"
 case "$out" in
   *"unbound variable"*) bad "the bash script survives set -u -- got: $out" ;;
@@ -1866,14 +1864,14 @@ case "$out" in
   *) bad "the bash script offers the verbs -- got: $out" ;;
 esac
 
-# And the boundary the engine and the parser have to agree on: brig's own flag
-# is offered right of the ref, where split still reads it.
+# The boundary the engine and split() must agree on: a brig flag right of the
+# ref, which split() still reads.
 out="$("$BASH_OLDEST" "$WORK/bashdrive.sh" "$WORK/brig.bash" "$WORK/brig" run claude --m 2>&1)"
 [ "$out" = "--mem" ] && ok "the bash script offers brig's flags right of the ref" \
   || bad "the bash script offers --mem right of the ref -- got: $out"
 
-# fish, when the host has it. The script is skipped rather than assumed: it is
-# the one shell that is not on a stock macOS or CI image.
+# fish, when installed. Skipped otherwise: it is not on a stock macOS or CI
+# image.
 if command -v fish >/dev/null 2>&1; then
   "$WORK/brig" completion fish > "$WORK/brig.fish" 2>/dev/null
   out="$(PATH="$WORK:$PATH" fish -c "source $WORK/brig.fish; complete -C 'brig run cl'" 2>&1)"

--- a/script/smoke.sh
+++ b/script/smoke.sh
@@ -1870,6 +1870,14 @@ out="$("$BASH_OLDEST" "$WORK/bashdrive.sh" "$WORK/brig.bash" "$WORK/brig" run cl
 [ "$out" = "--mem" ] && ok "the bash script offers brig's flags right of the ref" \
   || bad "the bash script offers --mem right of the ref -- got: $out"
 
+# The inline `--flag=value` shape, which only zsh and fish produce: bash has
+# "=" in COMP_WORDBREAKS and sends the halves separately. Checked through the
+# engine rather than a shell, since it is the argv shape that matters.
+out="$("$WORK/brig" __complete -- run "--network=is" 2>/dev/null | tr '\n' ' ')"
+[ "$out" = ":names --network=isolated " ] \
+  && ok "an inline flag value completes, qualified with its flag" \
+  || bad "inline --network=is completes -- got: $out"
+
 # fish, when installed. Skipped otherwise: it is not on a stock macOS or CI
 # image.
 if command -v fish >/dev/null 2>&1; then

--- a/script/smoke.sh
+++ b/script/smoke.sh
@@ -1832,5 +1832,58 @@ grep -q '^  ok  runtime .*0.1.0-rc23' "$WORK/doctor.out" \
   && ok "doctor names the runtime version" \
   || bad "doctor names the runtime version -- got: $(grep runtime "$WORK/doctor.out")"
 
+echo "== completion =="
+# The completion scripts are shell code, so the unit tests cannot run them: they
+# cover the engine's answers, and these cover the scripts that render them.
+#
+# Driven under `set -u`, which is where this went wrong once: an empty array
+# expanded under `set -u` is an unbound variable before bash 4.4, so the error
+# landed across the reader's prompt on the very first word. /bin/bash is
+# preferred over whatever `bash` resolves to for exactly that reason -- on macOS
+# it is 3.2, the version that reproduces it, while `bash` on PATH is often a
+# Homebrew 5.x that cannot. CI is Linux, where both are 5.x and this case checks
+# only that the script runs clean under `set -u`; the version that fails is on
+# the machines people develop on.
+BASH_OLDEST=bash
+[ -x /bin/bash ] && BASH_OLDEST=/bin/bash
+"$WORK/brig" completion bash > "$WORK/brig.bash" 2>/dev/null \
+  && ok "completion bash prints a script" || bad "completion bash prints a script"
+
+cat > "$WORK/bashdrive.sh" <<'DRIVE'
+set -u
+source "$1"
+shift
+COMP_WORDS=("$@"); COMP_CWORD=$(( ${#COMP_WORDS[@]} - 1 )); COMPREPLY=()
+_brig_completion
+printf '%s\n' "${COMPREPLY[@]-}"
+DRIVE
+
+# The first word: the case where the array left of the cursor is empty.
+out="$("$BASH_OLDEST" "$WORK/bashdrive.sh" "$WORK/brig.bash" "$WORK/brig" "" 2>&1)"
+case "$out" in
+  *"unbound variable"*) bad "the bash script survives set -u -- got: $out" ;;
+  *run*) ok "the bash script survives set -u and offers the verbs" ;;
+  *) bad "the bash script offers the verbs -- got: $out" ;;
+esac
+
+# And the boundary the engine and the parser have to agree on: brig's own flag
+# is offered right of the ref, where split still reads it.
+out="$("$BASH_OLDEST" "$WORK/bashdrive.sh" "$WORK/brig.bash" "$WORK/brig" run claude --m 2>&1)"
+[ "$out" = "--mem" ] && ok "the bash script offers brig's flags right of the ref" \
+  || bad "the bash script offers --mem right of the ref -- got: $out"
+
+# fish, when the host has it. The script is skipped rather than assumed: it is
+# the one shell that is not on a stock macOS or CI image.
+if command -v fish >/dev/null 2>&1; then
+  "$WORK/brig" completion fish > "$WORK/brig.fish" 2>/dev/null
+  out="$(PATH="$WORK:$PATH" fish -c "source $WORK/brig.fish; complete -C 'brig run cl'" 2>&1)"
+  case "$out" in
+    *claude*) ok "the fish script offers refs" ;;
+    *) bad "the fish script offers refs -- got: $out" ;;
+  esac
+else
+  echo "  --   fish not installed, skipping its script"
+fi
+
 [ "$fail" = 0 ] && echo PASS || echo FAILURES
 exit "$fail"


### PR DESCRIPTION
## Summary

Refs, agent names and flags are all typed by hand, and a name that is wrong is
only reported once brig has resolved it. That cost falls hardest on the closed
flag sets: three positions with two closed vocabularies only help a reader who
can discover them, and completion is how they discover them.

`brig completion bash|zsh|fish` prints a script to stdout and installs nothing --
where a script belongs differs per shell and per host, and a command that edits
a startup file has a blast radius no other verb here has. The docs carry the
line per shell, and the Homebrew cask now installs all three itself.

The scripts carry none of brig's vocabulary. Each one collects the words left of
the cursor, hands them to a hidden `brig __complete`, and renders what comes
back: a directive line, then the candidates. So the verbs, the refs and every
position rule are declared once, in Go, beside the table that already decides
them, and the three shells cannot come to disagree about what brig accepts
because none of them knows.

Completion stops exactly where brig's own parsing stops. Global flags left of
the verb; brig's own flags on **either** side of the ref, because `split` reads
them wherever they stand on the run line; and then nothing, from the first word
or flag brig does not own -- `--`, an unrecognised flag, or a bare word past
run's project slot, which is itself offered as directories. What brig does not
own it does not complete, and that boundary is walked once, in the order `split`
walks it, so the engine and the parser cannot disagree about where it is.

Refs complete as one grammar, `claude` and `claude@refactor` together: the agents
from the profile registry, the labels from the session index. The index is a file
read rather than a question put to the runtime, because detecting a runtime and
listing its sandboxes costs hundreds of milliseconds on a keystroke and answers
nothing at all on a host that has none. A sandbox removed outside brig therefore
lingers as a candidate until the next `brig ls` prunes it -- a stale candidate is
a name that fails when run, not a wrong action.

## Related issues

Closes #12
Refs #47 (the position table this reads is what makes "the flags legal at the
cursor" answerable)

## Changes

- `brig completion bash|zsh|fish` prints an embedded script; nothing is installed.
- `brig __complete` is the engine: candidates on stdout, nothing on stderr, exit
  0 always, and dispatched before the profile-load notices for that reason -- a
  warning printed on a TAB press lands in the middle of the line being typed.
- Four directives are the wire format. `:names` carries matched candidates;
  `:dirs` and `:files` hand the slot to the shell, which is the one thing a
  candidate list cannot say; `:none` means brig owns nothing here, and is
  distinct from a failure so a shell does not fall back to filenames where brig
  asked for silence.
- `walkRunLine` decides the boundary the way `split` does, including the `=` that
  bash breaks out of `--flag=value` (it is consumed with its value, so it is not
  read as the ref or shifted into an operand slot) and `rm --all`, which names no
  session and refuses every argument, so it completes nothing further.
- Run-line flags come from `brigFlags` directly, so a flag added there is
  completed with no further change. The noun groups build their arguments with a
  `flag.FlagSet` inside the function that runs them, so there is no table to read
  them off; `groups` is that table for completion only, and a subcommand missing
  from it completes nothing.
- Only what the help text teaches is offered. The retired spellings brig still
  answers to (`exec`, `shell`, `env`, `create`, `reset`, `profiles`, `policies`,
  `--name`, `--workspace`, `agent list`) are absent. `--memory` needed a new
  `undocumented` field on `brigFlags`: it is not retiring, but the table could
  not otherwise say "still works, do not teach it".
- `stop` and `rm` offer the sessions there are rather than every agent there
  could be. `run`, `sh` and `info` take an agent that has never run, so they
  offer all of them. `agent edit` and `agent rm` offer only agents with a file of
  their own, which is what both commands require.
- `wrap.SessionRefs` reads the session index's keys. The index was already keyed
  by ref, so nothing new is recorded.
- The archive carries the three scripts verbatim and `homebrew_casks.completions`
  installs them, so a cask install has completion without a second step.

## Checklist

- [x] `make all` passes (vet, test, build)
- [x] `script/smoke.sh` passes
- [x] I have added or updated tests covering the change
- [x] I have run `go test ./... -race`, if the change touches concurrency, subprocesses or the daemon
- [ ] ~~I have exercised the change against a real runtime (`brig run <agent>`), if it touches the run, exec or credential path~~
- [x] I have updated the affected docs (README, `docs/security.md`, `docs/profiles.md`, `docs/brigd.md`)

Testing beyond the suite: **all three scripts have now had their own shell run
over them.** bash through a real completion call on `/bin/bash` 3.2.57 (no
`compopt`, which is why every `compopt` call is guarded) under `set -u`; zsh
through real TAB presses in a `zpty` pseudo-terminal; fish through `complete -C`
on fish 4.9.2. All three answer as the table expects, `:dirs` and `:files`
included.

`script/smoke.sh` now carries a completion section for that, since these are
shell bugs the Go tests cannot reach. It prefers `/bin/bash` over whatever `bash`
resolves to, because on macOS that is 3.2 -- the version where the `set -u` bug
lives -- while `bash` on PATH is often a Homebrew 5.x that cannot reproduce it.
Both new bash cases were confirmed to fail against the previous scripts.

`cmd/brig/completion_test.go` is a 43-case position table plus tests for the wire
format, for the engine's silence when a profile will not parse, for the dispatch
path including the `--` guard, and `TestGroupsTableCoversEveryGroupFlag`, which
reads the noun groups' own flag registrations through `go/ast` and requires each
to appear in the completion table.

## Credentials and the sandbox boundary

Neither promise changes, and one of them shaped a decision worth flagging:
**secret names are deliberately not completed.** Listing them means opening the
store -- on macOS that is `security dump-keychain`, and a secret-service backend
can raise an unlock prompt -- and a keystroke must do neither. `brig secret <TAB>`
completes the subcommands; the operand stays empty. `TestCompletePositions`
asserts that (`secret names are not offered`), so a later change that reaches for
the store on a keystroke fails the test rather than surprising someone at a
prompt.

What the engine reads on a keystroke: the profile registry, the session index,
and the policy directory. What it does not: the runtime, the keyring, or any
credential. The one new export, `wrap.SessionRefs`, returns session names, which
`brig ls` already prints.

---
Written with AI assistance (Claude Code). I have reviewed every line and am
accountable for it.
