### PR TITLE
feat(wrap): Measure the boot instead of quoting it

### DIFF
--- a/cmd/brig/main.go
+++ b/cmd/brig/main.go
@@ -625,6 +625,7 @@ func dispatch(args []string) error {
 		if err := cfg.EnsureRunning(set); err != nil {
 			return err
 		}
+		recordBoot(cfg)
 		// Under --json, down the child path so brig survives the shell and reports
 		// its exit status on a Run line, the same handover an agent gets. Only sh
 		// reaches here with jsonRun set -- shell is refused above.
@@ -673,6 +674,7 @@ func runAgent(cfg *wrap.Config, set creds.Set, t profile.Profile, tail []string,
 	if err := cfg.EnsureRunning(set); err != nil {
 		return err
 	}
+	recordBoot(cfg)
 	// Each branch below has a --json form: the object stands in for the text it
 	// would otherwise print, because a script asked for one machine-readable line
 	// and a bare name or a warning beside it would be the noise --json exists to
@@ -2939,6 +2941,21 @@ var jsonRun *jsonRunContext
 type jsonRunContext struct {
 	ref     string
 	sandbox string
+	// boot is how long the sandbox took to become reachable, in milliseconds,
+	// when this invocation booted it; nil when it found one already running.
+	boot *int64
+}
+
+// recordBoot copies the measured boot time onto the Run object's context, once
+// EnsureRunning has returned. A run without --json has no jsonRun and nothing
+// to record; a run that reused a sandbox has no BootTime and records nothing,
+// so the field's absence says "not booted here" rather than "booted in zero".
+func recordBoot(cfg *wrap.Config) {
+	if jsonRun == nil || cfg.BootTime == 0 {
+		return
+	}
+	ms := cfg.BootTime.Milliseconds()
+	jsonRun.boot = &ms
 }
 
 // detectRuntimeFor is the seam the run-line tests replace, so a test can drive a
@@ -2950,17 +2967,25 @@ var detectRuntimeFor = runtime.DetectFor
 // runData is the payload of a Run object: what a --json run says about itself
 // once the agent has run, or once brig has refused to run it.
 //
-// error and signal are omitempty because each names a case that did not always
-// happen: error only on a brig refusal, signal only on an agent the kernel
-// killed. ref and sandbox are always present, so a consumer reads them
-// unconditionally. See #110 and the field rule in jsonout.go.
+// error, signal and bootMillis are omitempty because each names a case that
+// did not always happen: error only on a brig refusal, signal only on an agent
+// the kernel killed, bootMillis only when this invocation booted the sandbox
+// rather than finding it running. ref and sandbox are always present, so a
+// consumer reads them unconditionally. See #110 and the field rule in
+// jsonout.go.
+//
+// bootMillis is measured, from the runtime being asked to boot to the first
+// probe the guest agent answered, so it includes the VMM's own start. A
+// pointer rather than an integer so a stub that boots in under a millisecond
+// still reports 0 instead of dropping the field.
 type runData struct {
-	Ref     string `json:"ref"`
-	Sandbox string `json:"sandbox"`
-	Stage   string `json:"stage"`
-	Exit    int    `json:"exit"`
-	Error   string `json:"error,omitempty"`
-	Signal  string `json:"signal,omitempty"`
+	Ref        string `json:"ref"`
+	Sandbox    string `json:"sandbox"`
+	Stage      string `json:"stage"`
+	Exit       int    `json:"exit"`
+	Error      string `json:"error,omitempty"`
+	Signal     string `json:"signal,omitempty"`
+	BootMillis *int64 `json:"bootMillis,omitempty"`
 }
 
 // writeRunObject prints one Run object to stdout, compact, on its own line. It
@@ -2968,12 +2993,13 @@ type runData struct {
 // and none has to thread them through.
 func writeRunObject(stage string, exit int, errMsg, signal string) error {
 	return writeJSONLine(os.Stdout, "Run", runData{
-		Ref:     jsonRun.ref,
-		Sandbox: jsonRun.sandbox,
-		Stage:   stage,
-		Exit:    exit,
-		Error:   errMsg,
-		Signal:  signal,
+		Ref:        jsonRun.ref,
+		Sandbox:    jsonRun.sandbox,
+		Stage:      stage,
+		Exit:       exit,
+		Error:      errMsg,
+		Signal:     signal,
+		BootMillis: jsonRun.boot,
 	})
 }
 

--- a/cmd/brig/run_json_test.go
+++ b/cmd/brig/run_json_test.go
@@ -6,9 +6,11 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/brig-sh/brig/internal/profile"
 	"github.com/brig-sh/brig/internal/runtime"
+	"github.com/brig-sh/brig/internal/wrap"
 )
 
 // jsonRuntime is a runtime a full `brig run` can drive with none on PATH. It
@@ -237,5 +239,52 @@ func TestDetachJSONPrintsTheObjectAndTextPrintsTheName(t *testing.T) {
 	}
 	if strings.TrimSpace(textOut) != "brig-faker" {
 		t.Errorf("text -d printed %q, want the bare sandbox name", textOut)
+	}
+}
+
+// slowBootRuntime is a jsonRuntime whose boot takes long enough to measure, so
+// the case below can tell "the boot was timed" from "the field is present".
+type slowBootRuntime struct{ jsonRuntime }
+
+func (r *slowBootRuntime) Run(runtime.RunSpec) error {
+	time.Sleep(20 * time.Millisecond)
+	return nil
+}
+
+// A --json run that booted the sandbox reports how long the boot took, in
+// milliseconds, beside the agent's exit status: measured rather than quoted. The runtime here is asked to boot
+// (nothing is running), so the field is present and covers the boot's sleep.
+func TestRunJSONReportsTheBootTime(t *testing.T) {
+	rt := &slowBootRuntime{}
+	jsonRunHost(t, rt)
+
+	out, _ := captureStdout(t, func() error { return run([]string{"--json", "run", "faker"}) })
+	data, _ := lastJSONLine(t, out)["data"].(map[string]any)
+	ms, ok := data["bootMillis"].(float64)
+	if !ok {
+		t.Fatalf("a booted sandbox carried no bootMillis: %v", data)
+	}
+	if ms < 20 {
+		t.Errorf("bootMillis = %v, want at least the 20ms the boot took", ms)
+	}
+}
+
+// A run that found its sandbox running did not boot it, so the object carries
+// no bootMillis at all: absent means "not measured here", which a zero would
+// misreport as a boot that took no time. Tested at the seam rather than through
+// a full run, because the stub runtime cannot read the workspace marker back
+// and so every full run through it restarts the sandbox; the reuse decision
+// itself is covered in internal/wrap.
+func TestRecordBootSkipsAReusedSandbox(t *testing.T) {
+	jsonRun = &jsonRunContext{ref: "faker"}
+	t.Cleanup(func() { jsonRun = nil })
+
+	recordBoot(&wrap.Config{})
+	if jsonRun.boot != nil {
+		t.Errorf("a zero BootTime was recorded as %d ms", *jsonRun.boot)
+	}
+	recordBoot(&wrap.Config{BootTime: 2300 * time.Millisecond})
+	if jsonRun.boot == nil || *jsonRun.boot != 2300 {
+		t.Errorf("boot = %v, want 2300 ms", jsonRun.boot)
 	}
 }

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -588,6 +588,11 @@ status when `stage` is `"agent"`, and one of Brig's own exit codes
 otherwise. See [Exit codes](#exit-codes) for what those carve-outs mean for
 a script.
 
+When the run booted the sandbox, `data.bootMillis` carries the measured time
+from the runtime being asked to start to the first answer from the guest
+agent, so it includes the VMM's own start. A run that found the sandbox
+already up omits the field rather than reporting zero.
+
 ## Exit codes
 
 | Code | Meaning |

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -479,7 +479,11 @@ brig logs claude
 That is `hull logs` underneath, and the message names that spelling too, for
 a boot that never became a sandbox Brig can address by ref.
 
-The guest's own errors are there, not in Brig's output. If the guest is only
+The guest's own errors are there, not in Brig's output. To see how long a
+boot that does succeed takes, run with `--verbose`: Brig prints
+`sandbox ready in 2.3s`, measured from the runtime being asked to start to the
+first answer from the guest agent, so it includes the VMM's own start. Under
+`--json` the same number is the Run line's `bootMillis`. If the guest is only
 slow rather than broken, give it longer with `BRIG_READY_TIMEOUT` (seconds,
 default 30):
 

--- a/internal/wrap/boottime_test.go
+++ b/internal/wrap/boottime_test.go
@@ -1,0 +1,103 @@
+package wrap
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/brig-sh/brig/internal/creds"
+	"github.com/brig-sh/brig/internal/runtime"
+)
+
+// lateRuntime is a livenessRuntime whose guest agent is not up when the VMM
+// is: the first answers-after-1 probes fail, the way a real guest fails them
+// for the seconds between the VMM starting and the agent binding its listener.
+type lateRuntime struct {
+	livenessRuntime
+	answersAfter int
+	probes       int
+}
+
+func (r *lateRuntime) Probe(runtime.ExecSpec) bool {
+	r.probes++
+	return r.probes >= r.answersAfter
+}
+
+// The number the issue asks for: a boot is timed from the runtime being
+// asked to start to the first probe the guest answered, so a guest that needs
+// a second probe reports at least one probe interval, and the figure sits under
+// the timeout that would have failed the boot.
+func TestEnsureRunningMeasuresTheBoot(t *testing.T) {
+	rt := &lateRuntime{answersAfter: 2}
+	c := livenessConfig(t, &rt.livenessRuntime)
+	c.Runtime = rt
+	c.ReadyTimeout = 5 * time.Second
+
+	if err := c.EnsureRunning(creds.Set{}); err != nil {
+		t.Fatalf("a boot with a late guest was refused: %v", err)
+	}
+	if rt.probes != 2 {
+		t.Errorf("probed %d times, want 2", rt.probes)
+	}
+	if c.BootTime < 300*time.Millisecond {
+		t.Errorf("BootTime = %s, want at least one 300ms probe interval", c.BootTime)
+	}
+	if c.BootTime >= c.ReadyTimeout {
+		t.Errorf("BootTime = %s, not under the %s timeout", c.BootTime, c.ReadyTimeout)
+	}
+}
+
+// A sandbox found running was not booted here, so there is nothing to report:
+// the field stays zero rather than carrying the time a probe of a live guest
+// took, which is a different number.
+func TestEnsureRunningDoesNotTimeAReusedSandbox(t *testing.T) {
+	rt := &livenessRuntime{running: true}
+	c := livenessConfig(t, rt)
+
+	if err := c.EnsureRunning(creds.Set{}); err != nil {
+		t.Fatal(err)
+	}
+	if c.BootTime != 0 {
+		t.Errorf("a reused sandbox reported a boot time of %s", c.BootTime)
+	}
+}
+
+// The line is narration, not a warning: nobody acts on it, and the smoke test
+// reads the default output line by line. It waits for --verbose.
+func TestBootTimeLineWaitsForVerbose(t *testing.T) {
+	for _, v := range []Verbosity{Quiet, Normal, Verbose} {
+		rt := &livenessRuntime{}
+		c := livenessConfig(t, rt)
+		progress := &bytes.Buffer{}
+		c.Progress = progress
+		c.Verbosity = v
+		if err := c.EnsureRunning(creds.Set{}); err != nil {
+			t.Fatal(err)
+		}
+		said := strings.Contains(progress.String(), "sandbox ready in")
+		if v < Verbose && said {
+			t.Errorf("level %d printed the boot time: %q", v, progress.String())
+		}
+		if v >= Verbose && !said {
+			t.Errorf("--verbose did not print the boot time: %q", progress.String())
+		}
+	}
+}
+
+// The timeout is unchanged: a guest that never answers is still refused with
+// the same message, and no boot time is recorded for it.
+func TestEnsureRunningStillTimesOut(t *testing.T) {
+	rt := &lateRuntime{answersAfter: 1 << 30}
+	c := livenessConfig(t, &rt.livenessRuntime)
+	c.Runtime = rt
+	c.ReadyTimeout = 0
+
+	err := c.EnsureRunning(creds.Set{})
+	if err == nil || !strings.Contains(err.Error(), "did not become ready") {
+		t.Fatalf("err = %v, want the readiness refusal", err)
+	}
+	if c.BootTime != 0 {
+		t.Errorf("a boot that timed out recorded %s", c.BootTime)
+	}
+}

--- a/internal/wrap/config.go
+++ b/internal/wrap/config.go
@@ -75,6 +75,14 @@ type Config struct {
 	// listener.
 	ReadyTimeout time.Duration
 
+	// BootTime is how long this invocation's boot took, from the runtime
+	// being asked to start the sandbox to the first probe the guest agent
+	// answered. It is set by EnsureRunning and only when it booted: a sandbox
+	// found already running was not measured, and the field stays zero. The
+	// number is what the verbose "sandbox ready in" line and the Run
+	// object's bootMillis report -- measured rather than quoted.
+	BootTime time.Duration
+
 	// Env is what the guest sees, with BRIG_FORWARD_ENV already applied. See
 	// envOverride for what that override does and does not reach. The
 	// requirement list it may read from stays on Profile: one list, one place.

--- a/internal/wrap/run.go
+++ b/internal/wrap/run.go
@@ -372,6 +372,10 @@ func (c *Config) EnsureRunning(set creds.Set) error {
 		Progress: c.runtimeOutput(),
 		Notice:   c.runtimeNotice(),
 	}
+	// The clock starts here rather than in waitReady: the VMM's own start is
+	// part of what the reader waits through, and a number that left it out
+	// would flatter every backend equally.
+	started := time.Now()
 	if err := c.Runtime.Run(spec); err != nil {
 		return fmt.Errorf("could not start the sandbox: %w", err)
 	}
@@ -381,9 +385,15 @@ func (c *Config) EnsureRunning(set creds.Set) error {
 	// still has this workspace, and the next command has to resolve the same one
 	// to find out.
 	c.rememberSession()
-	if !c.waitReady() {
+	took, ok := c.waitReady(started)
+	if !ok {
 		return fmt.Errorf("sandbox did not become ready; check '%s'", c.logHint())
 	}
+	c.BootTime = took
+	// Narration rather than a warning: nobody acts on it, and the smoke test
+	// reads the default output. Rounded to a tenth of a second, which is as
+	// fine as a 300 ms probe interval can honestly claim.
+	c.progressf("sandbox ready in %s", took.Round(100*time.Millisecond))
 	if c.Profile.IsGUI() {
 		focusWindow()
 	}
@@ -488,14 +498,21 @@ func (c *Config) logHint() string {
 // instance running as soon as the VMM process starts, while the guest agent
 // binds its listener a few seconds later. Everything that asks the guest a
 // question waits here first.
-func (c *Config) waitReady() bool {
+//
+// since is when the wait is counted from, and the elapsed returned is measured
+// from it to the first probe that answered. EnsureRunning passes the moment it
+// asked the runtime to boot, so the number covers the VMM start as well as the
+// agent's; a caller re-checking a sandbox that was already up passes now and
+// ignores the figure. The timeout still runs from the call, not from since,
+// so a slow VMM launch does not eat into the guest's allowance.
+func (c *Config) waitReady(since time.Time) (time.Duration, bool) {
 	deadline := time.Now().Add(c.ReadyTimeout)
 	for {
 		if c.Runtime.Probe(runtime.ExecSpec{Name: c.VMName, Cmd: []string{"/bin/true"}}) {
-			return true
+			return time.Since(since), true
 		}
 		if time.Now().After(deadline) {
-			return false
+			return 0, false
 		}
 		time.Sleep(300 * time.Millisecond)
 	}
@@ -519,7 +536,7 @@ func (c *Config) guestMountsWorkspace() bool {
 	if err != nil {
 		return false
 	}
-	if !c.waitReady() {
+	if _, ok := c.waitReady(time.Now()); !ok {
 		return false
 	}
 	seen, err := c.Runtime.Output(runtime.ExecSpec{

--- a/script/smoke.sh
+++ b/script/smoke.sh
@@ -307,6 +307,13 @@ grep -q '^ISOLATION .*microVM (hull, vz backend)' "$WORK/env.err" \
 grep -q 'env-token-secret\|gh-secret\|host-token' "$WORK/env.err" \
   && bad "the envelope printed a credential value" \
   || ok "the envelope names credentials, never values"
+# How long the boot took is said at the verbose level only: it is narration
+# nobody acts on, so the default run above, which did the booting, stays
+# without it. The positive half is under "run --json" below, where a sandbox
+# is removed first so the run measures a boot rather than reusing this one.
+grep -q 'sandbox ready in' "$WORK/run.err" \
+  && bad "a default run printed the boot time -- got: $(cat "$WORK/run.err")" \
+  || ok "a default run does not print the boot time"
 
 # -q prints no envelope either, which is no longer -q's doing -- the default
 # prints none. Kept as the guard that asking for less never yields more.
@@ -2030,6 +2037,15 @@ echo "== run --json =="
 # survives the exec and reports the outcome on one JSON line. The stub's exec
 # exits 7; brig exits 7 too, with that status carried on a parseable last line --
 # which is how a script tells "the agent failed" from "brig refused to start it".
+# A boot is timed, from the runtime being asked to start to the first probe
+# the guest answered, and --verbose says so in one line. The sandbox is removed
+# first so this run boots rather than reuses; a reused sandbox was not booted
+# here and reports nothing.
+"$WORK/brig" rm --all > /dev/null 2>&1
+"$WORK/brig" --verbose run ubuntu -- true > /dev/null 2> "$WORK/boot.err"
+grep -q '^brig: sandbox ready in [0-9.]*m\{0,1\}s$' "$WORK/boot.err" \
+  && ok "--verbose says how long the boot took" \
+  || bad "--verbose says how long the boot took -- got: $(cat "$WORK/boot.err")"
 "$WORK/brig" rm --all > /dev/null 2>&1
 STUB_EXEC_EXIT=7 "$WORK/brig" --json run ubuntu -- true \
   > "$WORK/json.out" 2> "$WORK/json.err"
@@ -2046,6 +2062,13 @@ assert d["data"]["stage"] == "agent", d
 assert d["data"]["exit"] == 7, d' "$last" 2>/dev/null \
     && ok "the last stdout line is a Run object with stage agent and exit 7" \
     || bad "the last stdout line is not the expected Run object -- got: $last"
+  # rm --all above means this run booted, so the object carries the measured
+  # boot time in milliseconds, a non-negative integer.
+  python3 -c 'import json,sys
+d = json.loads(sys.argv[1])["data"]
+assert isinstance(d["bootMillis"], int) and d["bootMillis"] >= 0, d' "$last" 2>/dev/null \
+    && ok "a Run object for a boot carries bootMillis" \
+    || bad "a Run object for a boot carries bootMillis -- got: $last"
 fi
 case "$last" in
   *'"kind":"Run"'*) ok "brig --json run prints a compact Run object" ;;


### PR DESCRIPTION
## Summary

The VMM process is up several seconds before the in-guest agent binds its listener, and nothing measured that gap: `waitReady` polled the agent and returned a bool. So the boot times we talk about were quoted, not measured.

`EnsureRunning` now reads the clock just before it asks the runtime to boot and `waitReady` returns the elapsed time to the first probe that answered, so the number covers the VMM start as well as the agent's. Under `--verbose` a run prints `brig: sandbox ready in 2.3s` (rounded to a tenth of a second, which is as fine as a 300 ms probe interval can honestly claim); the default and `-q` outputs are unchanged. The `--json` Run object carries `bootMillis`, present only when this invocation booted the sandbox, so a reused sandbox reports nothing rather than zero. The ready timeout still runs from the wait, not from the VMM launch.

Not exercised against a real runtime in this PR: the run path only gained a clock read around the existing `Run` and `Probe` calls, and the stub runtime covers the timing and the verbosity gate.

## Changes

- `internal/wrap/run.go`: `waitReady(since) (time.Duration, bool)`; `EnsureRunning` records `Config.BootTime` and narrates it at the verbose level
- `internal/wrap/config.go`: `BootTime` field
- `cmd/brig/main.go`: `bootMillis` on the `--json` Run object, additive within the apiVersion
- `internal/wrap/boottime_test.go`, `cmd/brig/run_json_test.go`, `script/smoke.sh`: the elapsed is positive and under the timeout on a stub that answers on the second probe, zero on a reused sandbox, the line appears at verbose only, and the JSON run carries an integer `bootMillis`
- README `--json` row and `docs/troubleshooting.md`: one clause and one paragraph

## Checklist

- [x] `make all` passes (vet, test, build)
- [x] `script/smoke.sh` passes
- [x] I have added or updated tests covering the change
- ~~I have run `go test ./... -race`, if the change touches concurrency, subprocesses or the daemon~~
- [ ] I have exercised the change against a real runtime (`brig run <agent>`), if it touches the run, exec or credential path
- [x] I have updated the affected docs (README, `docs/security.md`, `docs/profiles.md`, `docs/brigd.md`)
