### PR TITLE
docs: Match the docs and two messages to the brig we ship

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -7,7 +7,7 @@ assignees: ''
 ---
 
 <!--
-Write a specific, imperative title, e.g. "brig env omits a forwarded variable
+Write a specific, imperative title, e.g. "brig info omits a forwarded variable
 when the profile is file-backed". Search open and closed issues first to avoid
 duplicates.
 -->

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,8 +32,8 @@ jobs:
         with:
           go-version: stable
           check-latest: true
-          # sigs.k8s.io/yaml is the only dependency, but there is a go.sum
-          # to key the cache on now.
+          # Three direct dependencies (godbus/dbus, x/sys, sigs.k8s.io/yaml),
+          # and a go.sum to key the cache on.
           cache: true
 
       - name: gofmt
@@ -113,8 +113,8 @@ jobs:
         with:
           go-version: stable
           check-latest: true
-          # sigs.k8s.io/yaml is the only dependency, but there is a go.sum
-          # to key the cache on now.
+          # Three direct dependencies (godbus/dbus, x/sys, sigs.k8s.io/yaml),
+          # and a go.sum to key the cache on.
           cache: true
 
       # A release config that only runs on a tag is a config nobody has run.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,9 +7,13 @@ notes come first.
 ## Repo specifics
 
 - Build: `make build` produces `./brig` and `./brigd`. `make all` is
-  `vet test build`, which is what CI gates on.
-- Dependencies: brig has **one** direct dependency (`sigs.k8s.io/yaml`), and
-  that is deliberate. It shells out to `cosign`, `oras` and `security` rather
+  `vet test build`. CI runs that plus `gofmt -l`, `script/smoke.sh`, a
+  cross-compile for darwin/arm64 and linux/amd64, and a check that no test
+  disappeared.
+- Dependencies: brig has **three** direct dependencies -- `sigs.k8s.io/yaml`
+  for profiles, `golang.org/x/sys` for terminal and process calls, and
+  `github.com/godbus/dbus/v5` for the Linux secret store -- and that list is
+  deliberately short. It shells out to `cosign`, `oras` and `security` rather
   than linking them, which keeps the attack surface of a tool that handles
   credentials small. Please do not add a dependency without saying in the PR
   why shelling out or using the standard library will not do.
@@ -276,8 +280,7 @@ A few norms that make reviews pleasant on both sides:
 
 A PR is mergeable when:
 
-- CI is green: linting (including commit-message linting), builds, unit tests
-  and end-to-end tests pass.
+- CI is green: linting, builds, unit tests and end-to-end tests pass.
 - The required approvals are in place.
 - The branch is up to date with `main` (rebased, with a clean, logical commit
   series).

--- a/README.md
+++ b/README.md
@@ -43,9 +43,24 @@ git clone https://github.com/brig-sh/brig && cd brig
 make build                    # produces ./brig and ./brigd
 ```
 
-macOS needs `hull` on PATH (see [macOS](#macos) above); Linux needs
+macOS needs `hull` on PATH (see [macOS](#macos) below); Linux needs
 `nerdctl`. brig finds either. `cosign` is optional but recommended -- without
 it, guest images cannot be verified and brig says so on every boot.
+
+Without Homebrew, `install.sh` fetches the newest release for your platform,
+checks the archive against the published `checksums.txt` with sha256, and
+installs `brig` and `brigd` into `/usr/local/bin` (`BRIG_INSTALL_DIR` and
+`BRIG_VERSION` override the destination and the version):
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/brig-sh/brig/main/install.sh | sh
+```
+
+It does not check the cosign signature on `checksums.txt`, because that needs
+cosign installed; [Verifying a brig download](#verifying-a-brig-download) is
+that step, and the archive also carries the three completion scripts under
+`completions/`, which the script leaves for you to install
+([docs/completions.md](docs/completions.md)).
 
 Two tools are needed only by a profile marked `genericBoot`, which boots an
 image that was never built to be a guest and therefore needs a kernel and an
@@ -129,12 +144,13 @@ separate Linux re-implementation of it.
 | `brig rm <ref>` | stop and remove the sandbox. The workspace is untouched |
 | `brig rm --all` | stop and remove every brig sandbox. Workspaces are untouched |
 | `brig ls [-q]` | every brig sandbox, running or merely holding its name, with its ref and workspace. `-q` prints the refs alone, for a script |
-| `brig logs <ref>` | stream the sandbox's log; `--gateway` reads the gateway's |
+| `brig logs <ref> [--follow] [--tail N] [--raw]` | stream the sandbox's log: `--follow` keeps reading, `--tail N` starts N lines from the end (default: all), `--raw` leaves terminal escape sequences in, which are filtered out otherwise. `--gateway [<ref>]` reads the gateway's log instead: the shared one, or with a ref the gateway serving that sandbox alone |
 | `brig info <ref>` | the boundary a run would trust -- sandbox, workspace, image, credentials **by name only** -- and whether the guest will be authenticated |
+| `brig doctor [<agent>]` | check the host, the hypervisor, the runtime, the boot assets, cosign, the profiles, the secret store and brigd, one line each; given an agent, its image too |
 | `brig agent ls` | the agents, their images, and what each one refuses to forward |
 | `brig agent show <agent>` | print one agent's spec. `--json` for JSON instead of YAML |
-| `brig agent new <name> --from <agent>` | copy an agent under a new name, ready to edit |
-| `brig agent edit\|rm\|import\|export` | manage agents |
+| `brig agent new <name> --from <agent>` | copy an agent under a new name, ready to edit. `--json` writes JSON; `-f` replaces a file already there |
+| `brig agent edit\|rm\|import\|export` | manage agents. `rm -y` answers the question in advance; `export <agent> [name]` prints one or saves it under a name |
 | `brig policy ls\|create\|edit\|show\|rm` | manage policies. `show --json` for JSON instead of YAML |
 | `brig policy attach\|detach <policy> <profile> [-n NAME]` | bind or unbind a policy to every run of a profile, or `-n` for one session |
 | `brig policy check <profile> [-n NAME]` | what is bound to a run of a profile (or `-n` session), and whether brig can enforce anything against it |
@@ -196,6 +212,7 @@ so, without taking the token, so a line that works today keeps working.
 | --- | --- |
 | `--verbose` | the execution envelope, brig's own progress and the runtime's own output. No short form: `-v` is Claude Code's version flag, codex's verbose flag and Docker's volume flag, so brig does not claim the letter |
 | `-q, --quiet` | identifiers and errors only, for a script. It drops brig's warnings; on `ls` it prints the refs alone. A verification that did not hold is printed even here. Still read after the verb for this release, with a note |
+| `--json` | machine-readable output, for the read verbs: `ls`, `info`, `agent ls`, `secret ls` and `doctor`. Also accepted after the verb (`brig ls --json`); every other verb refuses it. With `run`, brig runs the agent as a child and, after it exits, prints one JSON line with its exit status, so a script can tell "brig refused" from "the agent failed". Within one `apiVersion` the JSON only gains fields, never renames or drops one, and no field carries a credential value |
 
 By default a run prints what you have to act on, then the agent: warnings,
 errors, and one line saying verification held. The execution envelope, brig's
@@ -394,7 +411,8 @@ The verbs line up deliberately, so muscle memory carries over:
 | `sbx -t/--template` | `brig -t/--image` | |
 | `sbx -m/--memory`, `--cpus`, `-d` | same | |
 | `sbx --name <name>` | `brig <agent>@<name>` | brig's `--name` still works and says what replaces it |
-| `sbx --publish`, `--deny-network` | n/a | not yet; brig does not manage guest networking, and sandboxes share one network -- see [docs/security.md](docs/security.md#things-brig-does-not-claim) |
+| `sbx --publish` | n/a | not yet; brig does not forward a guest port |
+| `sbx --deny-network` | `brig --network offline` | no route out at all. `--network isolated` is a network of the sandbox's own, and an egress policy (`brig policy`) filters what leaves it -- see [docs/security.md](docs/security.md#things-brig-does-not-claim) |
 | `sbx --clone` | n/a | not yet; the workspace is mounted directly |
 | `sbx login` | n/a | nothing to sign in to |
 
@@ -474,8 +492,9 @@ sandbox cannot use a credential it cannot see. Prefer a fine-grained
 `brig secret` is a store of brig's own, and it is the only store a run reads.
 `brig secret import` fills it from your host; these verbs are how you fill it
 by hand, from any backend you like. On macOS it keeps each secret in your login
-keychain; there is no Linux backend yet, and brig says so rather than falling
-back to a file.
+keychain; on Linux in a Secret Service keyring on your session bus
+(gnome-keyring or KWallet). With no keyring to reach, brig says which half is
+missing rather than falling back to a file ([docs/secrets.md](docs/secrets.md#linux)).
 
 ```bash
 printf %s "$TOKEN" | brig secret create gh-token   # the value comes from stdin
@@ -510,19 +529,24 @@ your own.
 $ brig info claude
 PROFILE      claude-code
 SANDBOX      brig-claude-code (hull)
-ISOLATION    microVM (hull, vz backend)
+ISOLATION    microVM (hull, hvi backend)
 WORKSPACE    /Users/you/brig/claude-code (read-write)
 IMAGE        ghcr.io/brig-sh/claude-code-stock:latest (pull missing)
 VERIFY       warn, against brig's own trust policy
-CREDENTIALS  GH_TOKEN
-brig: forwarding to guest:
-brig:   GH_TOKEN(secret)
+CREDENTIALS  claude-credentials
+NETWORK      shared (one network for every sandbox on this host)
+brig: workspace /Users/you/brig/claude-code (sandbox brig-claude-code)
+brig: runtime hull (/opt/homebrew/bin/hull)
+...
 ```
 
 The block at the top is the execution envelope: the boundary the run would
-trust, printed before the sandbox boots. `brig run` prints the same block before
-it starts one, so what you preview is what you get. Names only, never values.
-`brig -q` drops it.
+trust, printed before the sandbox boots. `brig --verbose run` prints the same
+block before it starts one, so what you preview is what you get. Names only,
+never values. A run with a project adds a `PROJECT` row, and one with a policy
+attached a `POLICY` row. The `brig:` lines after it are the full report, which
+`brig info` goes on to print: what is forwarded and from where, what is never
+forwarded, and the guest git settings.
 
 A secret a profile declares but the store does not have fails the run before
 any sandbox is created, naming every one that is missing and the command that
@@ -795,7 +819,7 @@ worth knowing:
 
 ## Environment variables
 
-Every setting is read in this order, first hit wins:
+A setting that belongs to a run is read in this order, first hit wins:
 
 ```
 BRIG_<AGENT>_<KEY>   →   BRIG_<KEY>
@@ -803,9 +827,25 @@ BRIG_<AGENT>_<KEY>   →   BRIG_<KEY>
 
 `<AGENT>` is the profile name uppercased with dashes as underscores
 (`BRIG_CLAUDE_CODE_WORKSPACE`), so one shell can carry different settings for
-two agents.
+two agents. That prefix is honoured by the per-run settings: `WORKSPACE`,
+`NAME`, `IMAGE`, `PULL`, `MEM`, `CPUS`, `READY_TIMEOUT`, `TITLE`, `NETWORK`,
+`SKILLS`, `FORWARD_ENV`, `ALLOW_REFS`, `ALLOW_DENIED`, `ALLOW_EXPIRED`, the
+`GIT_*` group, `TRUST_WORKSPACE`, `VERIFY`, `VERIFY_REGISTRY`,
+`VERIFY_IDENTITY`, `VERIFY_ISSUER`, `COSIGN_BIN`, `HYPERVISOR` and
+`ROOTFS_TYPE`. The settings that describe the host rather than a run are read
+under `BRIG_<KEY>` only: `PROFILE_DIR`, `POLICY_DIR`, `STATE_DIR`, `RUNTIME`,
+`RUNTIME_BIN`, `CONTAINERD_RUNTIME`, `GATEWAY_SOCK`, `GATEWAY_DIR`,
+`BOOT_ASSETS`, `BOOT_ASSETS_REF` and `ENV_ARGV`.
 
-Booleans are shell-style: anything except `0` is on.
+Booleans come in two kinds. A switch whose safe position is off --
+`BRIG_GIT_CONFIG`, `BRIG_SKILLS`, `BRIG_TRUST_WORKSPACE`, `BRIG_ALLOW_REFS`,
+`BRIG_ALLOW_DENIED`, `BRIG_ALLOW_EXPIRED` -- takes `1`, `true`, `yes` or `on`
+to turn on and `0`, `false`, `no` or `off` to turn off, case-insensitively,
+and refuses the run on any other value rather than guessing: under the
+shell-style rule `BRIG_ALLOW_DENIED=false` would have turned the guard off by
+turning it on. Absent or empty keeps the default. `BRIG_GIT_IDENTITY` is a
+tuning knob and keeps the shell rule, anything but `0` is on. `BRIG_ENV_ARGV`
+is on only when it is exactly `1`.
 
 ### Where things live
 
@@ -814,6 +854,7 @@ Booleans are shell-style: anything except `0` is on.
 | `BRIG_WORKSPACE` | `~/brig/<agent>` | Host directory mounted as the guest home. A named session appends `-<slug>` |
 | `BRIG_NAME` | `brig-<agent>` | Sandbox (VM or container) name; must begin with `brig-`. A named session appends `-<slug>` |
 | `BRIG_PROFILE_DIR` | `~/.config/brig` | Where custom profiles are read from and written to (`BRIG_TEMPLATE_DIR` still works) |
+| `BRIG_POLICY_DIR` | `~/.config/brig/policies` | Where egress policies are read from and written to (`$XDG_CONFIG_HOME/brig/policies`). See [docs/policies.md](docs/policies.md) |
 | `BRIG_STATE_DIR` | `~/.brig` | Where brig keeps what has to outlive one command, including the workspace each sandbox was started with. Bookkeeping only: an unusable file there costs a restart, never a failed command |
 
 ### Image and guest
@@ -856,7 +897,7 @@ Removed: `BRIG_CREDENTIALS_CMD` ran a command of yours on every boot to read the
 | variable | default | what it does |
 | --- | --- | --- |
 | `BRIG_TRUST_WORKSPACE` | `1` | Pre-answer the agent's "do you trust the files in this folder?" for the directory each run starts in. The guest sees only the workspace, so mounting it already answered that question |
-| `BRIG_VERIFY` | `warn` | `warn`, `require` or `off` -- see the table above |
+| `BRIG_VERIFY` | `warn` | `warn`, `require` or `off` -- see the table above. `strict` is `require`; `none` and `0` are `off`. Any other value refuses the run |
 | `BRIG_VERIFY_REGISTRY` | `ghcr.io/brig-sh/` | Image prefix treated as "ours", so a check is expected |
 | `BRIG_VERIFY_IDENTITY` | community-images workflow | Certificate identity regexp cosign must match |
 | `BRIG_VERIFY_ISSUER` | GitHub Actions OIDC | Certificate OIDC issuer |
@@ -868,13 +909,13 @@ Removed: `BRIG_CREDENTIALS_CMD` ran a command of yours on every boot to read the
 | --- | --- | --- |
 | `BRIG_RUNTIME` | `hull` on macOS, `nerdctl` elsewhere | Which backend to drive |
 | `BRIG_RUNTIME_BIN` | first of `hull` / `nerdctl`, `docker` on PATH | Path to that binary |
-| `BRIG_HYPERVISOR` | `vz` | Hypervisor backend, macOS only: `vz`, `hvi` or `qemu`. Only `vz` has a graphical console, so a GUI profile is refused on the others |
+| `BRIG_HYPERVISOR` | the profile's `hypervisor`, else `vz` | Hypervisor backend, macOS only: `vz`, `hvi` or `qemu`. Set, it wins over the profile; the `vz` default applies only when the profile is silent, and six of the eight shipped profiles say `hvi`. Only `vz` has a graphical console, so a GUI profile is refused on the others. `hvi` needs macOS 15 or newer, and brig refuses the run on an older one rather than letting the VMM crash |
 | `BRIG_GATEWAY_SOCK` | `~/.brig/gateway-<subnet>.sock` | Control socket of the user-mode network gateway. `hvi` has no egress without one, so brig starts a shared gateway there and joins every sandbox on the shared network to it. The default name carries the network it serves, so a gateway left from a different subnet is never reused for guests that are not on it |
 | `BRIG_GATEWAY_DIR` | the directory of `BRIG_GATEWAY_SOCK`, else `~/.brig` | Where the gateway sockets live. A sandbox on `--network isolated`, or one carrying a policy, gets a gateway of its own here (`sandbox-<name>.sock`) on a `/30` of its own, rather than joining the shared one |
 | `BRIG_BOOT_ASSETS` | whatever `hull assets dir` reports on macOS, `$XDG_DATA_HOME/brig/assets` (default `~/.local/share/brig/assets`) on Linux | Directory holding the host kernel and `container-initrd` used to boot a profile marked `genericBoot`. The kernel is named `Image` on arm64 and `bzImage` on x86_64. Set it and brig uses what is there, unchanged; leave it unset and brig downloads the pair on first use (hull on macOS, `oras` on Linux) |
 | `BRIG_BOOT_ASSETS_REF` | `ghcr.io/nofireai/hull-assets:<os>-<arch>` | The bundle brig fetches when the boot assets are missing. Override to pin a version or use a mirror |
 | `BRIG_ROOTFS_TYPE` | profile's `rootfsType` | How the guest root reaches the VM: `block`, `virtiofs` or `9pfs` |
-| `BRIG_ENV_ARGV` | `0` | Put forwarded values back on the runtime's command line, where `ps` can read them. For a runtime build that does not accept a bare `--env KEY`. Opt-in, and it costs you the `ps` guarantee. Inert for a value brig resolved on your behalf -- a secret from its store, or the host credential -- which stays off the command line regardless |
+| `BRIG_ENV_ARGV` | `0` | Put forwarded values back on the runtime's command line, where `ps` can read them. For a runtime build that does not accept a bare `--env KEY`. Opt-in -- on only when set to exactly `1` -- and it costs you the `ps` guarantee. Inert for a value brig resolved on your behalf -- a secret from its store, or the host credential -- which stays off the command line regardless |
 | `DO_NOT_TRACK`, `HULL_TELEMETRY_DISABLED` | | Passed through to the runtime untouched, and always win |
 
 
@@ -891,7 +932,7 @@ CLI uses. Line-delimited JSON on a unix socket:
 ```
 
 It does not proxy exec. Handing your terminal to a process inside the guest
-means passing file descriptors, and `brig exec` already does that correctly by
+means passing file descriptors, and `brig sh` already does that correctly by
 replacing itself with the runtime. The daemon owns lifecycle, the CLI owns the
 terminal. See [docs/brigd.md](docs/brigd.md).
 
@@ -905,8 +946,9 @@ binary, so brig works with no setup at all. Guest images live in
 [brig-sh/community-images](https://github.com/brig-sh/community-images) with
 open Dockerfiles, and a profile name is the same string as its image name.
 
-Claude Code and Codex are the proven core. Gemini, Grok and opencode are
-example profiles. `claude-desktop` is the GUI app in a windowed VM, and
+Claude Code and Codex are the proven core. Gemini, Grok, opencode and cursor
+are example profiles, and cursor ships without an image (see
+[Image tags](#image-tags)). `claude-desktop` is the GUI app in a windowed VM, and
 `ubuntu` is a plain root shell for when you need to inspect guest networking
 or raise a raw socket.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -65,8 +65,10 @@ written down.
 Out of scope are the limitations brig already declares. `docs/security.md` lists
 them under
 [Things brig does not claim](docs/security.md#things-brig-does-not-claim): brig
-does not sandbox the agent from the network, does not isolate one sandbox from
-another, does not filter terminal escape sequences the agent writes, and does
+does not sandbox the agent from the network by default, does not isolate one
+sandbox from another under the default shared network (`--network isolated`
+and `--network offline` are the postures that do), does not filter terminal
+escape sequences the agent writes, and does
 not stop an agent misusing a credential it was deliberately handed. A report
 that brig does one of those is describing a known limitation, not a
 vulnerability. That page is the authority on the boundary, so we point at it

--- a/assets/README.md
+++ b/assets/README.md
@@ -25,14 +25,16 @@ outlines, so the files carry no font dependency.
 
 | File | Use |
 | --- | --- |
-| `svg/brig-avatar.svg`, `png/brig-avatar-*.png` | Org and repo avatar. Full-bleed navy square, no baked corner radius -- GitHub rounds it. |
-| `svg/brig-mark-on-{dark,light}.svg` | The mark alone, transparent background. |
-| `svg/brig-lockup-on-{dark,light}.svg` | Horizontal lockup, transparent, for README headers via `<picture>`. |
-| `svg/brig-lockup-badge.svg` | Lockup on its own navy field, for slides and anywhere the background is uncontrolled. |
-| `svg/hull-*.svg` | The same set for `hull`. |
+| `brig-avatar.svg`, `brig-avatar-512.png` | Org and repo avatar. Full-bleed navy square, no baked corner radius -- GitHub rounds it. The 512 PNG is the one GitHub takes for the org picture. |
+| `brig-mark-on-{dark,light}.svg` | The mark alone, transparent background. |
+| `brig-lockup-on-{dark,light}.svg` | Horizontal lockup, transparent, for README headers via `<picture>`. |
+| `brig-lockup-badge.svg` | Lockup on its own navy field, for slides and anywhere the background is uncontrolled. |
+| `nofire-logo.svg`, `nofire-logo-on-dark.svg` | The NOFire AI logo, for the README footer. |
+| `architecture.svg` | The diagram in the README's "What brig is". |
 
-PNG exports live in `png/`. The 1024 and 512 avatars are what GitHub wants for
-the org picture; everything else is convenience.
+The directory is flat. hull's own set of marks lives in
+[brig-sh/brig-artwork](https://github.com/brig-sh/brig-artwork) with the
+sources for these.
 
 ## Rules
 
@@ -44,4 +46,4 @@ the org picture; everything else is convenience.
 - Do not re-colour the bars. Brass on navy is the only pairing that survives
   both GitHub themes.
 
-Generated from `svg/`; regenerate PNGs with `rsvg-convert`.
+Regenerate the PNG from the SVG with `rsvg-convert`.

--- a/cmd/brig/main.go
+++ b/cmd/brig/main.go
@@ -107,8 +107,9 @@ flags (before the agent's own arguments; -- ends brig's parsing):
       --mem MB           guest memory
       --cpus N           guest vCPUs
   -d, --detach           with run: start the sandbox and exit
-      --skills           project your own ~/.claude skills and plugins into
-                         the guest, read-only (or BRIG_SKILLS=1)
+      --skills           copy your own ~/.claude skills and plugins into the
+                         guest home; the host copy is never written
+                         (or BRIG_SKILLS=1)
       --network MODE     shared, isolated or offline (or BRIG_NETWORK)
       --offline          shorthand for --network offline: the agent runs, the
                          workspace is there, nothing leaves
@@ -136,7 +137,7 @@ settings (BRIG_<AGENT>_<KEY> wins over BRIG_<KEY>; see the README for all):
   BRIG_WORKSPACE       host directory mounted as the guest home
   BRIG_IMAGE           guest image
   BRIG_PULL            missing (default) | always | never
-  BRIG_SKILLS          1 to project your ~/.claude skills and plugins read-only
+  BRIG_SKILLS          1 to copy your ~/.claude skills and plugins into the guest
   BRIG_FORWARD_ENV     replaces the env-sourced bindings, space-separated
   BRIG_GIT_CONFIG      1 to write the guest git-over-HTTPS files
   BRIG_VERIFY          warn (default) | require | off -- guest image signature

--- a/cmd/brig/policy.go
+++ b/cmd/brig/policy.go
@@ -711,7 +711,7 @@ func attachPolicy(args []string) error {
 	}
 	p, ok := profile.Lookup(profileName)
 	if !ok {
-		return notFoundf("unknown profile %q. `brig profiles` lists them", profileName)
+		return notFoundf("unknown profile %q. `brig agent ls` lists them", profileName)
 	}
 	if err := policy.CheckCoverage(p); err != nil {
 		return fmt.Errorf("cannot attach %s to %s: %w. Nothing was written", policyName, p.Name, err)
@@ -854,7 +854,7 @@ func checkPolicy(args []string) error {
 	}
 	p, ok := profile.Lookup(profileName)
 	if !ok {
-		return notFoundf("unknown profile %q. `brig profiles` lists them", profileName)
+		return notFoundf("unknown profile %q. `brig agent ls` lists them", profileName)
 	}
 	names, err := policy.EffectivePolicies(p, session, policy.Dir())
 	if err != nil {

--- a/cmd/brig/policy_test.go
+++ b/cmd/brig/policy_test.go
@@ -1389,6 +1389,11 @@ func TestAttachUnknownProfile(t *testing.T) {
 	if err == nil || !strings.Contains(err.Error(), "unknown profile") {
 		t.Errorf("wrong error for an unknown profile: %v", err)
 	}
+	// The listing it points at is the one the help teaches, not the retired
+	// `brig profiles`.
+	if err != nil && !strings.Contains(err.Error(), "`brig agent ls` lists them") {
+		t.Errorf("the unknown-profile message does not point at `brig agent ls`: %v", err)
+	}
 	// The same "unknown profile" message every other command in this
 	// codebase reports via notFoundf, which exitCode reads for exit 3 --
 	// a plain fmt.Errorf here would look identical on stderr but exit 1.
@@ -1850,6 +1855,9 @@ func TestCheckUnknownProfile(t *testing.T) {
 	err := checkPolicy([]string{"ghost"})
 	if err == nil || !strings.Contains(err.Error(), "unknown profile") {
 		t.Errorf("wrong error for an unknown profile: %v", err)
+	}
+	if err != nil && !strings.Contains(err.Error(), "`brig agent ls` lists them") {
+		t.Errorf("the unknown-profile message does not point at `brig agent ls`: %v", err)
 	}
 	if got := exitCode(err); got != exitNotFound {
 		t.Errorf("exitCode = %d, want %d (exitNotFound)", got, exitNotFound)

--- a/docs/brigd.md
+++ b/docs/brigd.md
@@ -10,7 +10,7 @@ never run it.
 ## What it does not do
 
 It does not proxy exec. Handing your terminal to a process inside the guest
-means passing file descriptors, and `brig exec` already does that correctly by
+means passing file descriptors, and `brig sh` already does that correctly by
 replacing itself with the runtime. The daemon owns lifecycle, the CLI owns the
 terminal.
 

--- a/docs/completions.md
+++ b/docs/completions.md
@@ -38,7 +38,7 @@ A brig line has three positions, and completion follows them.
 
 | where the cursor is | what is offered |
 | --- | --- |
-| before the verb | the verbs, and the global flags (`--verbose`, `-q`) |
+| before the verb | the verbs, and the global flags (`--verbose`, `-q`, `--json`) |
 | a flag, either side of the ref | the flags that verb honours -- brig reads its own on both sides |
 | a ref | every agent, and every session under one: `claude`, `claude@refactor` |
 | `brig run <ref> …` | the project directory, for the first word only |

--- a/docs/guest-image.md
+++ b/docs/guest-image.md
@@ -31,7 +31,7 @@ Resolved through the guest's `PATH` unless the table says otherwise.
 | `chmod` | sets the mode a `files:` binding declares, inside the create script | `internal/wrap/secretfiles.go`, `writeSecretFile` |
 | `rm` | `rm -f --` at the credential path before creating it, so a planted symlink is removed rather than followed | `internal/wrap/secretfiles.go`, `writeSecretFile` |
 | `sleep` | **Linux only.** nerdctl runs the container as `sleep infinity`, because a container exits when its command does and the sandbox has to outlive the exec that uses it | `internal/runtime/nerdctl.go`, `runArgs` |
-| `bash` | `brig shell` runs `bash -l`, and `brig shell <agent> '<command>'` runs `bash -lc`. It is also the `binary:` of the `ubuntu` profile | `internal/wrap/run.go`, `Shell` |
+| `bash` | `brig sh` runs `bash -l`, and `brig sh <agent> '<command>'` runs `bash -lc`. It is also the `binary:` of the `ubuntu` profile | `internal/wrap/run.go`, `Shell` |
 | the profile's `binary:` | `brig run` execs it. `claude` for claude-code, `codex` for codex, and so on | `cmd/brig/main.go`, `runAgent` |
 
 Two of these are conditional, and it is worth knowing which.
@@ -41,7 +41,7 @@ image and lets its own entrypoint run, so a macOS-only image can get away
 without it and then fail on Linux. Since `:latest` on the published profiles
 is a multi-arch index meant to work on both, treat `sleep` as required.
 
-`bash` is only reached by `brig shell`. That is also the verb people reach for
+`bash` is only reached by `brig sh`. That is also the verb people reach for
 when a sandbox is misbehaving, so an image without it works right up to the
 moment somebody needs to look inside it.
 
@@ -124,7 +124,7 @@ the image comes up as a microVM whose root holds everything,
 `CapEff: 000001ffffffffff` (`runArgs` in `internal/runtime/hull.go`, and the
 nerdctl equivalent in `internal/runtime/nerdctl.go`). Checking an image under
 the bare boot therefore reports failures against a boundary brig never gives
-it, which is why `script/check-guest-image.sh` boots through `brig create`
+it, which is why `script/check-guest-image.sh` boots through `brig run -d`
 rather than through the runtime.
 
 ## What `genericBoot` changes
@@ -273,7 +273,7 @@ Then check it rather than trusting this file, naming the profile it will run
 under. That profile has to be one brig knows, so import it first:
 
 ```bash
-brig profile import mine.yaml
+brig agent import mine.yaml
 script/check-guest-image.sh docker.io/me/mine:latest mine
 ```
 
@@ -301,7 +301,7 @@ failure order is the unhelpful part. In rough order of what you would hit:
   credential file happens.
 - **`chown` has no name to resolve.** No `/etc/passwd`, so the guest user does
   not exist even if the binaries did.
-- **`brig shell` cannot get you in to look.** No `bash`.
+- **`brig sh` cannot get you in to look.** No `bash`.
 
 Distroless is the same story with a tidier base. The `static` and `base`
 variants carry no shell and no coreutils, so every point above applies except
@@ -322,7 +322,7 @@ script/check-guest-image.sh <image> [profile]
 
 The profile defaults to `claude-code`, and naming one is how the check gets
 the boot the contract describes. The script boots the image with
-`BRIG_IMAGE=<image> brig create <profile> --name image-check`, in a scratch
+`BRIG_IMAGE=<image> brig run -d <profile>@image-check`, in a scratch
 workspace, and tears it down with `brig rm` when it is done. Going through
 brig is what supplies the hypervisor, the rootfs type, the generic-boot
 annotations and the capabilities described above; a bare `hull run` or
@@ -334,7 +334,7 @@ its last path element is the user `chown` has to resolve, and its `binary:` is
 the agent CLI the last line looks for. So the check is of this image under
 this profile rather than of an image in the abstract, which is the question
 you actually have. A profile of your own has to be one brig knows, through
-`brig profile import`.
+`brig agent import`.
 
 The requirements themselves run as root through the runtime's own exec against
 the sandbox brig created, one exec per line of the table above, so what they

--- a/docs/manual-tests/runtime-stdin.md
+++ b/docs/manual-tests/runtime-stdin.md
@@ -7,8 +7,8 @@ privileged exec. `go test ./internal/runtime/` only asserts on the argv a spec
 builds; it cannot see a guest. This is the guest-side check the plan asks for,
 run by hand on a macOS host with hull already installed.
 
-CI cannot run this: `ci.yml` is Linux-only and GitHub Actions is disabled at
-the repository level, so none of it is machine-verified.
+CI cannot run this: `ci.yml` runs on Linux only, with a stub runtime, so none
+of it is machine-verified.
 
 ## What was run
 

--- a/docs/manual-tests/runtime-stdin.md
+++ b/docs/manual-tests/runtime-stdin.md
@@ -13,7 +13,7 @@ the repository level, so none of it is machine-verified.
 ## What was run
 
 ```
-$ brig create claude-code
+$ brig run -d claude-code
 ...
 brig: starting sandbox brig-claude-code...
 VMM started (PID 34585)

--- a/docs/manual-tests/sandbox-reachability.md
+++ b/docs/manual-tests/sandbox-reachability.md
@@ -30,7 +30,9 @@ read it as isolation.
 
 ## macOS, `hvi`
 
-hull 0.1.0-rc21, `claude-code-stock`, sandboxes at `10.87.0.4` and `10.87.0.5`.
+hull 0.1.0-rc21, `claude-code-stock`, sandboxes at `10.87.0.4` and `10.87.0.5`
+on the shared subnet of the time. The shared network is `198.18.0.0/24` now
+(`internal/runtime/gateway.go`); the mechanism below does not depend on which.
 
 A packet capture on both guests, with a raw `AF_PACKET` socket, shows the
 mechanism:
@@ -88,7 +90,8 @@ creates that network in `Run` and removes it in `Remove`.
 
 ## Offline
 
-`--network none` gives a guest with `lo` only, no route, and no egress. The
+`--network offline` (`--net none` at hull, `--network none` at nerdctl) gives
+a guest with `lo` only, no route, and no egress. The
 same image on the default bridge has `eth0` and reaches the internet. This is
 true on Linux and on both macOS backends.
 

--- a/docs/manual-tests/secret-files.md
+++ b/docs/manual-tests/secret-files.md
@@ -58,13 +58,13 @@ $ echo '{"before":1}'        > $WS/.claude/history.jsonl
 ## 1. The mounts, and their order
 
 ```
-$ brig create claude-code
+$ brig run -d claude-code
 brig: image ghcr.io/brig-sh/claude-code-stock:latest: signature verified
 brig: starting sandbox brig-claude-code...
 VMM started (PID 55252)
 brig-claude-code
 
-$ brig exec claude-code -- sh -c \
+$ brig sh claude-code \
     'grep -E "claude|persist" /proc/self/mountinfo | awk "{print \$5, \$(NF-2)}"'
 /home/claude                                virtiofs
 /run/brig/persist/.claude%2Fsessions        virtiofs
@@ -86,7 +86,7 @@ depth, never from the file.
 ## 2. `stat -f -c %T`: the fail-closed check
 
 ```
-$ brig exec claude-code -- sh -c \
+$ brig sh claude-code \
     'for p in ~/.claude ~/.claude/sessions ~/.claude/history.jsonl \
               ~/.claude/projects ~/.claude/.credentials.json; do
        printf "%-38s %s\n" "$p" "$(stat -f -c %T $p)"; done'
@@ -104,7 +104,7 @@ brig makes both of these checks itself and fails the run on either, and the
 same run checks that the guest has no swap:
 
 ```
-$ brig exec claude-code -- cat /proc/swaps
+$ brig sh claude-code cat /proc/swaps
 Filename				Type		Size		Used		Priority
 ```
 
@@ -113,7 +113,7 @@ Header only. Nothing for a tmpfs page to be written out to.
 ## 3. The credential
 
 ```
-$ brig exec claude-code -- stat -c "%n %F %U:%G %a %s" ~/.claude/.credentials.json
+$ brig sh claude-code 'stat -c "%n %F %U:%G %a %s" ~/.claude/.credentials.json'
 /home/claude/.claude/.credentials.json regular file claude:root 600 170
 ```
 
@@ -124,7 +124,7 @@ mode 0600 makes the group irrelevant.
 The kept state is there too, read back from the host copies through the cover:
 
 ```
-$ brig exec claude-code -- cat .claude/sessions/old.jsonl .claude/history.jsonl
+$ brig sh claude-code cat .claude/sessions/old.jsonl .claude/history.jsonl
 session-from-before
 {"before":1}
 ```
@@ -157,7 +157,7 @@ real path; against the bind mount D4 originally specified that `renameat`
 returned `EBUSY`, and the temp file landed in the workspace. Simulated exactly:
 
 ```
-$ brig exec claude-code -- sh -c '
+$ brig sh claude-code '
     C=~/.claude/.credentials.json
     echo "inode before: $(stat -c %i $C)"
     T=$C.tmp.$$
@@ -182,11 +182,11 @@ file (section 4's `find` was re-run and is unchanged).
 that runs every time after the first.
 
 ```
-$ brig exec claude-code -- sh -c 'grep -cE "claude|persist" /proc/self/mountinfo'
+$ brig sh claude-code 'grep -cE "claude|persist" /proc/self/mountinfo'
 8
-$ brig create claude-code
+$ brig run -d claude-code
 brig-claude-code
-$ brig exec claude-code -- sh -c '
+$ brig sh claude-code '
     echo "mount lines: $(grep -cE "claude|persist" /proc/self/mountinfo)"
     stat -c "%n %U %a %s" ~/.claude/.credentials.json
     stat -f -c %T ~/.claude
@@ -205,8 +205,8 @@ cannot do:
 ```
 $ printf '%s' '{"claudeAiOauth":{"accessToken":"probe-rotated",...}}' \
     | brig secret update volumes-probe-cred -f -
-$ brig create claude-code
-$ brig exec claude-code -- sh -c \
+$ brig run -d claude-code
+$ brig sh claude-code \
     'wc -c < ~/.claude/.credentials.json; grep -o probe-rotated ~/.claude/.credentials.json'
 108
 probe-rotated
@@ -222,7 +222,7 @@ targets on the host through the workspace root and refuses rather than repairs.
 ```
 $ brig rm claude-code
 $ ln -s /etc $WS/.claude/sessions
-$ brig create claude-code
+$ brig run -d claude-code
 brig: refusing to mount .../ws/.claude/sessions: it is a symlink to "/etc", and
 brig writes only regular files inside the workspace. The workspace is mounted
 read-write as the sandbox's home, so that link was put there from inside the

--- a/docs/manual-tests/secret-files.md
+++ b/docs/manual-tests/secret-files.md
@@ -8,16 +8,17 @@ recording double: it can assert the order of the mounts and that no value ever
 reaches argv, but it cannot tell you what `stat -f -c %T` says in a real guest,
 which is the only thing that makes the design fail-closed rather than intended.
 
-CI cannot run this either: `ci.yml` is Linux-only and GitHub Actions is
-disabled at the repository level, so nothing in this PR is machine-verified.
+CI cannot run this either: `ci.yml` runs on Linux only, with a stub runtime,
+so nothing in this PR is machine-verified.
 
 Run on a macOS host (arm64, macOS 26.4) with hull installed, 2026-08-18,
 against `ghcr.io/brig-sh/claude-code-stock:latest` (Ubuntu, aarch64).
 
 ## The profile under test
 
-The built-in `claude-code` spec does not declare `volumes:` yet -- that is
-PR 8 -- so the run used a shadowing profile in a throwaway
+When this was run the built-in `claude-code` spec did not declare `volumes:`
+yet (it does now: a `512m` tmpfs over `.claude`, `internal/profile/specs/claude-code.yaml`),
+so the run used a shadowing profile in a throwaway
 `$XDG_CONFIG_HOME/brig/claude-code.yaml`: the built-in with `statePaths:`
 removed and this appended.
 

--- a/docs/manual-tests/secret-provenance.md
+++ b/docs/manual-tests/secret-provenance.md
@@ -12,8 +12,8 @@ because there is no other keychain `security -i`'s `-w`-must-be-last rule
 would exercise the same way (see `keychain_darwin_test.go`'s own comment on
 why its tests use the real keychain).
 
-CI cannot run this: `ci.yml` is Linux-only and GitHub Actions is disabled at
-the repository level, so none of it is machine-verified.
+CI cannot run this: `ci.yml` runs on Linux only, with a stub runtime, so none
+of it is machine-verified.
 
 ## What was run
 

--- a/docs/non-goals.md
+++ b/docs/non-goals.md
@@ -1,7 +1,7 @@
 # What brig will not do
 
 brig's shape comes from what it refuses. It delegates every mechanical
-operation to a runtime it does not own, keeps one direct dependency, needs no
+operation to a runtime it does not own, keeps its dependencies to three, needs no
 account, and adds only the things the layer underneath has no concept of. None
 of that was written down as a boundary, so every proposal to cross one arrived
 as a fresh argument with no prior answer. This page is the prior answer.
@@ -22,7 +22,7 @@ containerd does it on Linux, and brig's own work begins after the sandbox is
 running. Owning the boot path would mean owning Virtualization.framework, a
 kernel command line, an image store, a snapshotter and the vulnerability
 surface of all of it, in a tool whose reason to exist is that it handles your
-credentials carefully with one direct dependency. The four things brig adds on
+credentials carefully with three direct dependencies. The four things brig adds on
 top, in the README's "What brig is", are the four a runtime has no concept of.
 Everything else in the boot path already works.
 
@@ -34,12 +34,13 @@ runtime of our own.
 ## A policy engine with its own rules language
 
 There is a line here, and it is worth being exact about where it falls. A
-profile field the runtime enforces is fine: `network: none` translated into
+profile field the runtime enforces is fine: `network: offline` translated into
 the runtime's own flag is data, brig's job ends at the translation, and the
-guarantee is the runtime's to make. The README already lists sbx's
-`--publish` and `--deny-network` as "not yet" rather than never, and
-`docs/security.md` says there is no per-sandbox network policy yet. Those are
-missing fields, and fields are in scope. What is out of scope is a language:
+guarantee is the runtime's to make. An egress policy is the same shape one
+step up: a document of `allow` and `deny` rules handed to the gateway that
+enforces them, and refused where nothing can ([policies.md](policies.md)).
+The README still lists sbx's `--publish` as "not yet" rather than never, and
+a missing field of that kind is in scope. What is out of scope is a language:
 conditions, matchers, precedence rules and an evaluator that lives in brig. A
 decision brig evaluates is one people will believe is enforced, when in fact
 enforcement sits one layer down and brig can only ask for it.
@@ -107,14 +108,16 @@ permanently. That part is not up for review in twelve months or in sixty.
 
 A library per language is a release train per language, a dependency set per
 language, and a chance per language to drift behind the CLI, all to wrap a
-process the caller could have spawned. The single-dependency rule in
+process the caller could have spawned. The short dependency list in
 `CONTRIBUTING.md` exists for the tool itself, and the same reasoning applies to
 what we ask users to link into their programs. The commitment instead is a CLI
 disciplined enough not to need wrapping: stable verbs and exit codes, human
 output on stdout, diagnostics on stderr, and a `--json` mode wherever a program
-is the reader rather than a person. Today that mode exists on
-`brig profile export`; more verbs get it as callers need them, and asking for
-one is a small issue rather than an argument. For lifecycle control there is
+is the reader rather than a person. Today that mode covers the read verbs --
+`ls`, `info`, `agent ls`, `agent show`, `agent export`, `agent new`,
+`policy show`, `secret ls` and `doctor` -- and `run`, which under `--json`
+reports the agent's exit status on one line; more verbs get it as callers
+need them, and asking for one is a small issue rather than an argument. For lifecycle control there is
 already an interface with no library attached: `brigd` speaks line-delimited
 JSON over a unix socket and is documented in [brigd.md](brigd.md).
 
@@ -185,7 +188,7 @@ platform, not once but as they change.
 ## A plugin system
 
 Loading third-party code into the process that resolves your credentials is
-the thing the single-dependency rule exists to prevent, and a plugin API also
+the thing the short dependency list exists to prevent, and a plugin API also
 turns internal interfaces into a contract we then cannot change. brig is
 already extensible three ways that do not require it. Profiles are data, so
 any Linux CLI in an OCI image runs under brig with a YAML file and no code at

--- a/docs/non-goals.md
+++ b/docs/non-goals.md
@@ -125,12 +125,12 @@ cannot perform.
 
 ## A dashboard or a TUI ahead of the CLI
 
-The refusal is in the last three words. `brig ls`, `brig env` and
-`brig profiles` are how you see what exists, what would be forwarded and what
+The refusal is in the last three words. `brig ls`, `brig info` and
+`brig agent ls` are how you see what exists, what would be forwarded and what
 each profile refuses, and while any of that is missing from the CLI, adding a
 screen that displays it is building the second floor first. A live interface
 also has to stay in the middle of something, and brig deliberately does not:
-`brig exec` replaces itself with the runtime so `^C` and the exit status are
+`brig sh` replaces itself with the runtime so `^C` and the exit status are
 the agent's own, which `docs/security.md` explains and accepts the cost of.
 
 **Reopens when** the CLI covers the whole surface and someone shows a task that

--- a/docs/policies.md
+++ b/docs/policies.md
@@ -3,7 +3,7 @@
 A policy is a named YAML (or JSON) document declaring what an agent may
 reach outbound: a default of `allow` or `deny`, plus `host` or `cidr`
 exceptions on either side. `brig policy create` writes a starter and opens
-it in your editor, the same way `brig profile edit` does:
+it in your editor, the same way `brig agent edit` does:
 
 ```bash
 brig policy create no-net   # writes ~/.config/brig/policies/no-net.yaml
@@ -34,7 +34,7 @@ write to it.
 already follows -- a file need not be named after the policy it declares,
 though `create` always names them the same way. A directory can hold any
 number of policies, and one file that fails to parse does not stop the
-others from loading: `brig policies` reports it on stderr and lists
+others from loading: `brig policy ls` reports it on stderr and lists
 everything that did load. Two files declaring the same name is a mistake
 with no winner worth having, and is reported the same way.
 
@@ -57,7 +57,7 @@ egress:
 | --- | --- | --- |
 | `apiVersion` | yes | Pins the document shape. `brig.sh/v1alpha1` is the only value this build knows; anything else is refused rather than guessed at |
 | `name` | yes | The policy's identifier. Wins over the filename, and follows the same character rule as a profile name -- see [Naming a policy](#naming-a-policy) |
-| `desc` | no | One line, shown by `brig policies` |
+| `desc` | no | One line, shown by `brig policy ls` |
 | `egress.default` | yes | `allow` or `deny`, applied to any traffic neither list below names |
 | `egress.allow` | no | Exceptions to a `deny` default |
 | `egress.deny` | no | Always wins over `allow` and over `default`: a host named here is refused regardless, and no other settings source restores it |
@@ -106,8 +106,7 @@ brig: name "no" reads as false when written unquoted in YAML, not as itself; pic
 
 | verb | what it does |
 | --- | --- |
-| `brig policies` | every policy that parses, by name and description, and -- for one bound to anything -- what binds it |
-| `brig policy ls` | same (parity with `brig profiles` / `brig profile ls`) |
+| `brig policy ls` | every policy that parses, by name and description, and -- for one bound to anything -- what binds it. `brig policies` still works, with a note naming this spelling |
 | `brig policy create <name>` | write a starter document, then open it: `$VISUAL`, then `$EDITOR`, then `vi` |
 | `brig policy edit <name> [--force]` | open an existing one, and only replace it if the save still parses and validates. Refuses a rename that would orphan anything bound to it -- inline or attached -- unless `--force` |
 | `brig policy show <name> [--json]` | print the parsed document |
@@ -262,7 +261,7 @@ binding points at is still right here either way.
 Starting from nothing:
 
 ```console
-$ brig policies
+$ brig policy ls
 no policies yet; your own live in /home/you/.config/brig/policies
 brig policy create <name> writes a starter one
 ```
@@ -273,7 +272,7 @@ filled in:
 ```console
 $ brig policy create no-net
 /home/you/.config/brig/policies/no-net.yaml created
-$ brig policies
+$ brig policy ls
 no-net          only Anthropic's API and one internal range
 ```
 
@@ -306,7 +305,7 @@ $ brig policy show no-net --json
 
 `show` prints the parsed document back out, not the file verbatim, which is
 why the field order differs from what you typed -- YAML's own marshalling
-sorts keys, the same way `brig profile export --json` does.
+sorts keys, the same way `brig agent show --json` does.
 
 Edit it, and remove it:
 
@@ -321,7 +320,7 @@ removed /home/you/.config/brig/policies/no-net.yaml
 
 | what brig says | what happened |
 | --- | --- |
-| ``unknown policy "x". `brig policies` lists them`` | `show`, `edit` or `rm` on a name that is not there |
+| ``unknown policy "x". `brig policy ls` lists them`` | `show`, `edit` or `rm` on a name that is not there |
 | `name "x" may use only lowercase letters, digits, dot, dash and underscore, and must start with a letter or digit` | see [Naming a policy](#naming-a-policy) |
 | `name "x" reads as false when written unquoted in YAML, not as itself; pick a different name` | the name is a bare YAML boolean, null or number word -- see [Naming a policy](#naming-a-policy) |
 | `<path> already exists. Edit it directly with brig policy edit x, or pass --force to replace it with a fresh starter` | `create` on a name whose file is already there |
@@ -332,7 +331,7 @@ removed /home/you/.config/brig/policies/no-net.yaml
 | `host "x" contains whitespace or a control character` | a `host:` value that cannot be a domain or glob under any grammar |
 | `apiVersion is required, and must be "brig.sh/v1alpha1"` | a document with no `apiVersion:`, or the wrong one |
 | `not saved, <path> is unchanged: …` | `edit`'s save did not parse or validate, or renamed a name that is bound to something, without `--force`. The real file is untouched; the error names where your edit still is |
-| ``unknown profile "x". `brig profiles` lists them`` | `attach`, `detach` or `check` naming a profile that is not there |
+| ``unknown profile "x". `brig agent ls` lists them`` | `attach`, `detach` or `check` naming a profile that is not there |
 | `cannot attach x to y: y is kind: shell, which has no agent to hook an egress rule into. Nothing was written` | `attach` to a `kind: shell` or `kind: gui` profile |
 | `cannot enforce any policy on x: x is kind: shell, which has no agent to hook an egress rule into` | `check` on a `kind: shell` or `kind: gui` profile |
 | `x is bound to y, which no policy loads under -- nothing can enforce what did not load` | `check` on a profile bound to a name nothing loads under: either `--force` on `rm` or a rename left no policy behind it, or the file that declares it did not parse (named separately on stderr) |

--- a/docs/profiles.md
+++ b/docs/profiles.md
@@ -8,17 +8,17 @@ The quickest way to write one is to start from the closest existing profile
 rather than from a blank file:
 
 ```bash
-brig profile export claude-code mine   # writes ~/.config/brig/mine.yaml
-brig profile edit mine                 # change the image, and what it forwards
+brig agent new mine --from claude-code   # writes ~/.config/brig/mine.yaml
+brig agent edit mine                     # change the image, and what it forwards
 brig run mine
 ```
 
-The second word is a *name*, not a path: brig puts the file in your profile
+The name you give `new` is a *name*, not a path: brig puts the file in your profile
 directory, which is the only place a profile file does anything. It writes
 nowhere else -- a destination with a `/` in it is refused, not honoured.
 
 It is also the name the profile itself carries. brig keys on the `name:` field
-inside the file rather than on the file name, so export writes the name you
+inside the file rather than on the file name, so `new` writes the name you
 gave it into the file: `mine.yaml` says `name: mine`, and every command that
 takes a profile takes `mine` from that point on. Nothing else in the file is
 touched, so the image, the guest home and the comments still describe the
@@ -26,7 +26,7 @@ profile you copied -- that is what the edit in the second line is for.
 
 The exported file carries a header explaining every field, so you can edit it
 without coming back here. Once you have a profile of your own on disk,
-`brig profile edit` opens it directly in `$VISUAL`, then `$EDITOR`, then `vi`
+`brig agent edit` opens it directly in `$VISUAL`, then `$EDITOR`, then `vi`
 -- there is no round trip through a separate file any more. It only works on
 a profile backed by a file: a built-in has none, so it says so and prints the
 commands that would make one, and creates nothing itself.
@@ -50,23 +50,24 @@ project. The old `~/.config/brig/templates` default is not read. Nothing is
 migrated for you -- these files name credential variables, and there is no
 safe guess about which of them you still want -- but brig notices files left
 there and says so on every invocation until you move them across with
-`brig profile import`.
+`brig agent import`.
 
 **The directory starts empty, and brig never writes there unless you ask
-it to.** Nothing is pre-seeded on first run. `brig profile import` and
-`brig profile export <name> <dest>` are the only commands that write to it,
-and export refuses to overwrite an existing file unless you pass `--force`.
+it to.** Nothing is pre-seeded on first run. `brig agent import`,
+`brig agent export <agent> <name>` and `brig agent new <name> --from <agent>`
+are the only commands that write to it, and the last two refuse to overwrite
+an existing file unless you pass `--force`.
 
 A profile may be backed by more than one file, because a file need not be
 named after the profile inside it. Two files declaring one name is a mistake
 with no winner worth having -- which survives depends on where the names
 happen to sort -- so brig reports it and says which one won.
-`brig profile rm` takes all of them, after asking: a second file is by
+`brig agent rm` takes all of them, after asking: a second file is by
 definition not the file you named.
 
 A file may take a built-in's name. That is deliberate: it is how you pin your
 own image for a profile brig already knows about, without inventing a second
-name for it. `brig profiles` lists the merged set -- embedded and file-backed
+name for it. `brig agent ls` lists the merged set -- embedded and file-backed
 together, one namespace -- and marks where each came from: unmarked is
 embedded, `(file)` is a profile that exists only as a file, and
 `(file, overrides built-in)` is a file shadowing an embedded one.
@@ -74,11 +75,11 @@ embedded, `(file)` is a profile that exists only as a file, and
 ## Export and import
 
 ```bash
-brig profile export claude-code                # prints to stdout
-brig profile export claude-code mine           # ~/.config/brig/mine.yaml
-brig profile export claude-code mine --force   # ...overwriting what is there
-brig profile export claude-code > ./mine.yaml  # a copy somewhere of your own
-brig profile export x | brig profile import -
+brig agent export claude-code                # prints to stdout
+brig agent export claude-code mine           # ~/.config/brig/mine.yaml
+brig agent export claude-code mine --force   # ...overwriting what is there
+brig agent export claude-code > ./mine.yaml  # a copy somewhere of your own
+brig agent export x | brig agent import -
 ```
 
 With no destination, export prints to stdout, so it composes into a pipe.
@@ -95,13 +96,13 @@ to stdout and redirect it, under the shell's rules rather than brig's.
 A destination that is already spoken for is refused too, because the
 destination is the name written into the file. `claude` is how brig spells
 `claude-code`, and a profile actually called `claude` wins the lookup over
-that alias, so `brig profile export claude-code claude` would make every
+that alias, so `brig agent new claude --from claude-code` would make every
 `brig run claude` mean the copy and leave the built-in reachable only under
 its full name. A name a `reserved:` profile owns is refused for the same
 reason. Both say what the collision is; pick another name.
 
 Export writes YAML because a profile is a file a person edits, and YAML has
-comments. Use `brig profile export --json` if something downstream consumes
+comments. Use `brig agent show --json` if something downstream consumes
 profiles programmatically -- JSON is a subset of YAML, so import reads both
 with the same parser and neither has to guess.
 
@@ -115,7 +116,7 @@ with the same parser and neither has to guess.
 | `kind` | no | `agent` (the default), `shell` or `gui`. An `agent` needs a `binary`; the other two have nothing to pass arguments to |
 | `binary` | yes, for `kind: agent` | The agent CLI inside the guest |
 | `mem`, `cpus` | yes | Guest size. Both must be greater than zero |
-| `desc` | no | One line, shown by `brig profiles` |
+| `desc` | no | One line, shown by `brig agent ls` |
 | `secrets` | no | Names this profile wants out of brig's own secret store, checked before the sandbox is created. Each entry says whether a run without it should stop, and where `brig secret import` may find it. See below |
 | `env` | no | The variables the guest sees, and where each one's value comes from: a literal, a stored secret, or brig's own environment. See below |
 | `forward` | no | Deprecated spelling of `env` for the environment case. Still works; folded into `env` when the file is read. See below |
@@ -135,7 +136,7 @@ with the same parser and neither has to guess.
 | `onboarding` | no | A first-run state file to seed. See below |
 | `hostCredential` | no | **Deprecated, removed next release.** A credential read from the host keychain on every run when the environment carries none. Replaced by `secrets` with `sources`, filled once by `brig secret import`. See below |
 | `reserved` | no | Marks a profile that owns the workspace a session name could otherwise slug onto. See below |
-| `unpublished` | no | We ship the profile but not an image for it. `brig run` says so and stops, rather than letting the pull fail against the registry with a 404 that reads like an outage. Pass `--image` with one you built, and `brig profiles` marks it. `cursor` is the one that carries it |
+| `unpublished` | no | We ship the profile but not an image for it. `brig run` says so and stops, rather than letting the pull fail against the registry with a 404 that reads like an outage. Pass `--image` with one you built, and `brig agent ls` marks it. `cursor` is the one that carries it |
 | `policy` | no | Names of policies attached to this profile inline: every run carries all of them, unioned with whatever is attached separately by name |
 
 A misspelled field is refused rather than ignored. `forwards:` instead of
@@ -360,7 +361,7 @@ env:
 
 The translation happens once, at parse time, so nothing downstream of it has
 to know which spelling a given file used. One consequence worth knowing:
-`brig profile export --json` emits the `env:` form even for a profile
+`brig agent show --json` emits the `env:` form even for a profile
 written with `forward:`, because JSON export marshals the parsed profile,
 and by then there is no `forward:` left in it. Plain YAML export is
 unaffected -- it hands back the file exactly as written, comments and all,
@@ -493,15 +494,16 @@ about what persists is worse than the duplication.
 part of this. The mechanism is built (a re-run rewrites the file under a live
 agent); the verb is not.
 
-## `brig env`, to see what a run would send
+## `brig info`, to see what a run would send
 
-`brig env <profile>` reports what the guest would be handed, by name --
+`brig info <profile>` reports what the guest would be handed, by name --
 never a value, on any path. A variable sourced from the secret store is
 annotated `(secret)`; one from the deprecated `hostCredential:` is annotated
 `(host)`; an ambient or literal one is reported bare:
 
 ```
-$ brig env alex
+$ brig info alex
+...
 brig: workspace /Users/alex/brig/alex (sandbox brig-alex)
 brig: runtime hull (/opt/homebrew/bin/hull)
 brig: image ghcr.io/brig-sh/claude-code:latest (pull missing)
@@ -517,7 +519,7 @@ separate from the value, from the point a binding is resolved -- and the
 report is built from that name list alone, so no path through this command
 reads a value. A test fails the build if one ever reaches the output.
 
-`brig env` resolves secrets the same way any other run does, so a profile
+`brig info` resolves secrets the same way any other run does, so a profile
 missing one from the store fails the same way `brig run` would. It is not a
 preview that quietly skips what it cannot resolve.
 
@@ -540,7 +542,7 @@ The trailing word is reserved too, not just the full name: `claude-desktop`
 reserves `desktop` as well as `claude-desktop` itself. Watch for the
 consequence -- it is easy to trip over by accident. A profile of your own
 named `my-codex` with `reserved: true` reserves `codex` along with
-`my-codex`, so `brig profile import` of anything else named `codex` is
+`my-codex`, so `brig agent import` of anything else named `codex` is
 refused as a collision, even though nothing on brig's side is called that.
 
 ## `deny` is the billing guard
@@ -659,7 +661,7 @@ cpus: 4
 ```
 
 ```bash
-brig profile import mytool.yaml
+brig agent import mytool.yaml
 MYTOOL_TOKEN=$(pass show mytool/token) brig run mytool
 ```
 
@@ -718,7 +720,7 @@ file on your machine. On macOS brig asks hull where they are, because they live
 under hull's store and only hull knows where that is; on Linux it looks in
 `~/.local/share/brig/assets`. `BRIG_BOOT_ASSETS` overrides both.
 The kernel is named for the architecture it boots: `Image` on arm64,
-`bzImage` on x86_64. And the guest agent that `brig exec` talks to comes from
+`bzImage` on x86_64. And the guest agent that `brig sh` talks to comes from
 that initrd rather than from the image, which is what makes an unmodified image
 drivable at all.
 
@@ -749,7 +751,7 @@ brig refuses up front instead.
 ## Removing a profile
 
 ```bash
-brig profile rm mytool
+brig agent rm mytool
 ```
 
 The argument is a profile name, not a file name: `rm` resolves it through the
@@ -758,7 +760,7 @@ called. If more than one file declares the name, it takes all of them --
 removing only the one that loaded would promote the other and leave the
 profile listed exactly as before.
 
-That resolution is why `rm` asks. `mytool.yaml` for `brig profile rm mytool`
+That resolution is why `rm` asks. `mytool.yaml` for `brig agent rm mytool`
 is the file you named, and it goes without a word. Anything else -- an alias,
 a second file declaring the same profile, a file renamed by hand -- is a file
 brig found and you did not type, so it is named and the delete waits for a
@@ -766,7 +768,7 @@ brig found and you did not type, so it is named and the delete waits for a
 no terminal to ask on `rm` refuses and says so rather than assuming yes:
 
 ```bash
-brig profile rm claude -y   # the alias resolves to claude-code's file
+brig agent rm claude -y   # the alias resolves to claude-code's file
 ```
 
 Built-in profiles are compiled in, so there is nothing to remove -- import a

--- a/docs/profiles.md
+++ b/docs/profiles.md
@@ -128,7 +128,7 @@ with the same parser and neither has to guess.
 | `headless` | no | The agent supports a non-interactive run |
 | `guiTitle` | no | Window title, for a `kind: gui` profile |
 | `network` | no | the sandbox's network posture: `shared` (the default: one network for every sandbox on this host), `isolated` (a network of this sandbox's own) or `offline` (no route out at all). `BRIG_NETWORK`, `--network` and `--offline` win over it |
-| `hypervisor` | no | macOS backend to boot on: `vz` (the default, and the only one with a graphical console), `hvi` or `qemu`. `BRIG_HYPERVISOR` wins over it. Ignored on Linux, where the shim decides |
+| `hypervisor` | no | macOS backend to boot on: `vz` (the default when the field is absent, and the only one with a graphical console), `hvi` or `qemu`. Six of the eight shipped profiles say `hvi`. `BRIG_HYPERVISOR` wins over it. Ignored on Linux, where the shim decides |
 | `runtimeBin` | no | The runtime binary to drive instead of the one on `PATH`, `~` expanded. Unlike every other field this is about your machine rather than the workload, so it does not travel usefully to anyone else -- it is how you pin a profile to a build you are working on without exporting a variable in every shell. `BRIG_RUNTIME_BIN` wins over it |
 | `rootfsType` | no | How the guest root reaches the VM: `block`, `virtiofs` or `9pfs`. Left unset the runtime picks its own default, which is what a profile that only runs an agent wants. Set `block` when the sandbox installs packages and needs a real writable disk rather than a share sized to the image |
 | `genericBoot` | no | The image was never built to be a guest -- a plain OCI image with no kernel and no urunc metadata. The runtime supplies the kernel and initrd and boots it unmodified, on macOS and Linux alike. See below |
@@ -211,7 +211,7 @@ ignoring it reads as a working portable chain that resolves nothing:
 
 | `from:` | locator | what it reads |
 | --- | --- | --- |
-| `keychain` | `service:` | a macOS keychain generic-password item. macOS only; a Linux backend is [#8](https://github.com/brig-sh/brig/issues/8) |
+| `keychain` | `service:` | a macOS keychain generic-password item. macOS only: the Linux store is a Secret Service keyring ([secrets.md](secrets.md#linux)), and no source reads from it |
 | `file` | `path:` | a host file, verbatim. A leading `~` is expanded when it is read, so a profile carries no one host's home directory |
 | `env` | `var:` | a host environment variable, **copied once at import** |
 
@@ -239,10 +239,10 @@ to share a shape.
 
 On macOS the keychain source answers first, so nothing in a supported
 configuration today ever reaches `path: ~/.claude/.credentials.json`. That path
-is the **documented** Linux location rather than an observed one, and a Linux
-host has no store to import into yet ([#8](https://github.com/brig-sh/brig/issues/8)),
-so it is data that costs three lines and makes the profile portable the day the
-backend lands.
+is the **documented** Linux location rather than an observed one. On a Linux
+host with a keyring the import reads it and stores into the Secret Service
+backend ([secrets.md](secrets.md#linux)); it is data that costs three lines and
+makes the profile portable.
 
 ### What happens when a secret is missing
 
@@ -285,14 +285,15 @@ brig: no value for the secret "gh-token", and claude-code will run without it.
 brig: To supply one: brig secret create gh-token
 ```
 
-There is no secret store on Linux yet. A **required** secret therefore fails
-every run on the nerdctl backend, for the same reason and in the same way --
-failing closed is correct, but it is worth knowing before your first run of
-such a profile there rather than after. An **optional** one is silent there
-instead of warning on every run: there is no store to create it in, so nothing
-the user does on that host would change the outcome, and a warning about it
-would be noise rather than information. That is why the shipped `claude-code`
-still boots on Linux.
+On Linux the store is a Secret Service keyring, and a host without one --
+no session bus, or nothing answering on it -- has no store. A **required**
+secret therefore fails every run on such a host, for the same reason and in
+the same way; failing closed is correct, but it is worth knowing before your
+first run of such a profile there rather than after. An **optional** one is
+silent there instead of warning on every run: there is no store to create it
+in, so nothing the user does on that host short of installing a keyring would
+change the outcome, and a warning about it would be noise rather than
+information. That is why the shipped `claude-code` still boots on Linux.
 
 ### The `ref` grammar, and `refs:` chains
 
@@ -740,9 +741,10 @@ at a build you are iterating on, and downloading a release bundle over your own
 work would be the opposite of helpful. `BRIG_BOOT_ASSETS_REF` pins a specific
 bundle instead of the current one for your platform.
 
-The bundles come from
-[hull-assets](https://github.com/NOFireAI/hull-assets), one per guest platform;
-`oci/pull-bundle.sh` there does the same fetch by hand.
+The bundle is published as the OCI artifact `ghcr.io/nofireai/hull-assets`,
+one tag per guest platform, and pulls anonymously; the repository that builds
+it is not public. `oras pull ghcr.io/nofireai/hull-assets:<os>-<arch> --output
+<dir>` is the same fetch by hand.
 
 On Linux this needs `nerdctl` rather than `docker`. Docker does not carry OCI
 annotations through to the runtime, so the sandbox would boot with no kernel;

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -41,11 +41,12 @@ The first run is the slow one. In order:
   ```
   PROFILE      claude-code
   SANDBOX      brig-claude-code (hull)
-  ISOLATION    microVM (hull, vz backend)
+  ISOLATION    microVM (hull, hvi backend)
   WORKSPACE    /Users/you/brig/claude-code (read-write)
   IMAGE        ghcr.io/brig-sh/claude-code-stock:latest (pull missing)
   VERIFY       warn, against brig's own trust policy
-  CREDENTIALS  GH_TOKEN
+  CREDENTIALS  claude-credentials
+  NETWORK      shared (one network for every sandbox on this host)
   ```
 
   Credentials are named, never printed. An ordinary run goes straight to the

--- a/docs/runtimes.md
+++ b/docs/runtimes.md
@@ -20,13 +20,13 @@ Licences were read from each repository's `LICENSE` file on 2026-08-26.
 | `brig`, `brigd` | resolves the profile, the workspace and the credentials, then drives the runtime | this repository | Apache-2.0 |
 | `hull` | CLI that pulls an OCI image and boots it as a microVM on Apple Silicon | [brig-sh/hull](https://github.com/brig-sh/hull) | Apache-2.0 |
 | `vz-runner` | Swift helper hull launches for its `vz` backend, which is what talks to Virtualization.framework | same repository as hull, installed beside it | Apache-2.0 |
-| `hvi` | separate VM monitor for hull's `hvi` backend, which talks to Hypervisor.framework directly | a git submodule of hull (`hvi-vmm`), installed beside hull | unconfirmed: `hvi-vmm` is a private submodule of hull |
+| `hvi` | separate VM monitor for hull's `hvi` backend, which talks to Hypervisor.framework directly | [brig-sh/hvi-vmm](https://github.com/brig-sh/hvi-vmm), a git submodule of hull, installed beside hull | Apache-2.0 |
 | `nerdctl` | Docker-compatible CLI for containerd, the binary brig drives on Linux | [containerd/nerdctl](https://github.com/containerd/nerdctl) | Apache-2.0 |
 | `containerd` | daemon underneath nerdctl: it holds the image store and hands each container to a shim | [containerd/containerd](https://github.com/containerd/containerd) | Apache-2.0 |
 | `urunc` | the containerd shim `io.containerd.urunc.v2`, which boots the container as a microVM instead of a process | [urunc-dev/urunc](https://github.com/urunc-dev/urunc) | Apache-2.0 |
 | `cosign` | checks the signature on a guest image before it boots. Optional, and the check degrades to a warning without it | [sigstore/cosign](https://github.com/sigstore/cosign) | Apache-2.0 |
 | `oras` | pulls the boot bundle on Linux for a `genericBoot` profile. Optional otherwise | [oras-project/oras](https://github.com/oras-project/oras) | Apache-2.0 |
-| boot bundle | the kernel, `container-initrd` and the in-guest agent that let brig exec into an image built as an ordinary container. Published as an OCI artifact at `ghcr.io/nofireai/hull-assets`, one tag per guest platform | fetched by hull on macOS, by oras on Linux | unconfirmed: signed with keyless cosign, but its source repository is not public and states no licence |
+| boot bundle | the kernel, `container-initrd` and the in-guest agent that let brig exec into an image built as an ordinary container. Published as an OCI artifact at `ghcr.io/nofireai/hull-assets`, one tag per guest platform | fetched by hull on macOS, by oras on Linux | unconfirmed: signed with keyless cosign, but the repository that builds it is not public and states no licence |
 
 hull is published by the same organisation as brig and exists because brig
 needed it, but it is a usable runtime on its own and its command surface is
@@ -51,7 +51,9 @@ The runtime decides everything mechanical: how the image is pulled and stored,
 how the VM is configured and booted, how a command gets into the guest, and
 what a stopped instance means.
 
-Nothing is linked in. brig has one direct Go dependency and every interaction
+Nothing is linked in. brig has three direct Go dependencies -- `sigs.k8s.io/yaml`
+for the profiles, `golang.org/x/sys` for the terminal and process calls, and
+`github.com/godbus/dbus/v5` for the Linux secret store -- and every interaction
 below is a subprocess, which is the same rule that applies to `cosign` and
 `oras`.
 
@@ -61,12 +63,13 @@ Taken from the source. On macOS, from `internal/runtime/hull.go` unless another
 file is named:
 
 ```
+hull --version                          # does this hull boot a digest? (0.1.0-rc23 and later)
 hull assets pull                        # HULL_BOOT_ASSETS=<dir> in the environment
 hull assets dir
 hull ps
 hull ps -a                              # falls back to `hull ps` if -a is refused
 hull run --detach --name <name>
-     --hypervisor <vz|hvi|qemu> --net <shared|none>
+     --hypervisor <vz|hvi|qemu> --net <shared|none>   # none is --network offline
      --pull <missing|always|never> --mem <MB> --cpus <n>
      [--rootfs-type <block|virtiofs|9pfs>]
      [--annotation com.urunc.unikernel.bootKernel=<path>]
@@ -79,9 +82,22 @@ hull exec [-t] [--cwd <dir>] [-u <user>] [--env <NAME>]... <name> -- <cmd>...
 hull logs [--follow] [--tail <n>] <name>
 hull stop <name>
 hull rm <name>
+hull network-gateway --help             # does this hull enforce a policy? (--egress-default)
 hull network-gateway --socket <path> --qemu-socket <path>.qemu
      --subnet 198.18.0.0/24 --gateway-ip 198.18.0.1   # internal/runtime/gateway.go
+hull network-gateway --socket <path> --qemu-socket <path>.qemu
+     --subnet <a /30 of its own> --gateway-ip <first address on it>
+     [--egress-default <allow|deny>]                  # an isolated sandbox, or one
+     [--egress-allow <rule>]... [--egress-deny <rule>]...   # carrying a policy
 ```
+
+`hull --version` is the one version brig reads, and it reads it for one
+decision: a hull from 0.1.0-rc23 boots a digest reference from its own store,
+so brig pins the image it verified; an older one boots the tag, and brig says
+so. An unreadable answer counts as pinning. `network-gateway --help` is read
+for one word, `--egress-default`, before a sandbox carrying a policy is
+booted: a gateway that does not take the flag would drop the rules on the
+floor, so brig refuses the run instead.
 
 brig picks that subnet from 198.18.0.0/15, the range RFC 2544 reserves for
 network benchmarking: it is never routed on the public internet and almost
@@ -100,24 +116,30 @@ and it is also named in brig's error output when a sandbox will not come up.
 On Linux, from `internal/runtime/nerdctl.go`:
 
 ```
+nerdctl image inspect --format {{index .RepoDigests 0}} <ref>   # the digest to pin
 nerdctl ps --filter name=^<name>$ --format {{.Names}}
 nerdctl ps -a --format {{.Names}}\t{{.Status}}
+nerdctl network ls --format {{.Name}}
+nerdctl network create <name>            # --network isolated: a network per sandbox
+nerdctl network rm <name>                # with the sandbox, and by rm --all
 nerdctl run --detach --name <name>
      --runtime io.containerd.urunc.v2         # BRIG_CONTAINERD_RUNTIME overrides
      --memory <MB>m --cpus <n>
-     [--pull <missing|always|never>] [--network none]
+     [--pull <missing|always|never>]
+     [--network none | --network <name>]      # offline, or isolated
      [--annotation com.urunc.unikernel.bootKernel=<path>]
      [--annotation com.urunc.unikernel.bootInitrd=<path>]
      [-v <host>:<guest>[:ro]]... [--tmpfs <path>:<options>]...
      [-e <NAME>]... <image> sleep infinity
 nerdctl exec -i [-t] [-w <dir>] [-u <user>] [-e <NAME>]... <name> <cmd>...
+nerdctl logs [--follow] [--tail <n>] <name>
 nerdctl stop <name>
 nerdctl rm <name>
 ```
 
 The container is parked on `sleep infinity` because a container exits when its
 command does, and the sandbox has to outlive the exec that used it. As on
-macOS, `nerdctl logs <name>` is only ever suggested.
+macOS, `nerdctl logs <name>` is what `brig logs <ref>` runs.
 
 Two commands are not aimed at a runtime but run on the same paths:
 
@@ -154,17 +176,23 @@ the command line even then.
 4. Otherwise PATH: `hull` for the hull backend, and `nerdctl` then `docker` for
    the other one.
 
-What brig asks the runtime about itself is short. It never asks for a version.
-It asks hull where its boot assets live (`hull assets dir`), because they sit
-under hull's own store and a path compiled into brig would drift silently, and
-it asks either runtime which sandboxes exist and what state they are in (`ps`).
-`brig status` prints what it settled on, as `runtime hull (/opt/homebrew/bin/hull)`.
+What brig asks the runtime about itself is short. It asks hull where its boot
+assets live (`hull assets dir`), because they sit under hull's own store and a
+path compiled into brig would drift silently; it asks either runtime which
+sandboxes exist and what state they are in (`ps`); and it asks hull two
+capability questions, `hull --version` for digest pinning and
+`network-gateway --help` for policy enforcement, both described above.
+`brig info <ref>` prints what it settled on, as
+`runtime hull (/opt/homebrew/bin/hull)`, and `brig doctor` reports the
+runtime's version beside the rest of the host.
 
-The absence of a version check is deliberate but has a consequence worth
-knowing: brig degrades one feature at a time rather than refusing an old build
-outright. A hull without `assets dir` falls back to `~/.hull/assets`, and a
-runtime without `ps -a` falls back to the plain listing. A hull too old for a
-flag brig passes fails at that flag, with hull's own message.
+Neither answer gates the run outright, and that is deliberate: brig degrades
+one feature at a time rather than refusing an old build. A hull without
+`assets dir` falls back to `~/.hull/assets`, a runtime without `ps -a` falls
+back to the plain listing, and a hull that cannot pin a digest boots the tag
+and says so. The one refusal is a policy on a gateway that cannot enforce it.
+A hull too old for a flag brig passes fails at that flag, with hull's own
+message.
 
 ## What brig requires of each
 

--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -313,9 +313,8 @@ brig: a secret name starts with a letter, and "1password" starts with "1"
 
 The reason it is this narrow is that the name is three things at once. It is
 the keychain account, where a space or a slash would make the item awkward to
-address by hand. It is a word in brig's own error messages. And once profiles
-can reference stored secrets ([#7](https://github.com/brig-sh/brig/issues/7)),
-it is the tail of `ref: secrets.<name>` -- which is what rules out the `.`
+address by hand. It is a word in brig's own error messages. And a profile
+references it as the tail of `ref: secrets.<name>` -- which is what rules out the `.`
 specifically, since a dot would make that reference ambiguous. A leading digit
 reads as a number rather than a name, and a leading dash reads as a flag
 wherever the name is typed.
@@ -377,13 +376,17 @@ nothing told you about:
 
 ```console
 $ brig secret create gh-token
-brig: no secret store on this platform: a D-Bus session bus is running but no Secret Service answers on it. Install a keyring (gnome-keyring or KWallet, both speak the Secret Service API) and log in to a session that starts it, or bind the secret to a command instead with `brig secret import <profile> --from-command '<sh>'`, which holds no plaintext at rest
+brig: no secret store on this platform: a D-Bus session bus is running but no Secret Service answers on it. Install a keyring (gnome-keyring or KWallet, both speak the Secret Service API) and log in to a session that starts it, or read the secret once from a command's output with `brig secret import <profile> --from-command '<sh>'`, which stores it like any other import
 ```
 
 It says so *before* asking for a value. The check happens ahead of the read
 from stdin, so you are not sent off to find a token only to be told afterwards
-that there is nowhere to put it. Binding the secret to a command with
-`--from-command` is the other way out, and holds no plaintext at rest.
+that there is nowhere to put it. `--from-command` is the other way out for a
+value that lives in an external secret manager: the import runs the command
+once, takes its stdout, and stores that the way it stores any other import.
+It still needs a store to write into, so on a host with no keyring it is a
+way to fill the store from somewhere other than a file, not a way around
+having one.
 
 ## Errors you are likely to meet
 
@@ -402,8 +405,8 @@ point of the table: the error is the second entry point into these docs.
 | `the value for "x" is N bytes, and the keychain takes at most M` | over [the size limit](#the-size-limit) |
 | `deleting "x" cannot be undone, and there is no terminal to ask on. Pass -y to answer in advance: …` | a cron job or a unit file. `-y` is the answer given ahead |
 | `a secret name holds letters, digits, - and _, ...` | see [Naming a secret](#naming-a-secret) |
-| `no secret store on this platform: … no Secret Service answers on it …` | Linux with no keyring on the session bus. Install `gnome-keyring` or KWallet and log in to a session that starts it, or bind the secret with `--from-command` |
-| `no secret store on this platform: … a keyring is running but has no default collection …` | Linux with a keyring but no default collection yet (a headless or freshly provisioned session). Unlock your keyring once from a desktop session, which creates it, or bind the secret with `--from-command` |
+| `no secret store on this platform: … no Secret Service answers on it …` | Linux with no keyring on the session bus. Install `gnome-keyring` or KWallet and log in to a session that starts it |
+| `no secret store on this platform: … a keyring is running but has no default collection …` | Linux with a keyring but no default collection yet (a headless or freshly provisioned session). Unlock your keyring once from a desktop session, which creates it |
 | `"x" is a secret, not a profile, and import takes the profile that declares it: …` | `import`'s first argument is a profile. The message names the one that declares the secret you typed |
 | `nothing to import for "x": … held no value` | the profile's sources exist and none of them had anything. Usually: run the agent on the host once to log in |
 | `"x" is already stored and brig did not put it there, so importing would replace a value you supplied` | you created it by hand. `-y` if replacing it is what you meant |
@@ -420,8 +423,8 @@ value comes down a pipe rather than sitting in your history:
 ```console
 $ printf %s 'ghp_16C7e42F292c6912E7710c838347Ae178B4a' | brig secret create gh-token
 $ brig secret ls
-NAME      UPDATED
-gh-token  2026-08-15 21:09
+NAME      UPDATED           FROM
+gh-token  2026-08-15 21:09  -
 ```
 
 Use it. `claude-code` declares `gh-token`, so nothing else is needed -- the

--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -136,7 +136,7 @@ note: claude-desktop also declares claude-credentials, so this fills it there to
 ```
 
 Where it looks is data in the profile, not knowledge in brig: each secret
-carries a `sources:` list and the first that exists wins. `brig profiles` shows
+carries a `sources:` list and the first that exists wins. `brig agent ls` shows
 which names a profile can import and which it cannot, and
 [profiles.md](profiles.md) is how to declare them in one of your own.
 
@@ -428,7 +428,7 @@ Use it. `claude-code` declares `gh-token`, so nothing else is needed -- the
 name in the store is the binding:
 
 ```console
-$ brig env claude-code
+$ brig info claude-code
 ...
 brig: forwarding to guest:
 brig:   GH_TOKEN(secret)
@@ -436,7 +436,7 @@ brig: never forwarded for claude-code: ANTHROPIC_API_KEY ANTHROPIC_AUTH_TOKEN (t
 ```
 
 `(secret)` says the value came from brig's store rather than from your shell.
-`brig env` reports; `brig run claude-code` does it.
+`brig info` reports; `brig run claude-code` does it.
 
 An exported `GH_TOKEN` still wins, because the profile binds the name as a
 chain -- `refs: [env.GH_TOKEN, secrets.gh-token]` -- so

--- a/docs/security.md
+++ b/docs/security.md
@@ -28,6 +28,7 @@ Which of them you got is the `ISOLATION` row of the execution envelope, printed
 before every boot and by `brig info`:
 
 ```
+ISOLATION    microVM (hull, hvi backend)
 ISOLATION    microVM (hull, vz backend)
 ISOLATION    microVM (nerdctl over containerd, io.containerd.urunc.v2)
 ISOLATION    container (docker over containerd, runc: the guest shares the host kernel)
@@ -90,10 +91,12 @@ deprecated `forward:` spelling of one -- brig still reads the named variable
 from its own environment, so whatever populates that environment remains a
 usable backend for those.
 
-There is no secret store on Linux yet. A profile whose secrets are *optional*
-degrades there rather than failing: the run boots and the agent asks for a
-login, which is what `claude-code` does. A **required** secret does fail
-outright, because there is nowhere on that host to read it from.
+On Linux the store is a Secret Service keyring on your session bus,
+gnome-keyring or KWallet ([secrets.md](secrets.md#linux)). A host with no
+keyring has no store, and a profile whose secrets are *optional* degrades
+there rather than failing: the run boots and the agent asks for a login,
+which is what `claude-code` does. A **required** secret does fail outright,
+because there is nowhere on that host to read it from.
 
 Values are re-read on every exec, so a rotated credential is picked up without
 restarting the sandbox. Nothing is written into the workspace.
@@ -326,8 +329,9 @@ What that means for the things this document is about:
   import verb: the dialog appears when you asked for it, once, and never again
   on the boot path.
 
-There is no store on Linux yet; `brig secret` says so rather than falling back
-to a file, which would be a downgrade nothing told you about.
+On Linux the store is a Secret Service keyring, and a host without one has no
+store: `brig secret` says which half is missing rather than falling back to a
+file, which would be a downgrade nothing told you about.
 
 ## Writing into the workspace
 
@@ -444,7 +448,8 @@ is the case that stops.
 
 `BRIG_VERIFY=require` refuses anything that cannot be positively verified,
 third-party images included. `BRIG_VERIFY=off` skips the check. A typo in that
-setting falls back to `warn` rather than silently disabling it.
+setting refuses the run, naming the three values, rather than being read as
+either of them.
 
 Point `BRIG_VERIFY_REGISTRY`, `BRIG_VERIFY_IDENTITY` and `BRIG_VERIFY_ISSUER`
 at your own registry and workflow if you publish signed images yourself.
@@ -604,7 +609,8 @@ it.
 It does not sandbox the agent from the network by default, on any backend. A
 sandbox nobody attached a policy to has unrestricted egress, which is what
 every sandbox had before policies existed and what `brig run <agent>` gets on a
-fresh install.
+fresh install. `--network offline` is the one posture with no route out at
+all, on every backend.
 
 Attach one and that changes, on `hvi`: the rules are enforced at the network
 gateway brig gives that sandbox, and a run that cannot enforce them is refused
@@ -612,10 +618,10 @@ rather than booted unconstrained -- see [docs/policies.md](policies.md). On
 `vz`, on `qemu` and on Linux there is no policy to be had at all, and outbound
 traffic is whatever the runtime allows.
 
-It does not promise that one sandbox cannot reach another. What happens
-depends on the backend. brig asks every runtime for its shared network, with
-no setting to say otherwise. What the runtime then does with that request is
-the runtime's own behaviour, not brig's. The measurements are in
+It does not promise that one sandbox cannot reach another under the default
+`shared` network. What happens there depends on the backend: brig asks the
+runtime for its shared network, and what the runtime does with that request
+is the runtime's own behaviour, not brig's. The measurements are in
 [docs/manual-tests/sandbox-reachability.md](manual-tests/sandbox-reachability.md).
 
 | backend | can one sandbox reach another? |

--- a/docs/security.md
+++ b/docs/security.md
@@ -160,7 +160,7 @@ environment:
   anyway.
 - A variable on the profile's `deny` list is refused, with the reason.
 
-`brig env <agent>` reports the guest's environment, by name, and fails the
+`brig info <agent>` reports the guest's environment, by name, and fails the
 same way a run would if a declared secret cannot be resolved. It never
 prints a value: a secret-sourced variable comes back annotated, e.g.
 `GH_TOKEN(secret)`, never with the value itself. A credential delivered as a
@@ -398,7 +398,7 @@ one in the way is either something you put there deliberately, or the sandbox
 reaching for the host. Neither is a case for retrying: remove the link, or
 point the workspace somewhere else.
 
-`--workspace` pointed at a symlink is refused for the same reason, with the
+`--home` pointed at a symlink is refused for the same reason, with the
 same kind of message, and is fixed by naming the real directory.
 
 ## Guest images
@@ -648,7 +648,7 @@ brig owns no network to give: a run asking for it there is stopped and told
 which backend implements it, rather than booted onto the shared network under a
 row claiming otherwise. And it is about reachability, not resources -- an
 isolated sandbox is one process and one network more than a shared one, which
-is what `brig reset` prunes.
+is what `brig rm --all` prunes.
 
 It does not filter what the agent writes to your terminal. `brig` hands the
 tty over with `syscall.Exec` and is gone before the agent produces a byte,

--- a/docs/support.md
+++ b/docs/support.md
@@ -8,8 +8,11 @@ needs a Mac with Apple Silicon, or a Linux machine.
 | Mac with Apple Silicon (M1 or newer), macOS 15 or later | Yes |
 | Mac with Apple Silicon (M1 or newer), macOS 14 | Yes, if you start it with `BRIG_HYPERVISOR=vz` |
 | Intel Mac | No, brig needs Apple Silicon |
-| Linux, x86-64 or ARM64 | Yes, with `nerdctl` or Docker installed |
+| Linux, x86-64 or ARM64 | Yes, with `nerdctl` and containerd installed |
 
-On macOS, brig boots the virtual machine itself, so there is nothing else to
-install. On Linux it uses nerdctl and containerd, and Docker works in their
-place.
+On macOS the virtual machine is booted by [hull](https://github.com/brig-sh/hull),
+which the Homebrew cask installs with brig; a from-source brig needs hull on
+`PATH`. On Linux it uses nerdctl and containerd with the urunc shim. Docker is
+accepted in nerdctl's place for an image that carries its own kernel; a profile
+marked `genericBoot`, which is six of the eight shipped ones, is refused on
+Docker because it does not pass the boot annotations through to the runtime.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -113,7 +113,7 @@ not yours.
 Check the reference you are booting:
 
 ```bash
-brig env claude       # shows the image, among other things
+brig info claude      # shows the image, among other things
 ```
 
 Read the runtime's error for which of the two it is. If it is the wrong
@@ -206,7 +206,7 @@ loses it. See [Credentials](../README.md#credentials).
 First, ask brig what it would forward, by name:
 
 ```bash
-brig env claude
+brig info claude
 ```
 
 That reports what reaches the guest and whether the guest will be
@@ -253,7 +253,7 @@ Renew the login on the host and import it again, as the second line says.
 Renewing on the host alone does not help: a run reads brig's stored copy, and
 nothing re-reads the host until an import says so.
 
-## The sandbox restarted when I ran exec
+## The sandbox restarted when I ran sh
 
 ```
 brig: the running sandbox is not mounting /Users/alex/work -- its share went
@@ -263,7 +263,7 @@ Restarting it; any other session using this sandbox will be disconnected.
 
 brig compares the workspace the running sandbox has against the one this
 command asked for, and restarts the sandbox when they differ. Passing an
-explicit `--workspace` (or `BRIG_WORKSPACE`) that does not match the default
+explicit `--home` (or `BRIG_WORKSPACE`) that does not match the default
 the sandbox was started with trips this: brig reads it as the share having
 gone stale and recreates the VM.
 
@@ -273,11 +273,11 @@ Check which workspace the sandbox is on:
 brig ls               # shows each sandbox and its workspace
 ```
 
-If you did not mean to change the workspace, drop the `--workspace` flag so
-exec addresses the same session the sandbox already has. There is no flag today
+If you did not mean to change the workspace, drop the `--home` flag so
+`sh` addresses the same session the sandbox already has. There is no flag today
 that runs against a different workspace without this restart; a fix is in
 flight, and until it lands the honest description is that an explicit
-`--workspace` that differs from the remembered default restarts the sandbox.
+`--home` that differs from the remembered default restarts the sandbox.
 
 ## brew trust is not a command
 
@@ -317,7 +317,7 @@ files in there, so a link in the way was put there on purpose or by the
 sandbox reaching for the host. Nothing was written.
 
 This is not a case for retrying. Inspect the path the message names and remove
-the link, or point the workspace somewhere else. Pointing `--workspace` at a
+the link, or point the workspace somewhere else. Pointing `--home` at a
 symlink is refused the same way, and is fixed by naming the real directory.
 [docs/security.md](security.md#writing-into-the-workspace) explains why the
 refusal exists.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -8,6 +8,32 @@ the microVM runtime (`hull` on macOS, `nerdctl` on Linux), cosign, or
 Homebrew. Where a message is not brig's, it says so, because that is the first
 thing to know when the wording does not match anything in brig.
 
+Before reading further, run `brig doctor`. It checks the host, the
+hypervisor, the runtime and its version, the boot assets, cosign, the
+profiles, the secret store and brigd, one line each, and says what to do
+about a line that is not `ok`; `brig doctor <agent>` checks that agent's
+image too. `--json` is for a script or a bug report.
+
+## Exit codes
+
+A script does not have to parse the message. Every failure is reported on
+`stderr` with one of these codes, which are stable across releases:
+
+| code | meaning |
+| --- | --- |
+| `0` | success |
+| `1` | general failure -- something ran and did not finish |
+| `2` | usage error -- an unknown flag, a stray argument, a value in the wrong place |
+| `3` | no such profile or sandbox -- the name resolves to nothing. `brig rm` and `brig logs` on a ref with no sandbox exit here rather than handing the runtime's "instance not found" back as `1` |
+| `4` | runtime unavailable -- none is installed, `BRIG_RUNTIME_BIN` points at nothing, or the runtime could not be asked |
+| `5` | image verification refused the boot |
+| `6` | a credential the run needed could not be resolved |
+
+`brig stop` on a sandbox that is not running exits `0`: stopped is the state
+it asked for. `brig run --json` prints one JSON line with the agent's own exit
+status after it exits, so a caller can tell "brig refused" from "the agent
+failed".
+
 ## The sandbox never became ready
 
 ```
@@ -60,23 +86,36 @@ BRIG_HYPERVISOR=vz brig run claude
 ```
 
 For good, put `BRIG_HYPERVISOR=vz` in your shell profile, or upgrade to macOS
-15 or newer. macOS 26 is what hull is developed and tested on. A check that
-refuses `hvi` on an older macOS with this message, instead of letting the VMM
-crash, is in flight.
+15 or newer. macOS 26 is what hull is developed and tested on.
 
-## No microVM runtime found on PATH
-
-```
-brig: no microVM runtime found on PATH. brig drives hull on macOS: see
-https://github.com/brig-sh/brig#macos. Or point BRIG_RUNTIME_BIN at a build
-```
-
-On Linux the message is different, because the runtime there is `nerdctl`:
+Current releases do not get this far. brig reads the macOS version before it
+asks the runtime for anything, and refuses an `hvi` run on macOS 14 with the
+cause and the way past it:
 
 ```
-brig: no container runtime found: install nerdctl, or point
-BRIG_RUNTIME_BIN at one
+brig: the hvi hypervisor needs macOS 15 or newer (this is 14.5): its in-kernel
+interrupt controller does not exist here. Set BRIG_HYPERVISOR=vz for this run,
+or upgrade macOS
 ```
+
+The `dyld` log above is what an older brig left you to find.
+
+## No runtime found on PATH
+
+```
+brig: no runtime found on PATH: brig drives hull on macOS, and none was there.
+See https://github.com/brig-sh/brig#macos, or point BRIG_RUNTIME_BIN at a build
+```
+
+On Linux the second half is different, because the runtime there is `nerdctl`:
+
+```
+brig: no runtime found on PATH: install nerdctl, or point BRIG_RUNTIME_BIN at one
+```
+
+Either way the exit code is `4`. A `BRIG_RUNTIME_BIN` or a profile
+`runtimeBin` that names something missing is the same code with the setting
+named: `BRIG_RUNTIME_BIN is hull2, which is not on PATH`.
 
 brig delegates every boot to a runtime it does not ship, and could not find
 one. On macOS the cask depends on hull, so this usually means a from-source
@@ -168,16 +207,19 @@ brig: not a terminal, so there is nobody to ask: refusing. Set
 BRIG_VERIFY=off to boot it regardless.
 ```
 
-Answering no aborts:
+Answering no aborts, with exit code `5`:
 
 ```
-brig: aborted: the image failed verification. Pull it again, or set
-BRIG_VERIFY=off if you know why it fails
+brig: aborted: the image failed verification. Pull it again (BRIG_PULL=always),
+or set BRIG_IMAGE to a digest you have checked yourself
 ```
 
 The usual innocent cause is a stale local copy. Pull the image again
 (`BRIG_PULL=always brig run claude`) and let the check run against the current
-registry. If it still fails and you do not know why, do not boot it. An image
+registry. If it still fails and you do not know why, do not boot it; naming a
+digest you have checked yourself is the deliberate way past it, and
+`BRIG_VERIFY=off` is not offered here because disabling the control that
+caught it is not a remedy. An image
 published by someone else warns rather than stopping, because bring-your-own
 images are supported; a failure under brig's registry is the one case that
 stops.

--- a/install.sh
+++ b/install.sh
@@ -4,13 +4,16 @@
 #   curl -fsSL https://raw.githubusercontent.com/brig-sh/brig/main/install.sh | sh
 #
 # Downloads the latest release for this platform, checks it against the
-# published checksums, and installs brig and brigd. Homebrew is the better
-# path on macOS -- it also brings hull, the runtime brig needs there:
+# published checksums, and installs brig and brigd. The archive also carries
+# the shell completion scripts under completions/, which this script leaves
+# for you to install (docs/completions.md). Homebrew is the better path on
+# macOS -- it also brings hull, the runtime brig needs there, and installs
+# the completions:
 #
 #   brew tap brig-sh/brig && brew trust brig-sh/brig && brew install --cask brig
 #
 # Override the destination with BRIG_INSTALL_DIR, or the version with
-# BRIG_VERSION=v0.1.0-rc4.
+# BRIG_VERSION=v0.1.0-rc17.
 set -eu
 
 REPO=brig-sh/brig

--- a/internal/secret/secretservice_linux.go
+++ b/internal/secret/secretservice_linux.go
@@ -167,23 +167,23 @@ func openService(service string) (*secretService, error) {
 }
 
 // errNoBus and errNoService are the two shapes of the same refusal, and each
-// says which half is missing and both ways out: install a keyring, or bind the
-// secret to a command that holds no plaintext at rest. Both fixes appear in one
+// says which half is missing and both ways out: install a keyring, or take the
+// secret from a command's output once. Both fixes appear in one
 // message the way the darwin messages read, because a user who cannot install a
 // keyring still has the second door.
 func errNoBus(err error) error {
 	return fmt.Errorf("%w: no D-Bus session bus to reach a keyring on. Install a keyring "+
 		"(gnome-keyring or KWallet, both speak the Secret Service API) and log in to a session "+
-		"that starts it, or bind the secret to a command instead with "+
-		"`brig secret import <profile> --from-command '<sh>'`, which holds no plaintext at rest: %v",
+		"that starts it, or read the secret once from a command's output with "+
+		"`brig secret import <profile> --from-command '<sh>'`, which stores it like any other import: %v",
 		ErrUnsupported, err)
 }
 
 func errNoService() error {
 	return fmt.Errorf("%w: a D-Bus session bus is running but no Secret Service answers on it. "+
 		"Install a keyring (gnome-keyring or KWallet, both speak the Secret Service API) and log in "+
-		"to a session that starts it, or bind the secret to a command instead with "+
-		"`brig secret import <profile> --from-command '<sh>'`, which holds no plaintext at rest",
+		"to a session that starts it, or read the secret once from a command's output with "+
+		"`brig secret import <profile> --from-command '<sh>'`, which stores it like any other import",
 		ErrUnsupported)
 }
 
@@ -193,13 +193,13 @@ func errNoService() error {
 // that the default sits at some well-known path. Nothing has created it: a
 // headless or freshly provisioned session never unlocked a login keyring, so
 // brig has nowhere to store into. Both ways out again, in the voice of the two
-// above: an unlock from a desktop session is what creates the default, or bind
-// the secret to a command that holds no plaintext at rest.
+// above: an unlock from a desktop session is what creates the default, or take
+// the secret from a command's output once.
 func errNoDefaultCollection() error {
 	return fmt.Errorf("%w: a keyring is running but has no default collection to store into. "+
-		"Unlock your keyring once from a desktop session, which is what creates it, or bind the "+
-		"secret to a command instead with `brig secret import <profile> --from-command '<sh>'`, "+
-		"which holds no plaintext at rest",
+		"Unlock your keyring once from a desktop session, which is what creates it, or read the "+
+		"secret once from a command's output with `brig secret import <profile> --from-command '<sh>'`, "+
+		"which stores it like any other import",
 		ErrUnsupported)
 }
 

--- a/internal/secret/secretservice_linux_test.go
+++ b/internal/secret/secretservice_linux_test.go
@@ -109,6 +109,7 @@ func TestOpenReportsNoBus(t *testing.T) {
 			t.Errorf("open() = %v, want it to mention %q", err, want)
 		}
 	}
+	assertFromCommandIsHonest(t, err)
 }
 
 func TestOpenReportsNoService(t *testing.T) {
@@ -126,6 +127,21 @@ func TestOpenReportsNoService(t *testing.T) {
 		if !strings.Contains(err.Error(), want) {
 			t.Errorf("open() = %v, want it to mention %q", err, want)
 		}
+	}
+	assertFromCommandIsHonest(t, err)
+}
+
+// The way out each refusal offers has to describe what --from-command does:
+// the import runs the command once and stores its output like any other
+// import (cmd/brig/secretimport.go, readFor). An earlier wording promised it
+// "holds no plaintext at rest", which it does not.
+func assertFromCommandIsHonest(t *testing.T, err error) {
+	t.Helper()
+	if strings.Contains(err.Error(), "plaintext at rest") {
+		t.Errorf("%v: claims --from-command keeps no plaintext at rest; the import stores the command's output", err)
+	}
+	if !strings.Contains(err.Error(), "stores it like any other import") {
+		t.Errorf("%v: does not say --from-command stores the value", err)
 	}
 }
 
@@ -150,6 +166,7 @@ func TestResolveCollectionReportsNoDefaultCollection(t *testing.T) {
 			t.Errorf("resolveCollection() = %v, want it to mention %q", err, want)
 		}
 	}
+	assertFromCommandIsHonest(t, err)
 }
 
 // swapSeams replaces dialBus and hasSecretService for a test and returns a

--- a/script/check-guest-image.sh
+++ b/script/check-guest-image.sh
@@ -15,7 +15,7 @@
 #              last element, which is how brig derives it too. Its binary: is
 #              the agent CLI, checked for when the profile names one
 #
-# The boot goes through brig: `BRIG_IMAGE=<image> brig create <profile>`, torn
+# The boot goes through brig: `BRIG_IMAGE=<image> brig run -d <profile>@image-check`, torn
 # down with `brig rm`. That is the point of the script rather than an
 # implementation detail. An image booted bare as a container -- `hull run
 # <image>` with no profile behind it -- runs with the runtime's default
@@ -151,9 +151,9 @@ printf 'runtime: %s (%s)\n' "$KIND" "${RT:-none found}"
 if dry; then
 	printf '\nBRIG_DRY_RUN is set, so nothing was booted and nothing was checked.\n'
 	printf 'The boot would be:\n'
-	printf '  BRIG_IMAGE=%s BRIG_VERIFY=off %s create %s --name image-check --workspace <scratch>\n' \
+	printf '  BRIG_IMAGE=%s BRIG_VERIFY=off %s run -d %s@image-check --home <scratch>\n' \
 		"$IMAGE" "$BRIG_BIN" "$PROFILE"
-	printf '  %s rm %s --name image-check --workspace <scratch>\n' "$BRIG_BIN" "$PROFILE"
+	printf '  %s rm %s@image-check --home <scratch>\n' "$BRIG_BIN" "$PROFILE"
 	printf 'and each requirement would run as `%s exec -u root <sandbox>`.\n' \
 		"$(basename "${RT:-$KIND}")"
 	exit 0
@@ -184,7 +184,7 @@ cleanup() {
 	# Unconditionally, not only when the boot printed a name: a create that
 	# failed after the sandbox was up leaves one behind holding the name, and
 	# `brig rm` on a sandbox that was never created is a no-op.
-	"$BRIG_BIN" rm "$PROFILE" --name image-check --workspace "$WORKSPACE" >/dev/null 2>&1
+	"$BRIG_BIN" rm "$PROFILE@image-check" --home "$WORKSPACE" >/dev/null 2>&1
 	if [ -n "$LISTED" ]; then
 		"$RT" rm -f "$LISTED" >/dev/null 2>&1
 	fi
@@ -210,7 +210,7 @@ export BRIG_IMAGE="$IMAGE"
 export BRIG_VERIFY=off
 
 printf '\n'
-if BOOTED="$("$BRIG_BIN" create "$PROFILE" --name image-check --workspace "$WORKSPACE" 2>"$BOOTLOG")"; then
+if BOOTED="$("$BRIG_BIN" run -d "$PROFILE@image-check" --home "$WORKSPACE" 2>"$BOOTLOG")"; then
 	NAME="$(printf '%s\n' "$BOOTED" | tail -1 | tr -d '[:space:]')"
 else
 	# A create that fails during credential delivery leaves the sandbox
@@ -371,7 +371,7 @@ run 'rm' rm 'removes a planted symlink rather than following it' -- \
 run 'mount, tmpfs' mount 'covers a directory so a credential stays off disk' -- \
 	mount -t tmpfs -o size=1m,mode=0700,nodev,nosuid tmpfs "$SCRATCH/d"
 run 'sleep' sleep 'the container command on the nerdctl path' -- sleep 0
-run 'bash' bash 'brig shell' -- bash -lc 'exit 0'
+run 'bash' bash 'brig sh' -- bash -lc 'exit 0'
 
 if [ -n "$BINARY" ]; then
 	run "$BINARY" "$BINARY" "the profile's binary:" -- "$BINARY" --version


### PR DESCRIPTION
## Summary

The docs describe a brig a few releases old, and two strings in the binary do too. Most pages still teach the retired `brig profile`, `brig env` and `brig exec` verbs. The README does not mention `brig doctor`, `--json`, the `brig logs` flags or `BRIG_POLICY_DIR`. A few claims are simply wrong now: there is a Linux secret store, a BRIG_VERIFY typo refuses the run instead of falling back to warn, go.mod has three direct dependencies, `brig status` does not exist, and `--from-command` stores the command's output like any other import.

This patch fixes the strings in the binary and brings the README and docs/ back in line with the code. The code commit is message text only: the two `brig profiles` pointers in policy attach/check, the `--skills` help text, and the three Linux keyring refusals. Every replacement verb comes from the built binary's `--help`, every quoted error string from the function that prints it, and the `brig info` example is what the binary prints.

## Related issues

None.

## Changes

- `fix(cli)`: unknown-profile message on `policy attach` and `policy check` says `brig agent ls`; `--skills` help says the host's `~/.claude` is copied into the guest home; the Linux keyring refusals say `--from-command` reads the command once and stores the value like any other import. Tests assert both.
- README: Linux Secret Service backend; `brig doctor`, global `--json`, `brig logs --follow/--tail/--raw`, BRIG_POLICY_DIR in the tables; the StrictBool grammar and which keys honour `BRIG_<AGENT>_`; sbx comparison names `--network offline/isolated` and policies; `brig info` example from the binary (hvi, NETWORK row); BRIG_HYPERVISOR default only when the profile is silent; install.sh and its cosign step; cursor as an example profile.
- Retired spellings replaced across docs/, the bug template and `script/check-guest-image.sh` (`brig run -d <profile>@image-check --home`), with `bash -n` clean.
- Claims fixed in secrets.md, security.md, runtimes.md (three deps, `hull --version` and `network-gateway --help` probes, complete hull/nerdctl command lists, hvi-vmm public), CONTRIBUTING.md, the two ci.yml comments, support.md, non-goals.md, SECURITY.md, assets/README.md, install.sh header (behaviour unchanged), troubleshooting.md (current error strings, exit-code section incl. rm/logs exit 3, `brig doctor`), manual-tests, completions.md, quickstart.md, profiles.md.
- hull-assets is named as the OCI artifact `ghcr.io/nofireai/hull-assets` with the build repository noted as not public; no link to a private repository anywhere.

## Checklist

- [x] `make all` passes (vet, test, build)
- [x] `script/smoke.sh` passes
- [x] I have added or updated tests covering the change
- [x] I have run `go test ./... -race`, if the change touches concurrency, subprocesses or the daemon
- ~~I have exercised the change against a real runtime (`brig run <agent>`), if it touches the run, exec or credential path~~
- [x] I have updated the affected docs (README, `docs/security.md`, `docs/profiles.md`, `docs/brigd.md`)

## Credentials and the sandbox boundary

`internal/secret/secretservice_linux.go` changes only the text of the three refusals (`errNoBus`, `errNoService`, `errNoDefaultCollection`). No promise is affected: nothing about what is read, stored or forwarded moves. The wording previously claimed `--from-command` holds no plaintext at rest, which `readFor` in `cmd/brig/secretimport.go` does not do. `TestOpenReportsNoBus`, `TestOpenReportsNoService` and `TestResolveCollectionReportsNoDefaultCollection` in `secretservice_linux_test.go` now assert through `assertFromCommandIsHonest` that each message says the value is stored and never says otherwise; the file is Linux-only, so here it was compiled with `GOOS=linux go vet ./...` and `GOOS=linux go test -c ./internal/secret/`, and runs in CI on ubuntu-latest.

