### PR TITLE
fix(cli): read the global flags in the completion test off the table

### DIFF
--- a/cmd/brig/completion_test.go
+++ b/cmd/brig/completion_test.go
@@ -8,6 +8,7 @@ import (
 	"go/token"
 	"os"
 	"path/filepath"
+	"sort"
 	"strconv"
 	"strings"
 	"testing"
@@ -92,7 +93,12 @@ func TestCompletePositions(t *testing.T) {
 		name:      "left of the verb the flags are the global ones",
 		words:     []string{"-"},
 		directive: dirNames,
-		exactly:   []string{"--quiet", "--verbose", "-q"},
+		// Read off brigFlags rather than written out. A hand-kept copy of this
+		// set is what broke: --json became global in #7 and this case still
+		// named the three flags that came before it, so two changes that were
+		// each correct left main red when they met. The table is the one place
+		// a flag declares its position, so the test asks it.
+		exactly: globalFlagSpellings(),
 	}, {
 		name:      "a global flag does not hide the verb after it",
 		words:     []string{"-q", "r"},
@@ -632,5 +638,22 @@ func groupFlagNames() map[string]bool {
 			}
 		}
 	}
+	return out
+}
+
+// globalFlagSpellings is every spelling completion offers left of the verb:
+// the long form of each global flag, and the short one where it has it.
+func globalFlagSpellings() []string {
+	var out []string
+	for _, f := range brigFlags {
+		if f.position != posGlobal {
+			continue
+		}
+		out = append(out, "--"+f.long)
+		if f.short != "" {
+			out = append(out, "-"+f.short)
+		}
+	}
+	sort.Strings(out)
 	return out
 }


### PR DESCRIPTION
**`main` is red** and has been since 15:59 UTC. `go test ./cmd/brig/` fails:

```
brig -: candidates [--json --quiet --verbose -q], want exactly [--quiet --verbose -q]
```

Nobody made a mistake. #158 added completions with a test naming the three global flags that existed when it was written. #141 made `--json` global. Each was reviewed against a `main` without the other, and they merged four minutes apart.

The fix is not to add `--json` to the list. It is to stop keeping a second copy of the list: the expected set is now derived from `brigFlags`, where a flag declares its position, so a new global flag moves the test with it. That is the same shape the agent flag-overlap test already uses, and one fewer hand-kept list of the kind #145 is about.

Verified: `go vet ./...`, `go test -p 2 ./...` and `./script/smoke.sh` all pass on this branch, against a `main` where the suite currently fails.

This blocks everything else, so it is worth taking first.