### PR TITLE
Rewrite the README and docs around what the code does

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -55,9 +55,10 @@ info` reports the backend, and `hull ps` / `nerdctl ps` shows the instance.
 ## `brig doctor` output
 
 <!--
-Paste it in full, fenced. `brig doctor` reports every check it can and exits
-0 even when a line reads `!!`, so the whole report matters more than whether
-the command "passed".
+Paste it in full, fenced. `brig doctor` prints a fix beside every line that
+is not `ok`, and still exits 0 for most of them. Only a missing or broken
+runtime and an unreachable secret store set a nonzero status, so the whole
+report matters more than whether the command "passed".
 -->
 
 ## Logs and additional context

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -43,13 +43,22 @@ info` reports the backend, and `hull ps` / `nerdctl ps` shows the instance.
 
 <!-- Fill in what applies; delete the rest. -->
 
+- Command: <!-- the exact `brig ...` line that failed -->
 - Host OS: <!-- e.g. macOS 26.3, or Ubuntu 24.04 -->
 - Architecture: <!-- arm64 | amd64 -->
-- brig version: <!-- brig --version -->
+- brig version: <!-- run `brig version` and paste its output -->
 - Runtime and version: <!-- hull --version, or nerdctl --version -->
 - Profile: <!-- claude-code, codex, ... or a file-backed one -->
 - Installed how: <!-- Homebrew cask | install.sh | make build -->
 - Commit: <!-- git rev-parse HEAD, if built from source -->
+
+## `brig doctor` output
+
+<!--
+Paste it in full, fenced. `brig doctor` reports every check it can and exits
+0 even when a line reads `!!`, so the whole report matters more than whether
+the command "passed".
+-->
 
 ## Logs and additional context
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -32,11 +32,12 @@ from the right place.
 <!--
 Delete if there is none.
 
-brig's value is that the guest sees one directory and holds only the
-credentials it was named. A proposal that widens either -- a new mount, a new
-forwarded variable, a new host path the guest can reach -- is still worth
-making, but say so plainly here so the tradeoff is discussed rather than
-discovered. docs/security.md is the place those limits are written down.
+brig's value is that the guest reaches only the host directories brig names
+for it, and holds only the credentials it was named. A proposal that widens
+either -- a new mount, a new forwarded variable, a new host path the guest can
+reach -- is still worth making, but say so plainly here so the tradeoff is
+discussed rather than discovered. docs/security.md is the place those limits
+are written down.
 -->
 
 ## Additional context

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -24,9 +24,10 @@ Check items as you complete them; strike through (~~like this~~) any that do
 not apply, rather than deleting or rewording them. Keep the reasoning in
 Summary or Changes, not here.
 
-`make all` is vet + test + build, which is what CI gates on. `script/smoke.sh`
-drives the real binary end to end against a stub runtime and a stub cosign, so
-it runs anywhere -- no VM and no macOS needed. See CONTRIBUTING.md.
+`make all` is vet + test + build. Run it locally before you push: CI does not
+call make, and runs its own steps instead. See CONTRIBUTING.md for what CI
+runs. `script/smoke.sh` drives the real binary end to end against a stub
+runtime and a stub cosign, so it runs anywhere: no VM and no macOS needed.
 
 brig drives a runtime it does not own: hull on macOS, nerdctl on Linux. A
 change to how brig invokes either can pass every test here and still be wrong,
@@ -38,18 +39,19 @@ which is what the fifth box is for.
 - [ ] I have added or updated tests covering the change
 - [ ] I have run `go test ./... -race`, if the change touches concurrency, subprocesses or the daemon
 - [ ] I have exercised the change against a real runtime (`brig run <agent>`), if it touches the run, exec or credential path
-- [ ] I have updated the affected docs (README, `docs/security.md`, `docs/profiles.md`, `docs/brigd.md`)
+- [ ] I have updated the affected docs (see [docs/README.md](../docs/README.md) for the map)
 
 ## Credentials and the sandbox boundary
 
 <!--
 Delete this section if the change touches neither.
 
-brig makes two promises: the guest sees one directory, and it gets the
-credentials it was named and no others. Anything touching internal/wrap,
-internal/creds, internal/profile or internal/secret should say which promise it
-affects and how that was checked -- ideally with a test that fails without the
-change. A negative test is worth more here than a positive one: "the denied
-variable was not forwarded" and "the planted symlink was refused" are the
-assertions that catch a regression.
+brig makes two promises: the guest reaches only the host directories brig
+names for it, and it gets the credentials it was named and no others.
+Anything touching internal/wrap, internal/creds, internal/profile or
+internal/secret should say which promise it affects and how that was checked
+-- ideally with a test that fails without the change. A negative test is
+worth more here than a positive one: "the denied variable was not forwarded"
+and "the planted symlink was refused" are the assertions that catch a
+regression.
 -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,8 +42,8 @@ notes come first.
   and a stub cosign, so it needs neither a VM nor macOS and runs in CI. It
   covers profile resolution, credential forwarding, the image-verification
   decision table and the workspace lifecycle.
-- What `script/smoke.sh` cannot cover: brig drives a runtime it does not own
-  — `hull` on macOS, `nerdctl` on Linux. A change to how brig *invokes* either
+- What `script/smoke.sh` cannot cover: brig drives a runtime it does not own:
+  `hull` on macOS, `nerdctl` on Linux. A change to how brig *invokes* either
   can pass the whole suite and still be wrong. If you touch the run, exec or
   credential path, boot a real sandbox before opening the PR.
 
@@ -73,7 +73,7 @@ exists, and a change that weakens either is a bug even when every test passes:
 
 `docs/security.md` is where the limits of both are written down, including the
 ones that are weaker than they look. If a change moves either promise, say so
-in the PR and update that document in the same change — it is the page people
+in the PR and update that document in the same change. It is the page people
 read before deciding what credential to trust brig with, and it is only useful
 while it is true.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,10 +6,20 @@ notes come first.
 
 ## Repo specifics
 
-- Build: `make build` produces `./brig` and `./brigd`. `make all` is
-  `vet test build`. CI runs that plus `gofmt -l`, `script/smoke.sh`, a
-  cross-compile for darwin/arm64 and linux/amd64, and a check that no test
-  disappeared.
+- Build: `make build` produces `./brig` and `./brigd`. `make all` runs
+  `vet test build`. Run it before you push, but CI does not call `make` at
+  all: it runs its own steps, listed next.
+- What CI runs (`.github/workflows/ci.yml`): a `gofmt -l` gate, `go vet
+  ./...`, `go test -race -covermode=atomic -coverprofile=coverage.out ./...`
+  with a coverage upload to Codecov on pushes to `main`, `script/smoke.sh`,
+  a cross-compile for darwin/arm64 and linux/amd64, a check that no test
+  disappeared, and `goreleaser check` plus a full snapshot build so the
+  release config stays exercised before a tag depends on it. The one CI
+  label this repo reads is `removes-tests`: it skips the test-disappeared
+  check for a pull request that means to remove one.
+- There is no linter in this repository. No `golangci-lint` configuration
+  exists anywhere in the tree, and the Makefile has no lint target. The only
+  static gates are `gofmt -l` and `go vet`.
 - Dependencies: brig has **three** direct dependencies -- `sigs.k8s.io/yaml`
   for profiles, `golang.org/x/sys` for terminal and process calls, and
   `github.com/godbus/dbus/v5` for the Linux secret store -- and that list is
@@ -24,6 +34,10 @@ notes come first.
   touching concurrency, subprocesses or `brigd`. Note that
   `internal/secret` exercises the **real** login keychain on macOS, so those
   tests create and delete items under the `sh.brig.secret` service.
+- Docs: `script/check-retired-spellings.sh` fails a doc that teaches a
+  command spelling scheduled for removal. Run it before you open a docs PR.
+- Brand assets: logos, marks and the architecture diagram live under
+  `assets/`, with usage rules in [assets/README.md](assets/README.md).
 - End-to-end: `script/smoke.sh` drives the real binary against a stub runtime
   and a stub cosign, so it needs neither a VM nor macOS and runs in CI. It
   covers profile resolution, credential forwarding, the image-verification
@@ -44,11 +58,15 @@ notes come first.
 Most of brig is ordinary Go, but two properties are the reason the tool
 exists, and a change that weakens either is a bug even when every test passes:
 
-1. **The guest sees one directory.** The workspace is mounted as the sandbox's
-   home and nothing else on the host is reachable from inside it. Everything
-   brig writes into that directory it writes from the host, as you — so those
-   paths are attacker-controlled input, and they are handled through an
-   `os.Root` rather than by joining strings.
+1. **The guest reaches only the host directories brig names for it.** The
+   guest home is mounted as the sandbox's home. Name a project on the run
+   line and brig mounts that project too, read-write, as a second host
+   directory at `/work/<name>`. The agent can change those real project
+   files. `docs/security.md` names the further limits, including what a
+   profile's own hostmount can add. Everything brig writes into either
+   directory it writes from the host, as you. Those paths are
+   attacker-controlled input, and they are handled through an `os.Root`
+   rather than by joining strings.
 2. **The guest gets the credentials it was named, and no others.** Values are
    read from your environment per invocation, forwarded by name so they never
    appear in `ps`, and never written into the workspace.
@@ -280,7 +298,7 @@ A few norms that make reviews pleasant on both sides:
 
 A PR is mergeable when:
 
-- CI is green: linting, builds, unit tests and end-to-end tests pass.
+- CI is green: gofmt and go vet, builds, unit tests and the smoke test pass.
 - The required approvals are in place.
 - The branch is up to date with `main` (rebased, with a clean, logical commit
   series).

--- a/README.md
+++ b/README.md
@@ -13,986 +13,185 @@
   <a href="LICENSE"><img alt="License: Apache 2.0" src="https://img.shields.io/badge/license-Apache--2.0-blue.svg"></a>
 </p>
 
-**Run a coding agent in a sandbox where one directory is its whole world and
-the rest of the host is out of reach from inside it.** It boots with no
-credential at all, which is what keeps trying it cheap: log in inside the
-sandbox and that login lives in memory, so `brig stop` takes it with the VM and
-the next run asks again.
+**brig runs a coding agent inside a microVM on your own machine.** The agent
+gets a guest home of its own, plus the one project directory you name on the
+command line. Your other files stay where they are: brig mounts nothing else,
+and it reads no credential out of your keychain, your SSH agent or your secret
+manager to hand to the agent.
 
-## TL;DR
+That matters when you want to let an agent work unattended. The blast radius of
+a bad edit or a bad command is the project you handed it, and you can throw the
+sandbox away and start again.
+
+## How it works
+
+One command resolves a session on the host and boots it:
+
+```bash
+brig run claude ~/code/demo
+```
+
+- **The session** is `claude`, the default session of the `claude-code` agent.
+  `claude@refactor` is a second, independent session of the same agent, with
+  its own sandbox and its own guest home. Every verb takes this ref.
+- **The guest home** is a host directory, `~/brig/claude-code`, mounted as the
+  agent's home. The agent's settings and history live there and survive
+  restarts.
+- **The project** is the directory you named. It is mounted read-write at
+  `/work/demo`, and the agent starts there. Name no project and brig remounts
+  whatever that session ran with last. `--no-project` mounts none.
+- **The sandbox** is a microVM: `hull` on macOS, `nerdctl` with containerd and
+  the `urunc` shim on Linux.
+- **Credentials** are not carried in by default. The sandbox boots with none,
+  so the agent asks you to log in exactly as it would on a new machine.
+
+## Requirements
+
+| Host | Supported |
+| --- | --- |
+| Mac, Apple silicon, macOS 15 or newer | Yes |
+| Mac, Apple silicon, macOS 14 | Yes, with `BRIG_HYPERVISOR=vz` |
+| Intel Mac | No, brig needs Apple silicon |
+| Linux, x86-64 or arm64 | Yes, with nerdctl and containerd |
+
+Six of the eight built-in profiles ask for hull's `hvi` backend, which needs
+macOS 15. On macOS 14 brig refuses the run and names `BRIG_HYPERVISOR=vz` as
+the way past it. macOS 26 is what the project tests on.
+
+`cosign` is optional. Without it brig cannot check a guest image signature and
+says so on every boot. Full instructions, including Linux and building from
+source, are in [docs/install.md](docs/install.md).
+
+## Quickstart
+
+Install on macOS with Homebrew:
 
 ```bash
 brew tap brig-sh/brig
 brew trust brig-sh/brig       # brew refuses untrusted third-party taps
 brew install --cask brig
-
-brig run claude               # boots a sandbox, starts Claude Code in it
 ```
 
-Put the projects the agent should work on in `~/brig/claude-code`. That
-directory is the agent's entire world; no other directory on your machine is
-mounted into it, and it cannot reach your keychain, SSH agent or secret
-manager. The sandbox stays up between commands, so the second `brig run` is
-immediate.
+The cask brings [hull](https://github.com/brig-sh/hull) with it. During the
+`0.1.0-rc` series the casks are maintained by hand, so if the tap lags the
+newest release, use [install.sh](docs/install.md#installsh) instead.
 
-<details>
-<summary>Building from source, or on Linux</summary>
+Check what brig found on your host:
 
 ```bash
-git clone https://github.com/brig-sh/brig && cd brig
-make build                    # produces ./brig and ./brigd
+brig doctor
 ```
 
-macOS needs `hull` on PATH (see [macOS](#macos) below); Linux needs
-`nerdctl`. brig finds either. `cosign` is optional but recommended -- without
-it, guest images cannot be verified and brig says so on every boot.
+Each line names one fact: the host, the hypervisor, the runtime, the boot
+assets, cosign, the profiles, the secret store and brigd. A `!!` line prints
+the fix beside it. `--` means brig looked and found nothing to report, which is
+not a failure.
 
-Without Homebrew, `install.sh` fetches the newest release for your platform,
-checks the archive against the published `checksums.txt` with sha256, and
-installs `brig` and `brigd` into `/usr/local/bin` (`BRIG_INSTALL_DIR` and
-`BRIG_VERSION` override the destination and the version):
+Run an agent on a throwaway project:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/brig-sh/brig/main/install.sh | sh
+mkdir -p ~/code/demo && cd ~/code/demo
+brig run claude ~/code/demo
 ```
 
-It does not check the cosign signature on `checksums.txt`, because that needs
-cosign installed; [Verifying a brig download](#verifying-a-brig-download) is
-that step, and the archive also carries the three completion scripts under
-`completions/`, which the script leaves for you to install
-([docs/completions.md](docs/completions.md)).
+The first run pulls the guest image once, so it is the slow one. Claude Code
+then prompts you to log in, because the sandbox holds no credential. That login
+happens inside the guest. On `claude-code` it lands on a tmpfs, so `brig stop`
+takes it with the VM and the next run asks again. To carry in the login you
+already have on this Mac, see [docs/authentication.md](docs/authentication.md).
 
-Two tools are needed only by a profile marked `genericBoot`, which boots an
-image that was never built to be a guest and therefore needs a kernel and an
-initrd brig has to fetch. On macOS that is hull, which is already there and
-downloads them for its own use. On Linux it is `oras`, because hull does not
-build there -- without it brig says so and tells you what to fetch. Neither is
-needed for an image that carries its own kernel.
-</details>
+You know it worked when the agent's prompt appears and `pwd` inside it prints
+`/work/demo`. Leave the agent and the sandbox keeps running, so the next
+`brig run claude` is immediate.
 
-## macOS
-
-On macOS the sandbox is a microVM, booted by
-[hull](https://github.com/brig-sh/hull) over Virtualization.framework. The
-Homebrew cask depends on it, so `brew install --cask brig` brings it along.
-
-Building both from source works too. hull's build target is `make macos`, it
-needs a Rust toolchain for the `hvi` submodule, and the submodule has to be
-cloned:
+Stop it when you are done:
 
 ```bash
-git clone --recursive https://github.com/brig-sh/hull && cd hull && make macos
+brig stop claude    # stop the sandbox and keep its name
+brig rm claude      # stop it and remove it
 ```
 
-hull ships a `vz-runner` helper that needs the
-`com.apple.security.virtualization` entitlement, so a from-source build has to
-be signed with a Developer ID certificate to boot a VM. The released build is
-signed, notarized and stapled, which is the path to prefer.
-[docs/runtimes.md](docs/runtimes.md#building-hull-from-source-on-macos) states
-the signing requirement exactly, including the separate entitlement that the
-`hvi` backend the shipped profiles ask for carries.
+Neither touches `~/brig/claude-code` or `~/code/demo`. Your project and the
+agent's saved state stay on the host.
 
-On Linux brig drives `nerdctl` over containerd, and hands the container to
-the [urunc](https://github.com/urunc-dev/urunc) shim
-(`io.containerd.urunc.v2`), so the sandbox is a microVM there too. Point
-`BRIG_CONTAINERD_RUNTIME` at `runc` if you want a plain container instead.
+## Common workflows
 
-## What brig is
+```bash
+brig ls                          # every sandbox, with its ref and workspace
+brig run claude                  # reopen the session on the project it last used
+brig run claude@refactor ~/code/demo   # a second session, its own sandbox and home
+brig sh claude                   # a login shell inside the sandbox
+brig sh claude ls /work          # one command inside it
+brig info claude                 # the boundary a run would use, before booting
+brig logs claude --follow        # stream the sandbox's log
+```
 
-`brig` boots an agent CLI -- Claude Code, Codex, and others -- inside a microVM
-on macOS and on Linux alike, mounts one directory as the agent's home, and
-forwards your credentials into it per exec.
+`brig info` is the one to reach for when a run does not do what you expected.
+It prints the session, the image, the workspace, the verification mode, the
+network and the credentials by name, and it boots nothing.
+
+## The boundary
 
 <p align="center">
-  <img alt="brig sandbox architecture: brig run &lt;agent&gt; resolves the session on the host, hull over Hypervisor.framework on macOS and urunc over KVM on Linux boot it, and both give the guest the same contract" src="assets/architecture.svg" width="900">
+  <img alt="brig sandbox architecture: brig run resolves the session on the host; hull drives a microVM on macOS and urunc over KVM on Linux; both give the guest the same contract of a guest home, a project mount, per-exec credentials and a verified image" src="assets/architecture.svg" width="900">
 </p>
 
-It is not a container runtime, and does not want to be one. It delegates every
-mechanical operation -- boot this image, exec in it, stop it -- to `hull` on
-macOS and `nerdctl` on Linux, and adds only the four things those tools have
-no concept of:
-
-- **Workspace as guest home.** One host directory is the agent's whole world
-  and the unit of persistence: its logins, its settings and your projects live
-  there and survive a restart.
-- **Host-resolved credentials, handed in explicitly.** The guest cannot reach
-  your keychain, your secret manager or your SSH agent -- that inaccessibility
-  *is* the isolation boundary -- so brig resolves credentials on the host and
-  passes them in. Only from its own store, and only what a profile names: you
-  say once that a host login may enter a sandbox (`brig secret import`), and a
-  run on a shipped profile never reads another application's keychain. A
-  profile of your own still carrying the deprecated `hostCredential:` is the
-  exception, and reads the host item it names on every run. Never written into
-  the workspace, and never placed in a command line where `ps` could read it.
-- **A billing denylist.** `ANTHROPIC_API_KEY` outranks the OAuth token in
-  Claude Code's own precedence, so forwarding it would move a sandbox from
-  your subscription onto metered API billing without saying so. It is refused
-  by default. Codex gets the same treatment for `OPENAI_API_KEY`.
-- **Guest image verification.** Images are checked against the workflow that
-  built them before they boot.
-
-Both operating systems run the same library. There is no macOS behaviour and a
-separate Linux re-implementation of it.
-
-## Commands
-
-| command | what it does |
-| --- | --- |
-| `brig run <ref> [project] [args…]` | start the sandbox if needed, then run the agent. A directory named after the ref is mounted as this run's project and the agent starts in it. Remaining arguments pass through untouched. `-d` starts it and exits, printing its name |
-| `brig sh <ref> [cmd…]` | a login shell inside the sandbox, or one command in it |
-| `brig stop <ref>` | stop the sandbox, keep it. Starting it again is a boot, not a fresh creation |
-| `brig rm <ref>` | stop and remove the sandbox. The workspace is untouched |
-| `brig rm --all` | stop and remove every brig sandbox. Workspaces are untouched |
-| `brig ls [-q]` | every brig sandbox, running or merely holding its name, with its ref and workspace. `-q` prints the refs alone, for a script |
-| `brig logs <ref> [--follow] [--tail N] [--raw]` | stream the sandbox's log: `--follow` keeps reading, `--tail N` starts N lines from the end (default: all), `--raw` leaves terminal escape sequences in, which are filtered out otherwise. `--gateway [<ref>]` reads the gateway's log instead: the shared one, or with a ref the gateway serving that sandbox alone |
-| `brig info <ref>` | the boundary a run would trust -- sandbox, workspace, image, credentials **by name only** -- and whether the guest will be authenticated |
-| `brig doctor [<agent>]` | check the host, the hypervisor, the runtime, the boot assets, cosign, the profiles, the secret store and brigd, one line each; given an agent, its image too |
-| `brig agent ls` | the agents, their images, and what each one refuses to forward |
-| `brig agent show <agent>` | print one agent's spec. `--json` for JSON instead of YAML |
-| `brig agent new <name> --from <agent>` | copy an agent under a new name, ready to edit. `--json` writes JSON; `-f` replaces a file already there |
-| `brig agent edit\|rm\|import\|export` | manage agents. `rm -y` answers the question in advance; `export <agent> [name]` prints one or saves it under a name |
-| `brig policy ls\|create\|edit\|show\|rm` | manage policies. `show --json` for JSON instead of YAML |
-| `brig policy attach\|detach <policy> <profile> [-n NAME]` | bind or unbind a policy to every run of a profile, or `-n` for one session |
-| `brig policy check <profile> [-n NAME]` | what is bound to a run of a profile (or `-n` session), and whether brig can enforce anything against it |
-| `brig secret create\|read\|update\|delete\|ls` | keep secrets in your keyring |
-| `brig secret import <profile>` | fill that profile's secrets from your host, once |
-| `brig telemetry status\|on\|off` | report what is counted, or turn the counting on or off. See [Telemetry](#telemetry) |
-| `brig completion bash\|zsh\|fish` | print a completion script for your shell. A cask install already has it; see [completions.md](docs/completions.md) |
-| `brig version` | |
-
-A `<ref>` is the session: `claude` is that agent's default session, and
-`claude@refactor` is a session of its own. `brig ls` prints the ref of every
-sandbox, and every verb above takes one -- see [Named sessions](#named-sessions).
-
-The older spellings all still work and each prints a one-line note naming the
-new one, so nothing scripted breaks in this release; they no longer appear
-above. `brig profiles` and the whole `brig profile` group are now `brig agent`,
-`brig policies` is `brig policy ls`, and top-level `brig import` and
-`brig export` are `brig agent import` and `brig agent export`. So are the
-undocumented aliases that were never in this table -- `list`, `save`, `load`,
-`secret rm`. `brig template …` and `brig agents` remain from an earlier rename,
-and there is deliberately no `brig template edit`.
-
-The lifecycle verbs collapsed in the same way. `brig exec` and `brig shell` are
-both `brig sh`, which runs a command when you give it one and opens a login
-shell when you do not -- one verb, and which of the two you get is said by the
-line rather than by the word you reached for. `brig create` is `brig run -d`,
-`brig reset` is `brig rm --all`, and `brig env` is `brig info`. `-n`/`--name` is
-the label: `brig run claude@refactor` is what `brig run claude --name refactor`
-was. That one is mapped and warned about rather than quietly reinterpreted,
-because `--name` is also Claude Code's own flag.
-
-`-w`/`--workspace` is `--home`, on the same terms: both spellings keep working
-and each says so. The word went because there are two host directories on a run
-line now -- the guest's own home and the project you name -- and "workspace"
-could not say which of them it meant.
-
-`brig secret` keeps `create|read|update|delete`, and that is deliberate rather
-than an oversight. The tidier `set`/`get` pair would make one typo turn a read
-into a write, silently replacing a stored credential with no way back to the
-original value. The inconsistency is the cheaper of the two.
-
-A brig line has three places a token can stand, and they are not the same kind
-of place. Left of the verb are brig's global flags, a closed set -- an unknown
-flag there is a usage error naming the token, rather than an operand quietly
-swallowed. Between the verb and the agent are the run-line flags below. Right of
-the agent the vocabulary is the agent's, and `--` ends brig's parsing outright,
-so an agent flag spelled like one of brig's still reaches it.
-
-brig does still read its own flags after the agent, because `brig run claude -q`
-is a line that works -- `-q` has moved left of the verb, and the old spelling
-keeps working for this release and says so. What ends brig's reading is the
-first token it does not own. On `run` that is not the project directory -- the second bare word is
-brig's own operand, so brig reads past it and on to the next token; see
-[The project you name](#the-project-you-name). Once an unknown token has ended
-brig's reading, a brig flag further along belongs to the agent -- and brig says
-so, without taking the token, so a line that works today keeps working.
-
-| global flag | what it does |
-| --- | --- |
-| `--verbose` | the execution envelope, brig's own progress and the runtime's own output. No short form: `-v` is Claude Code's version flag, codex's verbose flag and Docker's volume flag, so brig does not claim the letter |
-| `-q, --quiet` | identifiers and errors only, for a script. It drops brig's warnings; on `ls` it prints the refs alone. A verification that did not hold is printed even here. Still read after the verb for this release, with a note |
-| `--json` | machine-readable output, for the read verbs: `ls`, `info`, `agent ls`, `secret ls` and `doctor`. Also accepted after the verb (`brig ls --json`); every other verb refuses it. With `run`, brig runs the agent as a child and, after it exits, prints one JSON line with its exit status, so a script can tell "brig refused" from "the agent failed". Within one `apiVersion` the JSON only gains fields, never renames or drops one, and no field carries a credential value |
-
-By default a run prints what you have to act on, then the agent: warnings,
-errors, and one line saying verification held. The execution envelope, brig's
-own progress lines and the runtime's own output wait for `--verbose` -- except
-that a boot which fails quotes what the runtime said whether or not you asked,
-because that is the only evidence there is. A long download gets one line saying
-it started and one saying it finished, rather than a stream. `brig info` prints
-the envelope on demand, without booting anything.
-
-Verification is the exception at both ends. A check that did **not** hold --
-a signature that failed, a bundle brig does not publish, a missing `cosign`,
-`BRIG_VERIFY=off` -- prints at every level, `-q` included: it is the one claim
-brig exists to make, and a scripted run is where an unchecked image matters
-most. A check that held prints one line, which `-q` drops. The policy those
-held under is the envelope's `VERIFY` row.
-
-| flag | what it does |
-| --- | --- |
-| `-n, --name NAME` | a session of its own: own workspace, own sandbox. Also written `<agent>@<label>` |
-| `--image IMAGE` | guest image to boot (`-t` still works, with a note) |
-| `--home PATH` | host directory to mount as the guest home (`-w`/`--workspace` still work, each with a note) |
-| `--no-project` | with `run`: mount no project, whatever this session ran with last |
-| `--mem MB` | guest memory (`--memory` also works; `-m` works with a note) |
-| `--cpus N` | guest vCPUs |
-| `-d, --detach` | with `run`: start the sandbox, print its name, exit |
-| `--skills` | seed your own `~/.claude` skills and plugins into the workspace |
-| `--network MODE` | `shared`, `isolated` or `offline` (or `BRIG_NETWORK`) |
-| `--offline` | shorthand for `--network offline`: no route out of the sandbox |
-
-Each flag overrides the corresponding `BRIG_*` setting, which overrides the
-profile.
-
-### Exit codes
-
-brig returns a small, stable set of exit codes so a script can tell what went
-wrong without reading the message. Anything a command prints on success stays on
-`stdout`; every failure below is reported on `stderr`.
-
-| code | meaning |
-| --- | --- |
-| `0` | success |
-| `1` | general failure -- something ran and did not finish |
-| `2` | usage error -- an unknown flag, a stray argument, a value in the wrong place |
-| `3` | no such profile or sandbox -- the name resolves to nothing |
-| `4` | runtime unavailable -- none is installed, or the one named is broken |
-| `5` | image verification refused the boot -- see [guest image verification](#guest-image-verification) |
-| `6` | a credential the run needed could not be resolved |
-
-`1` and `2` are unchanged from earlier releases. The rest name failures brig
-already produced under `1`, so a caller that only checked "zero or not" keeps
-working; one that wants to branch on the reason now can.
-
-```bash
-brig run claude -p "summarise this repo"   # headless, arguments passed through
-brig run claude -- --name not-a-session    # --name reaches claude, not brig
-brig sh codex 'ls -la ~'                   # one command, in a login shell
-brig sh codex                              # a login shell, no command
-```
-
-### The project you name
-
-```bash
-cd ~/src/myproject
-brig run claude .
-```
-
-That line does what it looks like. The directory is mounted at
-`/work/myproject` in the guest and the agent starts there.
-
-`/work`, not the guest home. The home is the agent's own -- its dotfiles, its
-onboarding state, its caches -- so a project mounted there could be mistaken for
-home state or collide with the agent's files. Under `/work` it cannot, by the
-mount layout rather than by a convention anyone has to remember. Both mounts are
-read-write, and `brig info` and the pre-run envelope name each of them.
-
-The project is per run, not part of the session. The session is its ref, and the
-ref is the home: `brig run claude ~/src/a` and `brig run claude ~/src/b` are the
-same session with the same home, one after the other. The one consequence worth
-knowing is that the second one restarts the sandbox -- a share is bound at boot
-and cannot be attached to a live guest -- and brig says so when it does. Nothing
-persistent is lost: the home is a host directory that survives the restart, and
-so is each project.
-
-Only `run` takes one. On `sh` the second bare word is already the guest command.
-
-The project is brig's own operand, like the ref, so brig keeps reading its own
-flags after it. Parsing ends at the next bare word or the first flag brig does
-not own -- everything from there is the agent's.
-
-```bash
-brig run claude ~/src/myproject -p "what does this do?"  # project, then agent args
-brig run claude ~/src/myproject --mem 4096 -d            # project, then brig flags
-brig run claude -- ~/src/myproject                       # a path FOR the agent
-brig run claude --home ~/homes/claude ~/src/myproject     # both, each named
-```
-
-**This is a breaking change, for one release.** That word used to end brig's
-parsing and reach the agent, so `brig run claude .` passed `.` to the agent.
-Anything brig now reads as a project it says so about, naming the reading it
-lost beside the one it gained, and `--` is how to keep the old one. The notice
-goes in the next release. A word that names no directory is refused rather than
-mounted, so a line that meant the agent gets an error and not a surprise.
-
-### Named sessions
-
-```bash
-brig run claude@refactor
-brig run claude --name refactor    # the same session, the older spelling
-```
-
-A session of its own: its own workspace (`~/brig/claude-code-refactor`), its
-own sandbox, and the name you typed reaches the agent as its display name.
-
-Paths use a lowercase form of the name -- letters, digits, dot, dash and
-underscore -- so `my_project` and `my-project` stay separate, while `Foo` and
-`foo` do not (macOS filesystems ignore case, and two names sharing one directory
-but not one VM is a bug waiting to happen). Nothing is shortened, so the name you
-pick is the directory you get. If the slug differs from what you typed, brig says
-which directory it used. `brig info claude@refactor` prints the one in use.
-
-The `@` form is the stricter of the two: a label brig would have to rewrite --
-uppercase, a space, a slash -- is refused rather than quietly rewritten, and the
-message names what it would have become. That is what makes the label safe to use
-as an address: nothing is silently mapped onto a directory you did not ask for.
-`--name` keeps its older, lenient behaviour.
-
-**Every verb takes the ref.** A named session is addressed as
-`<agent>@<label>`, and the older agent-plus-`--name` spelling still works
-everywhere it did:
-
-```bash
-brig sh   claude@refactor git status
-brig stop claude@refactor
-brig rm   claude@refactor      # removes the sandbox, keeps the workspace
-```
-
-**`brig ls` prints the ref**, in the first column, and that is the string every
-verb takes:
-
-```
-REF                   SANDBOX                    STATE     WORKSPACE
-claude-code           brig-claude-code           running   /Users/you/brig/claude-code
-claude-code@refactor  brig-claude-code-refactor  stopped   /Users/you/brig/claude-code-refactor
-```
-
-`brig ls -q` prints the refs alone, one to a line, so a script can read the
-listing and hand what it finds straight back to a verb:
-
-```bash
-brig ls -q | while read -r ref; do brig stop "$ref"; done
-```
-
-The `SANDBOX` column is the sandbox's own name, which is not a ref: `brig rm
-brig-claude-code-refactor` fails with "unknown profile", and it is there to be
-recognised in the runtime's own output rather than to be typed at brig. A
-sandbox brig has no session recorded for and cannot read a ref out of the name
-of -- one renamed with `BRIG_NAME`, say -- shows a `-` in the `REF` column and is
-left out of `brig ls -q` entirely, because every line of that output is meant to
-be a word a verb takes. `brig rm --all` is what clears one of those.
-
-To drop the workspace too, remove the directory `brig info` prints. And
-`brig rm --all` stops and removes every brig sandbox at once, named ones
-included, leaving all workspaces alone.
-
-**The home is remembered.** A session created with `--home` keeps that
-directory for every later verb, so `brig sh claude@refactor ls` finds it
-without repeating the flag. brig records it in `~/.brig/sessions.json`, filed
-under the session's ref, and reads it back when neither `--home` nor
-`BRIG_WORKSPACE` names one; `brig rm` drops the entry with the sandbox, and
-`brig ls` drops any whose sandbox has gone. That file is also where `brig ls`
-reads the ref it prints, and where the project a session last ran with is
-recorded -- which is how the next run knows whether it has to restart.
-
-That file is an index and not a record of the truth: the runtime stays the
-authority on what is actually mounted, and an unreadable index costs one restart
-rather than failing the command. Because it is filed under the ref, a session is
-found under either spelling of its agent -- `claude` and `claude-code` are one
-agent through an alias, and both reach the one entry. Pass either of them a directory that is not the one the sandbox is
-mounting and it restarts, as it always has -- a share cannot be moved on a
-running guest, and you asked for a different directory.
-
-### If you know Docker Sandboxes (`sbx`)
-
-The verbs line up deliberately, so muscle memory carries over:
-
-| `sbx` | `brig` | note |
-| --- | --- | --- |
-| `sbx run <agent> [path]` | same | the positional is the project brig mounts and starts the agent in; `--home` is the separate directory that is the guest's own |
-| `sbx create` | `brig run -d` | starts the sandbox and exits, printing its name |
-| `sbx ls` / `sbx stop` / `sbx rm` | same | |
-| `sbx exec` | `brig sh` | one verb for a command and for a login shell |
-| `sbx reset` | `brig rm --all` | the same removal as `brig rm`, over every sandbox |
-| `sbx cp` | n/a | the workspace is a live host directory, so there is nothing to copy across |
-| `sbx template ls\|save\|load\|rm` | `brig agent ls\|export\|import\|edit\|rm` | brig's profiles describe the *agent*, not just its image, and are YAML like sbx's kits |
-| `sbx secret set` | `brig secret create` + a profile's `secrets:` | brig has a store of its own and binds from it. Or point a profile at your existing secret manager: whatever puts a value in brig's environment is enough |
-| `sbx -t/--template` | `brig -t/--image` | |
-| `sbx -m/--memory`, `--cpus`, `-d` | same | |
-| `sbx --name <name>` | `brig <agent>@<name>` | brig's `--name` still works and says what replaces it |
-| `sbx --publish` | n/a | not yet; brig does not forward a guest port |
-| `sbx --deny-network` | `brig --network offline` | no route out at all. `--network isolated` is a network of the sandbox's own, and an egress policy (`brig policy`) filters what leaves it -- see [docs/security.md](docs/security.md#things-brig-does-not-claim) |
-| `sbx --clone` | n/a | not yet; the workspace is mounted directly |
-| `sbx login` | n/a | nothing to sign in to |
-
-The deeper differences are the interesting ones. sbx keeps secrets out of the
-guest entirely by rewriting auth headers in a host-side proxy; brig forwards
-the credential into the guest, because the agent has to be able to use it for
-anything other than a proxied HTTP call -- `git push`, a vendor CLI's own
-refresh, an MCP server. brig's answer to that exposure is a narrow blast
-radius (one workspace, a fine-grained token) rather than a sentinel value.
-
-## Credentials
-
-**A sandbox with no credential still boots.** `brig run claude-code` starts the
-agent and the agent asks you to log in, in there, exactly as it would on a
-machine you had just set up. Everything below is optional.
-
-```bash
-brig run claude-code               # log in inside the sandbox, or:
-brig secret import claude-code     # carry the login already on this Mac in, once
-```
-
-That in-sandbox login lasts as long as the sandbox does. It is written to
-`~/.claude/.credentials.json`, which sits on a memory-backed mount and never
-reaches host disk, so `brig stop` takes it with the rest of the VM and the next
-`brig run` asks again. Other paths under `~/.claude` do reach host disk by
-design; [docs/security.md](docs/security.md#what-reaches-host-disk) names them
-and says why. Importing is what makes a login outlive a stop: brig keeps that
-copy in your keyring and writes it back in on every boot. If you log in inside
-the sandbox on a host that has no login of its own, expect to repeat it.
-
-`import` reads your host login **once, when you type it**, and copies it into
-brig's own store. Every run after that reads only that store. On a shipped
-profile brig never opens another application's keychain item on the run path,
-so a run raises no approval dialog and performs no host read you did not ask
-for. A profile of your own still on the deprecated `hostCredential:` is the
-exception: it reads the host item it names on every run.
-
-The copy is a copy: renewing or revoking the login on the host does not change
-it. Run `brig secret import claude-code` again to refresh it, or
-`brig secret delete claude-credentials` to be rid of it. brig warns before boot
-when the stored copy has expired.
-
-Claude Code's credential arrives as a **file**, at the path the agent already
-reads -- `~/.claude/.credentials.json` in the guest -- on memory-backed storage
-that never reaches your disk. The agent refreshes it in there on its own, so a
-long session does not break every few hours. `docs/security.md` states what
-that costs, because it is not free: the document brig stores and hands over
-contains a **refresh token**.
-
-Credentials that no agent reads from a file still travel as environment
-variables -- `GH_TOKEN` for git over HTTPS, and the API keys that are env-only
-by their own tools' design. Three rules apply to every one of them:
-
-- **Unset or empty is skipped**, so it cannot shadow a value baked into the
-  image.
-- **A `scheme://` value read from the environment is refused** -- direnv and
-  friends readily leave a secret-manager reference in the environment
-  unresolved, and forwarded verbatim it yields "Invalid username or token" in
-  the guest, which looks exactly like a broken sandbox. A stored secret or a
-  `value:` literal skips this check, having been put there on purpose.
-  `BRIG_ALLOW_REFS=1` forwards an ambient one anyway.
-- **A denylisted variable is refused**, with the reason. `BRIG_ALLOW_DENIED=1`
-  if metered billing is genuinely what you want.
-
-`brig info <agent>` reports what would be forwarded, by name, and whether the
-guest will actually be authenticated -- an expired stored credential is exactly
-what sends a sandbox back to its login screen.
-
-Values reach the runtime through its environment, not its command line, so a
-forwarded credential is not readable in `ps`. Inside the sandbox it is
-readable by anything running alongside the agent, which is inherent: the
-sandbox cannot use a credential it cannot see. Prefer a fine-grained
-`GH_TOKEN` scoped to the repositories you want reachable.
-
-### The secret store
-
-`brig secret` is a store of brig's own, and it is the only store a run reads.
-`brig secret import` fills it from your host; these verbs are how you fill it
-by hand, from any backend you like. On macOS it keeps each secret in your login
-keychain; on Linux in a Secret Service keyring on your session bus
-(gnome-keyring or KWallet). With no keyring to reach, brig says which half is
-missing rather than falling back to a file ([docs/secrets.md](docs/secrets.md#linux)).
-
-```bash
-printf %s "$TOKEN" | brig secret create gh-token   # the value comes from stdin
-brig secret create deploy-key -f ~/.ssh/id_ed25519 # ... or from a file, verbatim
-brig secret read gh-token
-brig secret ls                                     # names and dates, never values
-brig secret delete gh-token                        # asks first; -y answers ahead
-```
-
-The value is never an argument, so it stays out of `ps` and out of your shell
-history. `create` refuses to overwrite and `update` refuses to create, so a
-typo in a name is a message rather than a silently lost secret.
-
-A profile declares the names it wants out of this store, so a stored secret
-reaches a sandbox on its own -- as a file where the agent reads one, and as an
-environment variable where it does not. `brig agent ls` prints each agent's
-list, and which of those names `brig secret import` can fill for you:
-
-```
-claude-code     Claude Code (Anthropic)
-                secrets: claude-credentials gh-token
-                  from your host: brig secret import claude-code (claude-credentials)
-                  by hand: brig secret create <name> (gh-token)
-```
-
-A secret that is missing does not stop `claude-code` from booting: both of its
-names are optional, and the run says what it could not find and carries on.
-[docs/profiles.md](docs/profiles.md) is how to declare them in a profile of
-your own.
-
-```console
-$ brig info claude
-PROFILE      claude-code
-SANDBOX      brig-claude-code (hull)
-ISOLATION    microVM (hull, hvi backend)
-WORKSPACE    /Users/you/brig/claude-code (read-write)
-IMAGE        ghcr.io/brig-sh/claude-code-stock:latest (pull missing)
-VERIFY       warn, against brig's own trust policy
-CREDENTIALS  claude-credentials
-NETWORK      shared (one network for every sandbox on this host)
-brig: workspace /Users/you/brig/claude-code (sandbox brig-claude-code)
-brig: runtime hull (/opt/homebrew/bin/hull)
-...
-```
-
-The block at the top is the execution envelope: the boundary the run would
-trust, printed before the sandbox boots. `brig --verbose run` prints the same
-block before it starts one, so what you preview is what you get. Names only,
-never values. A run with a project adds a `PROJECT` row, and one with a policy
-attached a `POLICY` row. The `brig:` lines after it are the full report, which
-`brig info` goes on to print: what is forwarded and from where, what is never
-forwarded, and the guest git settings.
-
-A secret a profile declares but the store does not have fails the run before
-any sandbox is created, naming every one that is missing and the command that
-creates it. This is the path to prefer over composing a value into brig's
-environment: a value brig resolved itself is exempt from `BRIG_ENV_ARGV` and
-stays off the runtime's command line whatever that is set to.
-
-[docs/secrets.md](docs/secrets.md) is the usage guide -- the verbs, the
-trailing-newline rule, the name grammar and the size limit. What the keychain
-does and does not protect is
-[docs/security.md](docs/security.md#the-secret-store).
-
-## Guest image verification
-
-Before booting an image, brig asks cosign not "was this signed?" but "was this
-built by that workflow, in that repo?" -- the identity is anchored on the
-repository *and* the workflow file, so a signature from anywhere else fails.
-
-| situation | what happens |
-| --- | --- |
-| image under `ghcr.io/brig-sh/`, signature verifies | one line saying so, boots. `--verbose` adds the per-check detail |
-| image published by someone else | **warning**, boots. Bring-your-own images are a supported way to use brig |
-| `cosign` not installed | **warning**, boots. "Could not check" is not "failed" |
-| image under `ghcr.io/brig-sh/`, signature does **not** verify | **stops and asks** `[y/N]`. With no terminal it refuses |
-
-Most profiles boot a kernel and an initrd brig downloads rather than their own
-image, and the initrd carries the in-guest agent. That bundle is checked the
-same way, against its own signing identity, under the same setting: a signature
-that does not verify stops the boot, a bundle brig does not publish warns, and
-`BRIG_VERIFY=require` refuses anything unchecked. The kernel is the more
-privileged of the two, so verifying the image alone was never the whole
-guarantee.
-
-`BRIG_VERIFY=require` refuses anything that cannot be positively verified,
-third-party images included. `BRIG_VERIFY=off` skips the check.
-[docs/security.md](docs/security.md) explains the reasoning, and what brig does
-not protect you from.
-
-For an image under `ghcr.io/brig-sh/`, brig resolves the tag to a digest,
-verifies that digest, and boots it, so the image it checked is the image that
-runs and the line saying so names the digest. If the registry cannot be reached
-the boot stops and asks, as it does for a bad signature. Images brig did not
-publish boot by tag with no registry round trip, as before. Pinning needs a
-runtime whose store answers a digest: containerd on Linux, and hull from
-0.1.0-rc23 on macOS. An older hull cannot, so brig verifies and boots the
-tag there and says so; under the default `missing` pull policy that check is of
-the tag in the registry, not necessarily the copy already in your store, and
-`BRIG_PULL=always` is the workaround until you upgrade. `claude-desktop` and
-`ubuntu` still point at `ghcr.io/nofireai/` images, so they warn on every boot
-until those move.
-
-### Image tags
-
-The five published agents default to `:latest`, a multi-arch index covering
-`linux/arm64` and `linux/amd64`. One reference is therefore right on an Apple
-Silicon Mac and on an x86 Linux host -- the runtime resolves the index and
-pulls the matching manifest.
-
-| tag | what it is |
-| --- | --- |
-| `:latest` | multi-arch index, arm64 + amd64. What the profiles use |
-| `:arm64`, `:amd64` | one architecture |
-| `:<arch>-<sha>` | immutable pin: that architecture, that build, permanently |
-
-All of them are signed the same way and verify with the same command.
-
-`:latest` moves when a new image is published, and under the default `missing`
-pull policy a cached tag is never re-resolved -- so a republished image stays
-invisible until you set `BRIG_PULL=always` or clear the store. When you want a
-guest that cannot move under you, pin the build:
-
-```bash
-brig run claude --image ghcr.io/brig-sh/claude-code:arm64-98f4739
-```
-
-`cursor` is built by community-images but deliberately not published, pending
-a terms check. `brig run cursor` says so rather than failing on a registry
-404; build the image yourself and pass `--image`.
-
-## Telemetry
-
-brig counts usage, and this section says so plainly because nothing else about
-the tool would lead you to expect it. There is no account and no server of
-brig's own, but the runtime brig drives on macOS reports a handful of events to
-a collector run by NOFire AI, tagged with brig's name because brig is the
-product you installed. On Linux, where the backend is `nerdctl`, nothing is
-sent at all.
-
-Turning it off is one line, and it is durable rather than per-shell:
-
-```bash
-brig telemetry off      # or: DO_NOT_TRACK=1 in your environment
-brig telemetry status   # what the current answer is, and what decided it
-```
-
-It is on by default once you answer yes, and the question is asked on the
-first command that hands your terminal to an agent. Until it has been
-answered, brig sends nothing: a sandbox boot happens with no terminal
-attached, so nobody could have been asked, and brig suppresses counting for it
-rather than letting a default stand in for consent.
-
-An event carries the product name and version, the OS version and CPU
-architecture, an install identifier generated on your machine (delete
-`~/.hull/telemetry.json` to rotate it), a timestamp and a checksum. On top of
-that envelope: which runtime operation ran and whether it succeeded, with
-failures bucketed into coarse classes such as `network` or `permission` and
-never the error text; which hypervisor backend booted and whether the boot
-worked; how long a sandbox lived; sampled memory and CPU of the VM process
-while a command is attached; and, if brig or the runtime panics, the panic
-type with a stack trace whose paths are trimmed. Crash reports queue in
-`~/.hull/crashes/`, where you can read or delete them before they go anywhere.
-
-What is never collected, as a commitment rather than a description of the
-current build:
-
-- workspace paths, or any host path
-- repository names, branches or remotes
-- command arguments, including the agent's own
-- agent prompts, or anything the agent read or wrote
-- secret names, secret values, or which credentials were forwarded
-- image names and registry references
-- network destinations the guest reached
-- file metadata: names, sizes, timestamps, counts
-
-Your IP address is not stored: it is discarded at ingestion. Raw events are
-kept for a year. If a future version widens what it collects, the question is
-asked again with the new list, and nothing from the wider set is sent until
-you answer it.
-
-The full field-by-field description is
-[hull's telemetry documentation](https://github.com/brig-sh/hull/blob/main/docs/telemetry.md),
-since hull is what does the sending. `HULL_TELEMETRY_DISABLED=1` and
-`DO_NOT_TRACK=1` both reach it untouched and both win over anything recorded on
-disk.
+What the sandbox keeps out: every host directory except the guest home and the
+project you name, your keychain, your SSH agent, and the API-key environment
+variables each profile refuses to forward.
+
+What it does not keep out. An agent can change anything in the project you
+mounted, because that mount is read-write and those are your real files. It can
+read any credential you chose to deliver into the guest. On the default
+`shared` network it can reach the internet, so anything it can read it can also
+send. Egress filtering exists, and brig enforces it only on hull's `hvi`
+backend; on any other backend a policy-bound run is refused rather than run
+unenforced.
+
+Image verification defaults to `warn`, which reports an unverifiable image and
+boots anyway. Set `BRIG_VERIFY=require` to refuse one instead.
+
+[docs/security.md](docs/security.md) states the boundary and its limits in
+full, and [docs/non-goals.md](docs/non-goals.md) says what brig does not try to
+be.
 
 ## Documentation
 
-The README is the overview. The details live in [docs/](docs/):
+| If you want to | Read |
+| --- | --- |
+| Install brig on any supported host | [docs/install.md](docs/install.md) |
+| Get a first agent running, step by step | [docs/quickstart.md](docs/quickstart.md) |
+| Understand homes, projects and sessions | [docs/sessions.md](docs/sessions.md) |
+| Log an agent in, or give it Git access | [docs/authentication.md](docs/authentication.md), [docs/secrets.md](docs/secrets.md) |
+| Look up a command, a flag or a variable | [docs/cli.md](docs/cli.md) |
+| Run your own agent or your own image | [docs/profiles.md](docs/profiles.md), [docs/guest-image.md](docs/guest-image.md) |
+| Restrict what the guest can reach | [docs/policies.md](docs/policies.md) |
+| Understand the isolation, and its limits | [docs/security.md](docs/security.md) |
+| Fix something that went wrong | [docs/troubleshooting.md](docs/troubleshooting.md) |
+| Move off a retired command spelling | [docs/migration.md](docs/migration.md) |
+| Know what is stable and what is not | [docs/stability.md](docs/stability.md) |
 
-- [quickstart.md](docs/quickstart.md) -- from install to a running agent, one page
-- [troubleshooting.md](docs/troubleshooting.md) -- when a run fails, organised by what you saw
-- [profiles.md](docs/profiles.md) -- writing an agent profile, field by field
-- [policies.md](docs/policies.md) -- writing an egress policy, verb by verb, with a worked example
-- [secrets.md](docs/secrets.md) -- `brig secret`, verb by verb, with a worked example
-- [completions.md](docs/completions.md) -- shell completion: installing it, and what completes where
-- [security.md](docs/security.md) -- what the boundary is, and what it is not
-- [non-goals.md](docs/non-goals.md) -- what brig will not do, with the reason
-  and what would reopen each one
-- [brigd.md](docs/brigd.md) -- the session daemon and its protocol
-- [runtimes.md](docs/runtimes.md) -- hull, nerdctl and urunc: what each one is, its licence, and every command brig runs against it
-- [support.md](docs/support.md) -- which computers brig runs on
+The full index is [docs/README.md](docs/README.md).
 
-Found a security problem? [SECURITY.md](SECURITY.md) is how to report it
-privately, rather than in a public issue.
+## Contributing and support
 
-## Custom agents and your own images
+[CONTRIBUTING.md](CONTRIBUTING.md) covers the build, the tests and the review
+norms. [AI_POLICY.md](AI_POLICY.md) says how AI-assisted contributions are
+handled. Report a vulnerability through [SECURITY.md](SECURITY.md), not a
+public issue. For anything else, [docs/support.md](docs/support.md) says where
+to ask.
 
-Any Linux CLI in an OCI image runs under brig, as long as the image also
-carries the utilities brig invokes to set the sandbox up and deliver the
-credential. [docs/guest-image.md](docs/guest-image.md) is the list, with the
-file that runs each one, and `script/check-guest-image.sh <image> [profile]`
-checks an image against it by booting it as that profile's sandbox, default
-`claude-code`. A stock distribution image passes as it ships; a
-`FROM scratch` image holding only your static binary fails every line. A
-profile just saves you spelling out the image, the guest home and the
-credential variables every time:
-
-```bash
-brig agent new mine --from claude-code   # start from the closest one
-brig agent edit mine                     # change the image, forward/deny
-brig run mine
-```
-
-The name is a name, not a path: brig writes `~/.config/brig/mine.yaml`, which
-is where a profile file has to be for brig to read it back. It is the agent's
-name as well as the file's -- `new` writes `name: mine` into the file, so `mine`
-is what every later command takes, `brig agent rm mine` included. Everything
-else in there still describes claude-code, which is what the edit on the second
-line is for. `new` writes that directory and nowhere else, so a path is refused
-rather than honoured -- redirect stdout (`brig agent show claude-code >
-mine.yaml`) if you want a copy of your own. It also refuses to overwrite an existing file
-unless you pass `--force`, since an export is generated bytes and the file it
-would replace is not.
-
-Profiles are **YAML or JSON** -- JSON is a subset of YAML, so one parser reads
-both and nothing has to guess. Export writes YAML, because a profile is a
-file a person edits and YAML has comments; the exported file carries a header
-explaining every field. `brig agent show --json` for anything consuming
-profiles programmatically.
-
-An imported file is stored byte for byte as you wrote it, so your comments and
-your ordering survive:
-
-```yaml
-# A brig profile. Edit it, then: brig agent import <this file>
-# ...
-name: mine
-image: docker.io/me/mine:latest
-guestHome: /home/mine
-binary: mine
-forward: [GH_TOKEN]      # inline lists work too
-mem: 8192                # this CLI is a memory hog
-cpus: 2
-```
-
-A misspelled field is refused rather than ignored -- `forwards:` would
-otherwise decode into nothing and forward no credentials, which looks exactly
-like a broken sandbox.
-
-A custom profile may take a built-in's name -- that is how you pin your own
-image for an agent brig already knows about. `brig agent ls` marks those
-`(file, overrides built-in)`. Your own live in `$XDG_CONFIG_HOME/brig`
-(default `~/.config/brig`), one file each; the directory starts empty and
-brig never writes there unless you ask it to.
-
-[docs/profiles.md](docs/profiles.md) walks through the fields with a worked
-example. Building an image for one is documented in
-[community-images/docs/bring-your-own-image.md](https://github.com/brig-sh/community-images/blob/main/docs/bring-your-own-image.md).
-
-## Git in the guest
-
-```bash
-BRIG_GIT_CONFIG=1 brig run claude
-```
-
-Off by default, because turning it on writes two files into your workspace: a
-credential helper that reads `GH_TOKEN` from the guest environment, and a
-gitconfig that rewrites SSH GitHub remotes to HTTPS (the guest has no SSH
-agent, so SSH remotes cannot work there). Neither file holds a secret. Set
-your login once with `git config --global github.user <login>`.
-
-Your commit identity is forwarded as environment, resolved from the directory
-you invoked brig in, so per-directory `includeIf` rules carry into the guest.
-Guest commits are unsigned: signing needs a host-side agent the guest cannot
-reach.
-
-`GIT_TERMINAL_PROMPT=0` is forwarded unconditionally -- inside an agent session
-there is nobody to answer a credential prompt, so git would simply hang.
-
-## Your own skills in the guest
-
-```bash
-brig run claude --skills          # or BRIG_SKILLS=1
-```
-
-Off by default. With it on, brig seeds the directories the profile lists in
-`hostConfigDir` and `projectPaths` -- `~/.claude/skills` and
-`~/.claude/plugins` for Claude Code -- into the workspace, mirroring the host
-layout, so the agent finds them at `~/.claude/skills` in the guest because the
-workspace *is* the guest home.
-
-**They are copied, not mounted read-only.** Read-only is what you would expect
-here, and it looks like the careful choice, but it is the wrong one: agents
-write inside these directories -- installing a plugin, populating a cache --
-and a read-only mount turns that into an I/O error the agent cannot handle.
-So the guest gets its own writable copy and your directory on the host is
-never written to, which is what read-only was for. What follows from that is
-worth knowing:
-
-- The copy is entry by entry, and only what is missing. A plugin the guest
-  installed is not clobbered on the next start, and a skill you add on the
-  host later still arrives.
-- The guest's copy wins. Once an entry exists in the workspace, brig leaves it
-  alone -- so editing a skill on the host does not update the one in the
-  sandbox. Delete it from the workspace to have it seeded again.
-- A path you do not have is skipped rather than refused, so skills without
-  plugins is not a case you have to care about.
-- The sandbox can change its copy, because it is a file in the workspace like
-  any other. It cannot change yours.
-
-## Environment variables
-
-A setting that belongs to a run is read in this order, first hit wins:
-
-```
-BRIG_<AGENT>_<KEY>   →   BRIG_<KEY>
-```
-
-`<AGENT>` is the profile name uppercased with dashes as underscores
-(`BRIG_CLAUDE_CODE_WORKSPACE`), so one shell can carry different settings for
-two agents. That prefix is honoured by the per-run settings: `WORKSPACE`,
-`NAME`, `IMAGE`, `PULL`, `MEM`, `CPUS`, `READY_TIMEOUT`, `TITLE`, `NETWORK`,
-`SKILLS`, `FORWARD_ENV`, `ALLOW_REFS`, `ALLOW_DENIED`, `ALLOW_EXPIRED`, the
-`GIT_*` group, `TRUST_WORKSPACE`, `VERIFY`, `VERIFY_REGISTRY`,
-`VERIFY_IDENTITY`, `VERIFY_ISSUER`, `COSIGN_BIN`, `HYPERVISOR` and
-`ROOTFS_TYPE`. The settings that describe the host rather than a run are read
-under `BRIG_<KEY>` only: `PROFILE_DIR`, `POLICY_DIR`, `STATE_DIR`, `RUNTIME`,
-`RUNTIME_BIN`, `CONTAINERD_RUNTIME`, `GATEWAY_SOCK`, `GATEWAY_DIR`,
-`BOOT_ASSETS`, `BOOT_ASSETS_REF` and `ENV_ARGV`.
-
-Booleans come in two kinds. A switch whose safe position is off --
-`BRIG_GIT_CONFIG`, `BRIG_SKILLS`, `BRIG_TRUST_WORKSPACE`, `BRIG_ALLOW_REFS`,
-`BRIG_ALLOW_DENIED`, `BRIG_ALLOW_EXPIRED` -- takes `1`, `true`, `yes` or `on`
-to turn on and `0`, `false`, `no` or `off` to turn off, case-insensitively,
-and refuses the run on any other value rather than guessing: under the
-shell-style rule `BRIG_ALLOW_DENIED=false` would have turned the guard off by
-turning it on. Absent or empty keeps the default. `BRIG_GIT_IDENTITY` is a
-tuning knob and keeps the shell rule, anything but `0` is on. `BRIG_ENV_ARGV`
-is on only when it is exactly `1`.
-
-### Where things live
-
-| variable | default | what it does |
-| --- | --- | --- |
-| `BRIG_WORKSPACE` | `~/brig/<agent>` | Host directory mounted as the guest home. A named session appends `-<slug>` |
-| `BRIG_NAME` | `brig-<agent>` | Sandbox (VM or container) name; must begin with `brig-`. A named session appends `-<slug>` |
-| `BRIG_PROFILE_DIR` | `~/.config/brig` | Where custom profiles are read from and written to (`BRIG_TEMPLATE_DIR` still works) |
-| `BRIG_POLICY_DIR` | `~/.config/brig/policies` | Where egress policies are read from and written to (`$XDG_CONFIG_HOME/brig/policies`). See [docs/policies.md](docs/policies.md) |
-| `BRIG_STATE_DIR` | `~/.brig` | Where brig keeps what has to outlive one command, including the workspace each sandbox was started with. Bookkeeping only: an unusable file there costs a restart, never a failed command |
-
-### Image and guest
-
-| variable | default | what it does |
-| --- | --- | --- |
-| `BRIG_IMAGE` | per profile | Guest image to boot |
-| `BRIG_PULL` | `missing` | `missing`, `always` or `never`. A cached tag is not re-resolved, so a republished moving tag stays invisible until you say `always` |
-| `BRIG_MEM` | per profile (4096) | Guest memory, MB |
-| `BRIG_CPUS` | per profile (4) | Guest vCPUs |
-| `BRIG_READY_TIMEOUT` | `30` | Seconds to wait for the in-guest agent after the runtime reports the sandbox running. The two are not the same moment |
-| `BRIG_TITLE` | per profile | Window title, for a graphical agent |
-| `BRIG_NETWORK` | per profile (`shared`) | `shared`, `isolated` or `offline`. `isolated` gives the sandbox a network of its own, which on Linux is what keeps two sandboxes from reaching each other; the macOS backends already keep them apart. `offline` boots the sandbox with no route out: the agent runs, the workspace is there, nothing leaves. Same as `--network`; `--offline` is shorthand for `--network offline`. An unrecognised value refuses the run |
-| `BRIG_SKILLS` | `0` | Seed the profile's `hostConfigDir`/`projectPaths` into the workspace -- for Claude Code, `~/.claude/skills` and `~/.claude/plugins`. Same as `--skills`; see [Your own skills in the guest](#your-own-skills-in-the-guest) |
-
-### Credentials
-
-| variable | default | what it does |
-| --- | --- | --- |
-| `BRIG_FORWARD_ENV` | per profile | Space-separated list of variables to forward. Replaces the profile's list rather than adding to it |
-| `BRIG_ALLOW_REFS` | `0` | Forward a value that looks like an unresolved `scheme://` secret reference |
-| `BRIG_ALLOW_DENIED` | `0` | Forward a variable on the profile's billing denylist |
-| `BRIG_ALLOW_EXPIRED` | `0` | Forward the host credential even though it reports as expired. brig withholds one by default, because a dead token turns into a confusing failure inside the guest rather than a clear one on the host. Set this if your clock is the thing that is wrong. Scoped to the deprecated `hostCredential:` path, and goes with it: an imported credential that has expired warns and is still delivered, so there is nothing to override |
-| `GIT_TERMINAL_PROMPT` | `0` | Forwarded as-is; set it to `1` on the host to let git prompt in the guest |
-
-Removed: `BRIG_CREDENTIALS_CMD` ran a command of yours on every boot to read the host credential. brig now refuses to start when it is set, and names the replacement, which reads your command once instead: `brig secret import <profile> <name> --from-command '<command>'`.
-
-### Guest git
-
-| variable | default | what it does |
-| --- | --- | --- |
-| `BRIG_GIT_CONFIG` | `0` | Write the credential helper and gitconfig into the workspace, routing SSH GitHub remotes over HTTPS |
-| `BRIG_GIT_HOSTS` | `github.com` | Space-separated hosts the token applies to |
-| `BRIG_GIT_USER` | `github.user`, then gh's record, then `x-access-token` | Username paired with the forwarded token |
-| `BRIG_GIT_IDENTITY` | `1` | Forward the host commit identity, resolved from the invoking directory |
-| `BRIG_GIT_NAME`, `BRIG_GIT_EMAIL` | host git config | Override that identity |
-
-### Trust and verification
-
-| variable | default | what it does |
-| --- | --- | --- |
-| `BRIG_TRUST_WORKSPACE` | `1` | Pre-answer the agent's "do you trust the files in this folder?" for the directory each run starts in. The guest sees only the workspace, so mounting it already answered that question |
-| `BRIG_VERIFY` | `warn` | `warn`, `require` or `off` -- see the table above. `strict` is `require`; `none` and `0` are `off`. Any other value refuses the run |
-| `BRIG_VERIFY_REGISTRY` | `ghcr.io/brig-sh/` | Image prefix treated as "ours", so a check is expected |
-| `BRIG_VERIFY_IDENTITY` | community-images workflow | Certificate identity regexp cosign must match |
-| `BRIG_VERIFY_ISSUER` | GitHub Actions OIDC | Certificate OIDC issuer |
-| `BRIG_COSIGN_BIN` | `cosign` | Path to cosign |
-
-### Runtime
-
-| variable | default | what it does |
-| --- | --- | --- |
-| `BRIG_RUNTIME` | `hull` on macOS, `nerdctl` elsewhere | Which backend to drive |
-| `BRIG_RUNTIME_BIN` | first of `hull` / `nerdctl`, `docker` on PATH | Path to that binary |
-| `BRIG_HYPERVISOR` | the profile's `hypervisor`, else `vz` | Hypervisor backend, macOS only: `vz`, `hvi` or `qemu`. Set, it wins over the profile; the `vz` default applies only when the profile is silent, and six of the eight shipped profiles say `hvi`. Only `vz` has a graphical console, so a GUI profile is refused on the others. `hvi` needs macOS 15 or newer, and brig refuses the run on an older one rather than letting the VMM crash |
-| `BRIG_GATEWAY_SOCK` | `~/.brig/gateway-<subnet>.sock` | Control socket of the user-mode network gateway. `hvi` has no egress without one, so brig starts a shared gateway there and joins every sandbox on the shared network to it. The default name carries the network it serves, so a gateway left from a different subnet is never reused for guests that are not on it |
-| `BRIG_GATEWAY_DIR` | the directory of `BRIG_GATEWAY_SOCK`, else `~/.brig` | Where the gateway sockets live. A sandbox on `--network isolated`, or one carrying a policy, gets a gateway of its own here (`sandbox-<name>.sock`) on a `/30` of its own, rather than joining the shared one |
-| `BRIG_BOOT_ASSETS` | whatever `hull assets dir` reports on macOS, `$XDG_DATA_HOME/brig/assets` (default `~/.local/share/brig/assets`) on Linux | Directory holding the host kernel and `container-initrd` used to boot a profile marked `genericBoot`. The kernel is named `Image` on arm64 and `bzImage` on x86_64. Set it and brig uses what is there, unchanged; leave it unset and brig downloads the pair on first use (hull on macOS, `oras` on Linux) |
-| `BRIG_BOOT_ASSETS_REF` | `ghcr.io/nofireai/hull-assets:<os>-<arch>` | The bundle brig fetches when the boot assets are missing. Override to pin a version or use a mirror |
-| `BRIG_ROOTFS_TYPE` | profile's `rootfsType` | How the guest root reaches the VM: `block`, `virtiofs` or `9pfs` |
-| `BRIG_ENV_ARGV` | `0` | Put forwarded values back on the runtime's command line, where `ps` can read them. For a runtime build that does not accept a bare `--env KEY`. Opt-in -- on only when set to exactly `1` -- and it costs you the `ps` guarantee. Inert for a value brig resolved on your behalf -- a secret from its store, or the host credential -- which stays off the command line regardless |
-| `DO_NOT_TRACK`, `HULL_TELEMETRY_DISABLED` | | Passed through to the runtime untouched, and always win |
-
-
-## brigd
-
-`brigd` keeps the session inventory and is the single owner of boot and
-teardown when several callers want the same sandbox, over the same library the
-CLI uses. Line-delimited JSON on a unix socket:
-
-```json
-{"op":"ensure","agent":"claude-code","name":"refactor"}
-{"op":"status"}
-{"op":"stop","agent":"claude-code","name":"refactor"}
-```
-
-It does not proxy exec. Handing your terminal to a process inside the guest
-means passing file descriptors, and `brig sh` already does that correctly by
-replacing itself with the runtime. The daemon owns lifecycle, the CLI owns the
-terminal. See [docs/brigd.md](docs/brigd.md).
-
-## Agents
-
-Profiles are data ([internal/profile](internal/profile/profile.go)): a binary,
-the variables carrying its credentials, the ones denied for billing safety,
-the state paths, and an image. The eight built-in specs live in
-[internal/profile/specs](internal/profile/specs/) and are embedded in the
-binary, so brig works with no setup at all. Guest images live in
-[brig-sh/community-images](https://github.com/brig-sh/community-images) with
-open Dockerfiles, and a profile name is the same string as its image name.
-
-Claude Code and Codex are the proven core. Gemini, Grok, opencode and cursor
-are example profiles, and cursor ships without an image (see
-[Image tags](#image-tags)). `claude-desktop` is the GUI app in a windowed VM, and
-`ubuntu` is a plain root shell for when you need to inspect guest networking
-or raise a raw socket.
-
-## Verifying a brig download
-
-Releases are signed with keyless cosign -- no key to distribute, none for us to
-lose:
-
-```bash
-cosign verify-blob \
-  --certificate checksums.txt.pem \
-  --signature checksums.txt.sig \
-  --certificate-identity-regexp \
-    '^https://github\.com/brig-sh/brig/\.github/workflows/release\.yml@refs/tags/v' \
-  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
-  checksums.txt
-
-shasum -a 256 -c checksums.txt --ignore-missing
-```
-
-The macOS binaries are also signed with a Developer ID certificate and
-notarized with Apple, so Gatekeeper accepts them without any quarantine
-fiddling. Each archive ships an SPDX SBOM.
-
-## Not yet ported
-
-- **Workspace clone/overlay and explicit-apply.** The workspace is mounted
-  directly, so an agent works on your files rather than on a private copy it
-  later applies.
+brig counts a small number of events and reports what it counts. Run
+`brig telemetry status` to see the current setting, and `brig telemetry off` to
+turn the counting off.
 
 ## License
 
-Apache-2.0, see [LICENSE](LICENSE). That covers brig itself. The agent CLIs it
-runs, and the guest images they come in, are each under their own terms.
-
----
+Apache License 2.0. See [LICENSE](LICENSE).
 
 <p align="center">
-  <a href="https://nofire.ai">
-    <picture>
-      <source media="(prefers-color-scheme: dark)" srcset="assets/nofire-logo-on-dark.svg">
-      <img alt="NOFire AI" src="assets/nofire-logo.svg" width="150">
-    </picture>
-  </a>
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="assets/nofire-logo-on-dark.svg">
+    <img alt="NOFire AI" src="assets/nofire-logo.svg" width="120">
+  </picture>
 </p>
-
-<p align="center">Powered by <a href="https://nofire.ai">NOFire AI</a></p>

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ brig run claude ~/code/demo
 - **The sandbox** is a microVM: `hull` on macOS, `nerdctl` with containerd and
   the `urunc` shim on Linux.
 - **Credentials** are not carried in by default. The sandbox boots with none,
-  so the agent asks you to log in exactly as it would on a new machine.
+  so the agent asks you to log in exactly as it does on a new machine.
 
 ## Requirements
 
@@ -122,7 +122,7 @@ brig run claude                  # reopen the session on the project it last use
 brig run claude@refactor ~/code/demo   # a second session, its own sandbox and home
 brig sh claude                   # a login shell inside the sandbox
 brig sh claude ls /work          # one command inside it
-brig info claude                 # the boundary a run would use, before booting
+brig info claude                 # the boundary a run uses, before booting
 brig logs claude --follow        # stream the sandbox's log
 ```
 

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ network and the credentials by name, and it boots nothing.
 ## The boundary
 
 <p align="center">
-  <img alt="brig sandbox architecture: brig run resolves the session on the host; hull drives a microVM on macOS and urunc over KVM on Linux; both give the guest the same contract of a guest home, a project mount, per-exec credentials and a verified image" src="assets/architecture.svg" width="900">
+  <img alt="brig sandbox architecture. brig run resolves the session on the host. hull drives a microVM on macOS, urunc over KVM on Linux. Both give the guest the same contract: a guest home, a project mount, per-exec credentials, and an image whose signature brig checks" src="assets/architecture.svg" width="900">
 </p>
 
 What the sandbox keeps out: every host directory except the guest home and the
@@ -145,7 +145,7 @@ mounted, because that mount is read-write and those are your real files. It can
 read any credential you chose to deliver into the guest. On the default
 `shared` network it can reach the internet, so anything it can read it can also
 send. Egress filtering exists, and brig enforces it only on hull's `hvi`
-backend; on any other backend a policy-bound run is refused rather than run
+backend. On any other backend a policy-bound run is refused rather than run
 unenforced.
 
 Image verification defaults to `warn`, which reports an unverifiable image and

--- a/assets/README.md
+++ b/assets/README.md
@@ -30,7 +30,7 @@ outlines, so the files carry no font dependency.
 | `brig-lockup-on-{dark,light}.svg` | Horizontal lockup, transparent, for README headers via `<picture>`. |
 | `brig-lockup-badge.svg` | Lockup on its own navy field, for slides and anywhere the background is uncontrolled. |
 | `nofire-logo.svg`, `nofire-logo-on-dark.svg` | The NOFire AI logo, for the README footer. |
-| `architecture.svg` | The diagram in the README's "What brig is". README embeds it with `<img src>`, so the SVG's own internal `<title>` and `<desc>` are never read by a browser. The `img` element's `alt` attribute carries the description instead. Keep that alt text current whenever you change the diagram. |
+| `architecture.svg` | The diagram in the README's "The boundary". README embeds it with `<img src>`, so the SVG's own internal `<title>` and `<desc>` are never read by a browser. The `img` element's `alt` attribute carries the description instead. Keep that alt text current whenever you change the diagram. |
 
 The directory is flat. hull's own set of marks lives in
 [brig-sh/brig-artwork](https://github.com/brig-sh/brig-artwork) with the

--- a/assets/README.md
+++ b/assets/README.md
@@ -30,7 +30,7 @@ outlines, so the files carry no font dependency.
 | `brig-lockup-on-{dark,light}.svg` | Horizontal lockup, transparent, for README headers via `<picture>`. |
 | `brig-lockup-badge.svg` | Lockup on its own navy field, for slides and anywhere the background is uncontrolled. |
 | `nofire-logo.svg`, `nofire-logo-on-dark.svg` | The NOFire AI logo, for the README footer. |
-| `architecture.svg` | The diagram in the README's "What brig is". |
+| `architecture.svg` | The diagram in the README's "What brig is". README embeds it with `<img src>`, so the SVG's own internal `<title>` and `<desc>` are never read by a browser. The `img` element's `alt` attribute carries the description instead. Keep that alt text current whenever you change the diagram. |
 
 The directory is flat. hull's own set of marks lives in
 [brig-sh/brig-artwork](https://github.com/brig-sh/brig-artwork) with the

--- a/assets/architecture.svg
+++ b/assets/architecture.svg
@@ -3,7 +3,7 @@
      font-family="'Avenir Next','Helvetica Neue',Helvetica,Arial,sans-serif"
      fill="none" stroke-linecap="round" stroke-linejoin="round">
   <title id="title">brig sandbox architecture</title>
-  <desc id="desc">One command, brig run agent, resolves a session on the host and boots it as a microVM. On macOS the runtime is hull over Hypervisor.framework; on Linux it is urunc, a containerd runtime-v2 shim, over KVM. Both hosts give the guest the same contract: the workspace mounted as the agent home, credentials passed per exec, and a cosign-verified guest image.</desc>
+  <desc id="desc">One command, brig run agent, resolves a session on the host and boots it as a microVM. On macOS the runtime is hull, over Virtualization.framework on its vz backend or Hypervisor.framework on its hvi backend. On Linux it is urunc, a containerd runtime-v2 shim, over KVM. Both hosts give the guest the same contract: a host directory mounted as the agent home, the project you name mounted read-write at /work, credentials passed per exec, and a guest image whose signature brig checks before boot.</desc>
   <style>
     svg { color: #253039; }
     .bg { fill: #fbfaf7; }
@@ -68,7 +68,7 @@
   <line x1="285" y1="278" x2="285" y2="300" class="line" stroke-width="1.3" marker-end="url(#arrow)"/>
   <rect x="54" y="302" width="462" height="58" rx="4" class="surface line" stroke-width="1.5"/>
   <g class="ink" stroke="none">
-    <text x="70" y="325" font-size="12.5" font-weight="650">hull &#183; Vz / QEMU backends</text>
+    <text x="70" y="325" font-size="12.5" font-weight="650">hull &#183; hvi / vz / qemu backends</text>
     <text x="70" y="345" class="muted" font-size="10.8">microVM runtime &#183; boots the guest image and mounts the workspace</text>
   </g>
 
@@ -116,9 +116,9 @@
 
   <rect x="54" y="542" width="330" height="70" rx="4" class="surface ember" stroke-width="1.8"/>
   <g class="ink" stroke="none">
-    <text x="70" y="566" font-size="12.2" font-weight="650">workspace as guest home</text>
-    <text x="70" y="586" class="muted" font-size="10.5">your project directory, mounted as the</text>
-    <text x="70" y="601" class="muted" font-size="10.5">agent&#8217;s home. Nothing else is visible.</text>
+    <text x="70" y="566" font-size="12.2" font-weight="650">guest home, plus one project</text>
+    <text x="70" y="586" class="muted" font-size="10.5">a host directory as the agent home, and</text>
+    <text x="70" y="601" class="muted" font-size="10.5">the project you name, read-write at /work.</text>
   </g>
 
   <rect x="396" y="542" width="330" height="70" rx="4" class="surface ember" stroke-width="1.8"/>
@@ -131,7 +131,7 @@
   <rect x="738" y="542" width="328" height="70" rx="4" class="surface ember" stroke-width="1.8"/>
   <g class="ink" stroke="none">
     <text x="754" y="566" font-size="12.2" font-weight="650">verified guest image</text>
-    <text x="754" y="586" class="muted" font-size="10.5">cosign signature checked against</text>
-    <text x="754" y="601" class="muted" font-size="10.5">ghcr.io/brig-sh before the guest boots.</text>
+    <text x="754" y="586" class="muted" font-size="10.5">cosign signature checked before boot.</text>
+    <text x="754" y="601" class="muted" font-size="10.5">warn reports, require refuses.</text>
   </g>
 </svg>

--- a/cmd/brig/doctor.go
+++ b/cmd/brig/doctor.go
@@ -149,7 +149,7 @@ func parseDoctorArgs(args []string) (jsonOut bool, agent string, err error) {
 // gives a caller the same code the equivalent run would have -- so a wrapper
 // script reads "fix the runtime" from doctor exactly as it reads it from a
 // failed `brig run`, without a second table to parse. #9 asked for a flat exit
-// 5; the exit-code table that landed in #104 (README around line 219) is the
+// 5; the exit-code table that landed in #104 (docs/cli.md, "Exit codes") is the
 // contract now, and 5 there is "verification refused", which a diagnostic that
 // boots nothing never does. Every other check is diagnostic: it prints its
 // finding and its fix and leaves the status alone, so `brig doctor` on a host

--- a/cmd/brig/exit.go
+++ b/cmd/brig/exit.go
@@ -8,8 +8,8 @@ import (
 	"github.com/brig-sh/brig/internal/wrap"
 )
 
-// Exit codes brig promises to a script. They are documented in the README
-// beside the command reference.
+// Exit codes brig promises to a script. They are documented in docs/cli.md,
+// under "Exit codes".
 //
 // The mapping below is no longer the only thing that produces them:
 // internal/exitcode classifies the same numbers for brigd, which cannot import

--- a/cmd/brig/exit_test.go
+++ b/cmd/brig/exit_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 // TestExitCode pins the mapping from an error to the process exit status. Every
-// code in the README table has a case here, so a documented code that nothing
+// code in docs/cli.md's table has a case here, so a documented code that nothing
 // returns is a test failure rather than a surprise for a script.
 func TestExitCode(t *testing.T) {
 	cases := []struct {

--- a/cmd/brig/main.go
+++ b/cmd/brig/main.go
@@ -133,7 +133,7 @@ every time: copy the closest one and edit it, with
 Building an image for one is documented at
   https://github.com/brig-sh/community-images/blob/main/docs/bring-your-own-image.md
 
-settings (BRIG_<AGENT>_<KEY> wins over BRIG_<KEY>; see the README for all):
+settings (BRIG_<AGENT>_<KEY> wins over BRIG_<KEY>; docs/cli.md has them all):
   BRIG_WORKSPACE       host directory mounted as the guest home
   BRIG_IMAGE           guest image
   BRIG_PULL            missing (default) | always | never
@@ -162,7 +162,7 @@ func main() {
 	// The exit status is a stable, documented set: a script can tell "you
 	// asked for the wrong thing" from "it ran and failed" from "the sandbox
 	// could not be verified" without parsing the message. exitCode owns the
-	// mapping; the README documents it. A run refused for any reason still
+	// mapping; docs/cli.md documents it. A run refused for any reason still
 	// exits non-zero, so a stop or a boot that removed or started nothing
 	// never reads as success.
 	os.Exit(exitCode(err))
@@ -1890,7 +1890,7 @@ func takeAll(args []string) (rest []string, all bool) {
 //
 // It asks the runtime whether that sandbox is there before handing over, so the
 // case the runtime used to answer with its own "instance not found" -- there is
-// nothing to remove -- is reported as a not-found (exit 3), the code the README
+// nothing to remove -- is reported as a not-found (exit 3), the code docs/cli.md
 // gives a name that resolves to nothing, rather than as a removal that ran and
 // failed (exit 1). A List that itself fails is a runtime that could not be asked
 // (exit 4), a different fact the exit table keeps apart, so it comes back
@@ -1918,7 +1918,7 @@ func removeSandbox(cfg *wrap.Config, ref string) error {
 //
 // It is how rm and logs tell "there is nothing here" -- a not-found, exit 3 --
 // from a runtime that could not be asked -- its own error, exit 4. The two are
-// different facts and the README's exit table keeps them apart, so a List that
+// different facts and docs/cli.md's exit table keeps them apart, so a List that
 // fails is returned as is rather than folded into absence.
 func sandboxPresent(rt runtime.Runtime, name string) (bool, error) {
 	list, err := rt.List()

--- a/cmd/brig/notfound_test.go
+++ b/cmd/brig/notfound_test.go
@@ -86,7 +86,7 @@ func TestRemoveSandboxProceedsWhenPresent(t *testing.T) {
 // A List that fails is a runtime that could not be asked, not a sandbox that is
 // gone: the error comes back as is, so exitCode reads it as the runtime class
 // rather than not-found. Turning "could not ask" into "not there" would erase a
-// fact the README's exit table keeps apart.
+// fact docs/cli.md's exit table keeps apart.
 func TestRemoveSandboxPropagatesAListError(t *testing.T) {
 	t.Setenv("BRIG_STATE_DIR", t.TempDir())
 	boom := errors.New("cannot connect to the daemon")

--- a/cmd/brig/secret_test.go
+++ b/cmd/brig/secret_test.go
@@ -681,8 +681,9 @@ func TestStdinIsAcceptedExplicitly(t *testing.T) {
 	}
 }
 
-// `-f -` is the conventional spelling of "the file is stdin", and the README
-// uses it, so it has to mean stdin rather than a file called "-".
+// `-f -` is the conventional spelling of "the file is stdin", and
+// docs/secrets.md uses it, so it has to mean stdin rather than a file
+// called "-".
 func TestDashAsTheFileMeansStdin(t *testing.T) {
 	f := newFake(t)
 	pipeStdin(t, "tok")

--- a/cmd/brig/telemetry.go
+++ b/cmd/brig/telemetry.go
@@ -24,8 +24,8 @@ runtime underneath, and these verbs set the answer it keeps, so an opt-out
 holds whether brig is the caller or not. DO_NOT_TRACK=1 in your environment
 turns it off without recording anything, and beats both.
 
-The telemetry section of the README lists every field an event carries, who
-receives it, and what is never collected.
+docs/telemetry.md lists every field an event carries, who receives it, and
+what is never collected.
 `
 
 // telemetryCmd reports and sets the telemetry answer.

--- a/docs/README.md
+++ b/docs/README.md
@@ -67,6 +67,6 @@ not current validation, and each one says so in its own header.
 | --- | --- |
 | [manual-tests/egress-policy.md](manual-tests/egress-policy.md) | Egress rules against a live gateway |
 | [manual-tests/runtime-stdin.md](manual-tests/runtime-stdin.md) | Standard input through the runtime |
-| [manual-tests/sandbox-reachability.md](manual-tests/sandbox-reachability.md) | What a guest could reach from inside the sandbox |
+| [manual-tests/sandbox-reachability.md](manual-tests/sandbox-reachability.md) | What a guest can reach from inside the sandbox |
 | [manual-tests/secret-files.md](manual-tests/secret-files.md) | File-delivered secrets and their tmpfs backing |
 | [manual-tests/secret-provenance.md](manual-tests/secret-provenance.md) | Where an imported secret came from |

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,72 @@
+# brig documentation
+
+Start with [the README](../README.md) for what brig is and a first run. This
+index is the map of everything else.
+
+## Get started
+
+| Page | What it gives you |
+| --- | --- |
+| [install.md](install.md) | Every way to install brig, per platform, and how to verify a download |
+| [quickstart.md](quickstart.md) | One agent running on a throwaway project, start to finish |
+| [support.md](support.md) | Where to ask a question or file a bug |
+
+## Use brig
+
+| Page | What it gives you |
+| --- | --- |
+| [sessions.md](sessions.md) | Guest homes, projects, named sessions, and what survives which command |
+| [authentication.md](authentication.md) | Getting an agent logged in, and Git access inside the guest |
+| [secrets.md](secrets.md) | The secret store, profile secret fields, and `brig secret import` |
+| [policies.md](policies.md) | Networking modes and egress policy |
+| [profiles.md](profiles.md) | The profile file format, and running your own agent |
+| [guest-image.md](guest-image.md) | The contract an image must meet to boot as a guest |
+| [completions.md](completions.md) | Shell completion for bash, zsh and fish |
+
+## Look something up
+
+| Page | What it gives you |
+| --- | --- |
+| [cli.md](cli.md) | Every verb and flag, the environment variables, the JSON output and the exit codes |
+| [migration.md](migration.md) | Every retired spelling and its replacement |
+| [stability.md](stability.md) | What you can script against, and what is expected to move |
+| [telemetry.md](telemetry.md) | What brig counts, and how to turn it off |
+
+## Understand the design
+
+| Page | What it gives you |
+| --- | --- |
+| [security.md](security.md) | What the sandbox isolates, and what an agent can still do |
+| [non-goals.md](non-goals.md) | What brig does not try to be |
+| [runtimes.md](runtimes.md) | The macOS backends, the Linux runtimes, and how one is chosen |
+| [brigd.md](brigd.md) | What the daemon is for |
+
+## Fix something
+
+| Page | What it gives you |
+| --- | --- |
+| [troubleshooting.md](troubleshooting.md) | Organized by the error you saw, with the command that confirms the fix |
+
+## Contribute
+
+| Page | What it gives you |
+| --- | --- |
+| [../CONTRIBUTING.md](../CONTRIBUTING.md) | The build, the tests, the review norms |
+| [../AI_POLICY.md](../AI_POLICY.md) | How AI-assisted contributions are handled |
+| [../SECURITY.md](../SECURITY.md) | Reporting a vulnerability |
+| [releasing.md](releasing.md) | Cutting a release. Maintainers only |
+| [../assets/README.md](../assets/README.md) | The logo and diagram assets, and how to use them |
+
+## Historical records
+
+[manual-tests/](manual-tests/) holds dated engineering records from specific
+changes. They evidence what was measured on the day they were written. They are
+not current validation, and each one says so in its own header.
+
+| Record | What it measured |
+| --- | --- |
+| [manual-tests/egress-policy.md](manual-tests/egress-policy.md) | Egress rules against a live gateway |
+| [manual-tests/runtime-stdin.md](manual-tests/runtime-stdin.md) | Standard input through the runtime |
+| [manual-tests/sandbox-reachability.md](manual-tests/sandbox-reachability.md) | What a guest could reach from inside the sandbox |
+| [manual-tests/secret-files.md](manual-tests/secret-files.md) | File-delivered secrets and their tmpfs backing |
+| [manual-tests/secret-provenance.md](manual-tests/secret-provenance.md) | Where an imported secret came from |

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -1,0 +1,161 @@
+# Logging an agent in
+
+By the end of this page you can pick how an agent gets its credentials. It
+can then reach GitHub over HTTPS from inside the guest.
+
+Prerequisites: brig installed ([install.md](install.md)) and a shipped agent,
+such as `claude-code`. Nothing else.
+
+This page uses **agent** for the CLI surface you run: `brig run claude`, a
+session. It uses **profile** for the file that declares credentials:
+`brig secret import claude-code`. A built-in agent and its profile share one
+name, but they are not the same thing. A profile has no session, and
+`brig secret import` takes no `@label`.
+
+## Three ways to give an agent a credential
+
+Pick based on whether the login already exists on your host, and whether you
+want it to survive `brig stop`.
+
+### 1. Log in inside the guest
+
+The default. It needs no setup:
+
+```bash
+brig run claude ~/code/demo
+```
+
+`claude-code` declares two secrets, `claude-credentials` and `gh-token`.
+Both are optional, so neither must exist before the sandbox boots.
+`brig info claude` prints the same warnings a `run` prints, without booting
+anything:
+
+```console
+$ brig info claude
+brig: no value for the secret "gh-token", and claude-code will run without it.
+brig: To supply one: brig secret create gh-token
+brig: no value for the secret "claude-credentials", and claude-code will run without it.
+brig: To carry it in from your host: brig secret import claude-code
+brig: run `claude` on the host once to log in
+```
+
+That run exits 0. Only a **required** secret stops a run before the sandbox
+exists, and no profile brig ships declares one. `brig --help`'s note that
+`info` "fails if a declared secret is missing" describes a path none of the
+eight built-in profiles can reach.
+
+Claude Code prompts for the login the sandbox does not have. Complete it
+inside the guest, the same way a fresh machine's first login works.
+
+Where that login lands next depends on the profile. `claude-code` and
+`claude-desktop` write it to a memory-backed mount. `brig stop claude` takes
+the whole VM with it, and the next `brig run claude` prompts again. The other
+five agent profiles mount the guest home from host disk instead: `codex`,
+`cursor`, `gemini`, `grok`, `opencode`. A login written there survives a stop.
+
+Choose this path for a first run with no setup. On `claude-code` or
+`claude-desktop`, you log in again after every `brig stop`. On the other five
+profiles, the login persists on its own.
+
+### 2. Carry your host login in, once
+
+You already logged in to the agent's own app or CLI on this Mac. You want
+that login to survive a stop, without repeating it inside the guest:
+
+```bash
+brig secret import claude-code
+```
+
+`claude-code` and `claude-desktop` fill `claude-credentials` from the first
+of two places on your host: the macOS keychain's `Claude Code-credentials`
+generic-password item, then the file `~/.claude/.credentials.json`. Neither
+declares a source for `gh-token`. That one takes a value you supply by hand
+(`brig secret create gh-token`) or export live, path 3 below.
+
+The other six shipped profiles declare no `secrets:` at all: `codex`,
+`cursor`, `gemini`, `grok`, `opencode`, `ubuntu`. There is nothing on your
+host for `import` to read. On a host with a working secret store, the
+command still succeeds: it prints `<profile>: importing 0 secrets` and exits
+0. On a host with no keyring it fails instead, even though there is nothing
+to import.
+
+**If a long `claude-code` session stops authenticating.** brig re-delivers the
+stored `claude-credentials` document on every command that reaches the
+sandbox. `run`, `sh` and `exec` all count, not only the first boot.
+
+Measured 2026-08-19 against a live account: Claude Code refreshes that
+document in place, and Anthropic rotates the refresh token single-use. A
+refresh inside the guest invalidates the host copy, so the next brig command
+re-delivers the dead stored document over the guest's fresh one. This can
+change with either the agent or the provider. If a session starts failing to
+authenticate, log in on the host again and re-run
+`brig secret import claude-code`.
+
+Choose this path when you already have a working login on this Mac, and want
+the sandbox to start already authenticated.
+
+### 3. Live environment bindings
+
+Some agents read a credential straight from your own environment, live, on
+every run:
+
+| profile | variable |
+| --- | --- |
+| `cursor` | `CURSOR_API_KEY` |
+| `gemini` | `GEMINI_API_KEY` |
+| `grok` | `XAI_API_KEY` |
+| `opencode` | `OPENROUTER_API_KEY` |
+
+Export it before you run:
+
+```bash
+export GEMINI_API_KEY=<key>
+brig run gemini ~/code/demo
+```
+
+`claude-code` and `claude-desktop` refuse `ANTHROPIC_API_KEY` and
+`ANTHROPIC_AUTH_TOKEN` from your environment on purpose: forwarding either
+one moves the sandbox off your subscription and onto metered billing.
+`codex` denies `OPENAI_API_KEY` for the same reason. It signs in with
+`codex login --device-auth` inside the guest instead, which is path 1 above.
+`codex` also declares no `secrets:`, so path 2 cannot fill one either.
+[secrets.md](secrets.md) has the exact message brig prints and the override.
+
+Choose this path when a key already lives in your shell, a CI job, or a
+secret manager's run-with-env wrapper. brig reads it fresh on every run
+instead of storing a copy.
+
+## Git access in the guest
+
+A token in `GH_TOKEN` is for git over HTTPS inside the guest, not for the
+agent's own authentication to its provider.
+
+Guest git over HTTPS is off by default. `brig info` reports the setting:
+
+```console
+$ brig info claude
+...
+brig: guest git over HTTPS: off (BRIG_GIT_CONFIG=1 to enable)
+```
+
+Turn it on with `BRIG_GIT_CONFIG=1`:
+
+```bash
+BRIG_GIT_CONFIG=1 brig run claude ~/code/demo
+```
+
+With it on, brig regenerates a credential helper and a managed gitconfig
+inside the guest on every run. The helper reads `GH_TOKEN` at the moment git
+asks for a credential. It does nothing when the variable is unset, so git
+reports its own authentication error instead of failing on an empty
+password.
+
+`GH_TOKEN` reaches the guest differently by profile. On `claude-code` and
+`claude-desktop` it is a chain: your exported `GH_TOKEN` wins if you set one,
+and a stored `gh-token` secret is the fallback. On the other six profiles it
+comes only from your exported `GH_TOKEN`. A stored `gh-token` secret does not
+reach them.
+
+[secrets.md](secrets.md) is the reference for the store behind path 2 and the
+`gh-token` fallback. [profiles.md](profiles.md) is where to change any of
+this for an agent of your own.

--- a/docs/brigd.md
+++ b/docs/brigd.md
@@ -4,36 +4,48 @@
 callers want the same sandbox. It runs the same `internal/wrap` library the
 CLI does, so it cannot grow a second opinion about how a sandbox is built.
 
-It is deliberately small. The CLI works fine without it, and most people will
+It is deliberately small, and optional. The CLI has no client for it: every
+`brig` command talks to the runtime directly, whether brigd is running or not.
+`brig doctor` reports it with a neutral `--`, the mark it gives anything
+absent that is not a problem, never `!!`:
+
+```
+--  brigd     not running (no socket at /Users/pmoust/.brig/brigd.sock)
+```
+
+Run it when something else wants one socket to ask brig through. That is a
+second tool driving several sandboxes from one process, or a client that
+wants boots on one sandbox serialized across several callers. Most people
 never run it.
 
 ## What it does not do
 
 It does not proxy exec. Handing your terminal to a process inside the guest
-means passing file descriptors, and `brig sh` already does that correctly by
+means passing file descriptors. `brig sh` already does that correctly, by
 replacing itself with the runtime. The daemon owns lifecycle, the CLI owns the
 terminal.
 
 ## Running it
 
 ```bash
-brigd                                  # ~/.brig/brigd.sock, or $XDG_RUNTIME_DIR
+brigd                                  # $XDG_RUNTIME_DIR/brigd.sock if set, else ~/.brig/brigd.sock
 brigd --socket /tmp/brigd.sock
 ```
 
 The socket is created 0600. It carries lifecycle control over sandboxes
 holding live credentials, so it belongs to the invoking user alone.
 
-A unix socket path has a length limit the kernel enforces -- 103 bytes on
-macOS, 107 on Linux -- and a path over it is refused before the bind, with the
-limit, the length given, and where the path came from. The kernel's own answer
-to an over-long path is `bind: invalid argument`, which names none of those.
+A unix socket path has a length limit the kernel enforces: 103 bytes on
+macOS, 107 on Linux. A path over it is refused before the bind, naming the
+limit, the length, and where the path came from. The kernel's own answer to
+an over-long path is `bind: invalid argument`, which names none of those.
 
-One daemon serves one socket path. Starting a second on a path that is already
-being served exits non-zero and names the process in the way, rather than
-taking the path over: two daemons on one socket would each keep an inventory
-of half the sandboxes. The lock is a `brigd.sock.lock` file beside the socket,
-held for as long as the daemon runs and released by the kernel if it dies.
+One daemon serves one socket path. Starting a second on a path already being
+served exits non-zero and names the process in the way, rather than taking
+the path over. Two daemons sharing one socket split the inventory, each
+holding half the sandboxes. The lock is a `brigd.sock.lock` file beside the
+socket, held for as long as the daemon runs and released by the kernel if it
+dies.
 
 ## Protocol
 
@@ -67,15 +79,16 @@ today.
 
 A request with no `v` is read as version 1: there is no client older than this,
 and the field has to start somewhere. A request carrying a `v` brigd does not
-know is refused with `code` 2 and an error naming the versions it does speak,
-rather than served a shape it may not understand. The response always carries
-`v`, so a client can tell what it is talking to from the answer itself.
+know is refused with `code` 2 and an error naming the versions it does speak.
+It is not served a shape brigd cannot be sure it understands. The response
+always carries `v`, so a client can tell what it is talking to from the
+answer itself.
 
 ### Request id
 
-A request may carry `id`, any string, and the response echoes it back unchanged,
-so a client pipelining several requests on one connection can match each answer
-to its question. Absent in, absent out:
+A request can carry `id`, any string, and the response echoes it back
+unchanged. A client pipelining several requests on one connection can match
+each answer to its question. Absent in, absent out:
 
 ```json
 {"v":1,"id":"boot-42","op":"ensure","agent":"claude-code"}
@@ -84,26 +97,27 @@ to its question. Absent in, absent out:
 
 ### Exit code
 
-Beside `error`, a response carries `code`: the stable exit status `brig` returns
-to a script, the same set and the same causes, so a script driving brigd
-branches the way one driving brig does. `0` on success, and on failure one of
-`1` general, `2` usage (an unknown op, an unknown protocol version), `3` no such
-profile or sandbox, `4` a runtime that is missing or broken, `5` a boot
-verification refused, `6` a credential that could not be resolved. The full
-table is in the README, beside the command reference.
+Beside `error`, a response carries `code`: the stable exit status `brig`
+returns to a script, the same set and the same causes. A script driving
+brigd branches the way one driving brig does. `0` is success. On failure it
+is one of `1` general, `2` usage (an unknown op, an unknown protocol
+version), or `3` no such profile or sandbox. The rest are `4` a runtime that
+is missing or broken, `5` a boot verification refused, and `6` a credential
+that was not resolved. The full table is at
+[docs/cli.md#exit-codes](cli.md#exit-codes).
 
 ```json
 {"v":1,"op":"ensure","agent":"no-such-profile"}
 {"v":1,"ok":false,"code":3,"error":"unknown agent \"no-such-profile\""}
 ```
 
-### Who may connect
+### Who can connect
 
 The socket is `0600` and the invoking user's alone. A mode is only a mode,
-though, so on each accepted connection brigd reads the peer's uid from the
-kernel -- `SO_PEERCRED` on Linux, `LOCAL_PEERCRED` on darwin, neither of them
-anything the peer can forge -- and refuses a uid other than its own with one
-line and a closed connection:
+though. On each accepted connection brigd reads the peer's uid from the
+kernel, which the peer cannot forge (`SO_PEERCRED` on Linux, `LOCAL_PEERCRED`
+on darwin). It refuses a uid other than its own, with one line and a closed
+connection:
 
 ```json
 {"v":1,"ok":false,"code":1,"error":"connection from uid 1001 refused: this socket serves only its owner, uid 1000"}
@@ -112,55 +126,56 @@ line and a closed connection:
 The socket carries lifecycle control over sandboxes holding live credentials, so
 this is a floor, not a nicety.
 
-`running` is re-read from the runtime on every report rather than taken from
-the inventory, so a sandbox stopped by something else is still reported as
-stopped. When the runtime could not be asked at all -- its binary is gone, a
+`running` is re-read from the runtime on every report, rather than taken from
+the inventory. A sandbox stopped by something else is still reported as
+stopped. When the runtime cannot be asked at all -- its binary is gone, a
 permission error, containerd is down -- the session carries `runningError`
-instead, and `running` says nothing:
+instead. `running` says nothing:
 
 ```json
 {"agent":"claude-code","sandbox":"brig-claude-code","workspace":"/Users/me/brig/claude-code",
   "running":false,"runningError":"nerdctl ps: exit status 1: cannot connect to containerd"}
 ```
 
-Show that as "cannot tell", not as a stopped sandbox: the daemon booted this
-one, so `running:false` on its own would claim it exited, and a runtime nobody
-could reach never made that claim.
+Show that as "cannot tell", not as a stopped sandbox. The daemon booted this
+one, so a bare `running:false` reads as exited, a claim a runtime nobody can
+reach never made.
 
-Anything the run says about itself comes back with it, as `warnings`, one line
-each: a credential that was not forwarded and why, a secret about to expire, an
-image that could not be verified. The CLI prints these on the terminal of the
-person who typed the command, and the daemon has no such terminal, so they
-travel to the client that asked rather than to whatever terminal brigd happens
-to have been started from.
+Anything the run says about itself comes back with it, as `warnings`, one
+line each. Examples: a credential that was not forwarded and why, a secret
+about to expire, an image the check did not confirm. The CLI prints these on
+the terminal of the person who typed the command. The daemon has no such
+terminal, so they travel to the client that asked, not to brigd's own
+terminal, wherever that is.
 
-Only things to act on. What a run narrates about its own progress, such as the
-line saying a boot has started, goes to brigd's stderr and not to the client, so
-an `ensure` that went entirely well comes back with no `warnings` at all.
+Only things to act on. What a run narrates about its own progress, such as
+the line saying a boot has started, goes to brigd's stderr, not to the
+client. An `ensure` that went entirely well comes back with no `warnings` at
+all.
 
 A connection that sends nothing for five minutes is closed. The deadline is
-reset on every read, so it bounds the silence and not the work: an `ensure`
+reset on every read, so it bounds the silence and not the work. An `ensure`
 that spends a minute booting is not racing it, and neither is a request that
 arrives in pieces.
 
 A response has thirty seconds to be delivered. A response is a line of JSON and
 fits the socket buffer, so a client that reads its answers never comes near
-this; one that asks and then stops reading would hold a goroutine and a
-descriptor open indefinitely once the buffer filled, and has its connection
+this. One that asks and then stops reading holds a goroutine and a
+descriptor open indefinitely once the buffer fills, so its connection is
 closed instead.
 
-A request line is at most 1 MiB, newline excluded. That is far more than an op,
-a profile name and a session name need; the limit exists so a client that never
-sends a newline cannot make the daemon buffer without bound. A longer one gets
-an error saying so written to it, and the connection is then closed, because
-what follows an over-length request in the stream cannot be told apart from the
-tail of it.
+A request line is at most 1 MiB, newline excluded. That is far more than an
+op, a profile name and a session name need. The limit exists so a client
+that never sends a newline cannot make the daemon buffer without bound. A
+longer one gets an error saying so written to it, and the connection is then
+closed. What follows an over-length request in the stream cannot be told
+apart from the tail of it.
 
-Whether that error is read is another matter. It goes out the moment the limit
-is reached, which is while the client is usually still writing, so a client that
+Whether that error is read is another matter. It goes out the moment the
+limit is reached, while the client is usually still writing. A client that
 does not read until its write returns sees the broken pipe rather than the
-error. The error is there for one that reads as it writes; the closed connection
-is what everybody else gets.
+error. The error is there for one that reads as it writes. The closed
+connection is what everybody else gets.
 
 For instance, with `socat`:
 
@@ -170,19 +185,19 @@ echo '{"op":"ensure","agent":"claude"}' | socat - UNIX-CONNECT:$HOME/.brig/brigd
 
 ## Behaviour worth knowing
 
-`ensure` takes exactly the CLI's path: it prepares the workspace, resolves
+`ensure` takes exactly the CLI's path: it prepares the guest home, resolves
 credentials, verifies the image and checks the share, then boots only if
 needed. Work on one sandbox is serialised, so two clients asking for the same
 one at the same moment get one boot rather than two.
 
 The daemon never asks a question. The image check stops to ask when an image
-claiming to be ours fails verification, and there is nobody on the other end of
-brigd's terminal to answer: the client is somewhere else and the sandbox's lock
-would be held across the wait. So a request that would have prompted is refused
+claiming to be ours fails verification. There is nobody at brigd's terminal
+to answer: the client is somewhere else, and the sandbox's lock stays held
+across the wait. So a request that needs a prompt is refused
 instead, with the reason and the setting that overrides it in `error`. Setting
 `BRIG_VERIFY=off`, or fixing the image, is how such a request goes through.
 
-The runtime is resolved per request, from the profile the request names, so a
+The runtime is resolved per request, from the profile the request names. A
 profile carrying `runtimeBin` drives the same binary through the daemon as it
 does through the CLI. A profile naming a binary that is not there fails that
 request and no other.
@@ -197,19 +212,21 @@ finds them.
 
 ## What a restart reconciles
 
-Nothing. On start brigd loads the profile registry and begins listening; it does
-not go to the runtime to rebuild which sandboxes it had started. The inventory
-is a cache of what this process has done, not a record of what exists -- the
-runtime is the source of truth, which is why `status` re-reads liveness from it
-on every report and `stop` will act on a running sandbox the inventory never
-heard of. So a fresh daemon has an empty inventory over a set of sandboxes that
-are still up: `status` shows none until something asks for them again, and
-`brig ls`, which reads the runtime directly, shows them throughout.
+Nothing. On start brigd loads the profile registry and begins listening. It
+does not go to the runtime to rebuild which sandboxes it had started. The
+inventory is a cache of what this process has done, not a record of what
+exists. The runtime is the source of truth. That is why `status` re-reads
+liveness from it on every report, and `stop` acts on a running sandbox the
+inventory never heard of.
+
+So a fresh daemon has an empty inventory over a set of sandboxes that are
+still up. `status` shows none until something asks for them again. `brig
+ls`, which reads the runtime directly, shows them throughout.
 
 ## Stability
 
 The protocol is versioned so a client can tell what it is talking to. It is
-**internal until brig 0.3**: within a version a field may be added, but none is
-renamed or removed, so a client that ignores unknown fields keeps working; a
-change that would break such a client is a new version (`v: 2`). That is the
+**internal until brig 0.3**: within a version a field can be added, but none
+is renamed or removed. A client that ignores unknown fields keeps working. A
+change that breaks such a client becomes a new version (`v: 2`). That is the
 same rule `brig --json` output follows.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,0 +1,738 @@
+# Command line reference
+
+Every brig verb and flag, the environment variables, the JSON output and the
+exit codes, checked against the code that implements them.
+[quickstart.md](quickstart.md) is the walkthrough for a first run. Read this
+page when you already know what you want and need the exact syntax.
+
+Every old spelling still works for one more release. This page teaches only
+the current one. [migration.md](migration.md) has the full old-to-new table
+and the deprecation window.
+
+## Verbs
+
+### `brig run`
+
+```bash
+brig run claude ~/code/demo
+```
+
+Starts the sandbox if it is not already running, then runs the agent inside
+it.
+
+```
+brig run <ref> [project] [args...]
+```
+
+- `<ref>` names the agent, and, with `@<label>`, a session of its own. See
+  [The ref](#the-ref) below.
+- `[project]` is a host directory. brig mounts it read-write at
+  `/work/<name>` and starts the agent there. See
+  [The run line](#the-run-line-ref-project-and-the-agents-own-arguments).
+- `[args...]` reach the agent untouched.
+
+Name no project, and brig remounts whatever this session ran with last:
+
+```bash
+brig run claude
+```
+
+Start a second, independent session of the same agent, with its own sandbox
+and its own guest home:
+
+```bash
+brig run claude@refactor ~/code/demo
+```
+
+Start the sandbox and exit, without attaching:
+
+```bash
+brig run claude ~/code/demo -d
+```
+
+Run with no project mounted at all, even one this session ran with before:
+
+```bash
+brig run claude --no-project
+```
+
+Pass an argument through to the agent rather than have brig read it. `--`
+ends brig's own parsing:
+
+```bash
+brig run claude ~/code/demo -- --version
+```
+
+### `brig sh`
+
+```bash
+brig sh claude
+```
+
+Opens a login shell inside the sandbox, starting it first if it is not
+running.
+
+```
+brig sh <ref> [command...]
+```
+
+`sh` takes no project argument. The first bare word after the ref is already
+the guest command:
+
+```bash
+brig sh claude ls /work
+```
+
+### `brig stop`
+
+```bash
+brig stop claude
+```
+
+Stops the sandbox and keeps its name and its state on disk. Stopping a
+sandbox that is not running is not an error, because that is already the
+state `stop` asks for.
+
+### `brig rm`
+
+```bash
+brig rm claude
+```
+
+Stops the sandbox and removes it. Your guest home and your project are host
+directories brig only mounted, so neither is touched.
+
+```bash
+brig rm --all
+```
+
+Stops and removes every sandbox brig has. `rm` and `stop` each take exactly
+one ref. Neither takes a list of them.
+
+### `brig ls`
+
+```bash
+brig ls
+```
+
+Lists every sandbox brig knows about, with its ref, state and workspace.
+
+```bash
+brig ls -q
+```
+
+Prints refs only, one per line, and skips a row with no derivable ref. Every
+line `-q` prints is a word another verb accepts.
+
+### `brig logs`
+
+```bash
+brig logs claude --follow
+```
+
+Streams the sandbox's log.
+
+```
+brig logs <ref> [--follow] [--tail N] [--raw]
+brig logs --gateway [<ref>]
+```
+
+| Flag | Meaning |
+| --- | --- |
+| `--follow` | keep streaming as new lines arrive |
+| `--tail N` | show the last `N` lines. Default: `-1`, meaning every line |
+| `--raw` | skip brig's own formatting |
+| `--gateway` | read the network gateway's log instead of the sandbox's own |
+
+With no ref, `--gateway` reads the shared gateway that serves the default
+network. With a ref, it reads that sandbox's own gateway log, which exists
+only for a sandbox on `--network isolated` or one carrying a policy:
+
+```bash
+brig logs --gateway
+brig logs --gateway claude
+```
+
+### `brig info`
+
+```bash
+brig info claude
+```
+
+Prints the execution envelope without booting anything: the sandbox name,
+the isolation, the guest home, the image, the verification mode, the network
+and the credentials by name.
+
+`info` fails only when a required secret cannot be resolved. A declared
+secret marked `required: false` prints a warning, and the command still
+exits `0`.
+
+### `brig doctor`
+
+```bash
+brig doctor
+```
+
+Checks, one line each: the host, the hypervisor, the runtime, the boot
+assets, cosign, the profile directory, the secret store and brigd.
+
+```bash
+brig doctor claude
+```
+
+Adds a ninth line, checking that agent's image.
+
+```bash
+brig doctor --json
+```
+
+Prints the same checks as a JSON array, each with `name`, `state`, `finding`
+and, when the check failed, `fix`.
+
+Only two checks gate the exit status: a missing or broken runtime, and a
+secret store that will not open. Every other finding, including one marked
+`!!`, prints its fix and leaves the exit status at `0`.
+
+### `brig version`
+
+```bash
+brig version
+```
+
+Prints `brig v0.1.0-rc18` in this release. `--version` is the same command.
+
+### `brig completion`
+
+```bash
+brig completion zsh > "${fpath[1]}/_brig"
+```
+
+Prints a completion script for `bash`, `zsh` or `fish` to stdout. Nothing is
+installed for you. See [completions.md](completions.md) for where each shell
+reads its script from, and exactly what completes where.
+
+### `brig agent`
+
+```bash
+brig agent ls
+```
+
+Lists the agents you can run.
+
+```
+brig agent ls
+brig agent show <agent>
+brig agent new <name> --from <agent>
+brig agent edit <name>
+brig agent rm <name>
+brig agent import <file>
+brig agent export <agent> [name]
+```
+
+Copy a built-in agent under a name of your own, then edit the copy:
+
+```bash
+brig agent new mine --from claude
+brig agent edit mine
+```
+
+A built-in agent has no file of its own until `new` gives it one. Print an
+agent, to read it or pipe it:
+
+```bash
+brig agent show claude-code
+```
+
+`export` is the alternative to `new --from`: same result, the other
+direction. Save a copy of an agent you did not create, under a name you
+choose:
+
+```bash
+brig agent export claude-code mine
+```
+
+Add a file you wrote or received:
+
+```bash
+brig agent import mine.yaml
+```
+
+Delete a file-backed agent, after asking:
+
+```bash
+brig agent rm mine
+```
+
+`--json` with `show`, `new` or `export` prints the document as JSON instead
+of YAML, with no envelope. See [`--json` output](#--json-output) below.
+[profiles.md](profiles.md) is the reference for the file format.
+
+### `brig policy`
+
+```bash
+brig policy ls
+```
+
+Lists every policy, and what binds it.
+
+```
+brig policy ls
+brig policy create <name>
+brig policy edit <name>
+brig policy show <name>
+brig policy rm <name>
+brig policy attach <policy> <agent> [-n <label>]
+brig policy detach <policy> <agent> [-n <label>]
+brig policy check <agent> [-n <label>]
+```
+
+Write a starter policy, then open it:
+
+```bash
+brig policy create locked-down
+```
+
+Bind it to every run of an agent:
+
+```bash
+brig policy attach locked-down claude
+```
+
+Bind it to one session instead of every run:
+
+```bash
+brig policy attach locked-down claude -n refactor
+```
+
+Confirm what is bound to a run, and whether brig can enforce it:
+
+```bash
+brig policy check claude
+```
+
+[policies.md](policies.md) covers the document format and what each network
+posture means.
+
+### `brig secret`
+
+```bash
+brig secret create gh-token
+```
+
+Reads the value from stdin and stores it under that name in your keyring.
+
+```
+brig secret create <name> [-f FILE]
+brig secret update <name> [-f FILE]
+brig secret read <name>
+brig secret delete <name>
+brig secret ls
+brig secret import <agent>
+brig secret import <agent> <name>
+```
+
+Fill every secret an agent's profile declares, from your host, once:
+
+```bash
+brig secret import claude-code
+```
+
+Fill one of them:
+
+```bash
+brig secret import claude-code gh-token
+```
+
+The value is never a command-line argument, so it never appears in `ps` or
+in your shell history. [secrets.md](secrets.md) covers the store, provenance
+and the sources a profile can declare.
+
+### `brig telemetry`
+
+```bash
+brig telemetry status
+```
+
+Reports whether usage data is sent, and what decided the answer.
+
+```bash
+brig telemetry off
+```
+
+Turns it off, durably, on this machine. See [telemetry.md](telemetry.md) for
+what is counted, what is never collected, and how the answer is stored.
+
+## The ref
+
+A ref is `<agent>` or `<agent>@<label>`. An empty label is the agent's
+default session, so `claude` and `claude@refactor` are two sessions of one
+agent, never two agents. [sessions.md](sessions.md) explains what a session
+keeps separate, and what survives which command.
+
+The separator is exactly one `@`. `brig` refuses a ref instead of rewriting
+it:
+
+| Written | Refused because |
+| --- | --- |
+| `claude@@x` | more than one `@` |
+| `@refactor` | no agent named before the `@` |
+| `claude@` | a trailing `@` names no session. Drop it for the default session, or name one |
+| `claude@Refactor` | the label is not already clean. Labels use lowercase letters, digits, dot, dash and underscore |
+
+A label is never rewritten for you. The label reaches two places that must
+agree on it, the sandbox name and the guest home directory, so a label that
+needs cleaning up first is refused rather than silently changed.
+
+## The run line: ref, project, and the agent's own arguments
+
+`brig run <ref> [project] [args...]` reads three kinds of token from one
+line, told apart by position and count, never by the filesystem:
+
+1. The first bare word is the ref.
+2. On `run` only, the second bare word is a project directory. brig mounts
+   it read-write at `/work/<basename>` and starts the agent there.
+3. The next bare word, or anything after `--`, is the agent's own argument.
+
+The directory named as the project must exist. brig does not read a bare
+word as a project only when a directory of that name happens to exist: an
+argument's meaning does not depend on the filesystem, so a directory that is
+not there is an error rather than a silent fallback to the agent's argv.
+
+`--` ends brig's own parsing outright. No word after it is ever read as a
+project, and a project already read before the marker stands:
+
+```bash
+brig run claude ~/code/demo -- --version
+```
+
+Brig's own flags keep being read after the ref and after the project,
+because both are brig's own operands too:
+
+```bash
+brig run claude ~/code/demo --mem 4096 -d
+```
+
+Only `run` takes a project this way. `brig sh claude ~/code/demo` reads
+`~/code/demo` as the start of the guest command, not as a directory to
+mount.
+
+## Flag placement
+
+A brig line has two positions for brig's own flags: global, left of the
+verb, and run-line, between the verb and wherever the agent's own arguments
+begin.
+
+| Position | Flags |
+| --- | --- |
+| Global | `--verbose`, `-q`/`--quiet`, `--json` |
+| Run-line | `--image`, `--home`, `--mem`, `--cpus`, `--no-project`, `-d`/`--detach`, `--skills`, `--network`, `--offline`, and, as peers, `-q`/`--quiet` and `--json` |
+
+The global position is a closed set. A token there that is none of the three
+global flags is refused by name, never forwarded to an agent:
+
+```
+brig: unknown flag "--nope" before the command. brig takes a command first:
+`brig run claude`, `brig ls`. If "--nope" is the agent's, it goes after the
+profile
+```
+
+Exactly two flags are accepted in both positions, and they behave
+differently:
+
+| Flag | After the verb, on the run line |
+| --- | --- |
+| `-q`/`--quiet` | still works this release, and prints one deprecation notice moving it left. See [migration.md](migration.md) |
+| `--json` | a permanent peer spelling. No notice, either position |
+
+```bash
+brig info claude --json
+brig --json info claude
+```
+
+Both print the same report, and neither is deprecated.
+
+An unrecognized flag before the ref is refused by name, because there is no
+agent yet to hand it to:
+
+```
+brig: unknown flag "--help" before the profile name. brig's own flags come
+before the profile and the agent's after it; put "--help" after the profile
+to pass it through, or -- to end brig's flags
+```
+
+The same spelling after the ref reaches the agent untouched. brig names one
+of its own flags found past that point, without taking it, so a working line
+keeps working:
+
+```bash
+brig run claude -p hi --quiet
+```
+
+runs the agent with `-p hi --quiet` and warns that `--quiet` looked like
+brig's own flag but stood where the agent's arguments already begin.
+
+### Run-line flags
+
+| Flag | Value | Default | Notes |
+| --- | --- | --- | --- |
+| `--image IMAGE` | image ref | the agent's own | guest image to boot |
+| `--home PATH` | host directory | the agent's own guest home | mounted as the agent's home. Replaces `--workspace`, see [migration.md](migration.md) |
+| `--mem MB` | number | the agent's own (`4096` for most shipped agents) | guest memory |
+| `--cpus N` | number | the agent's own (`4` for most shipped agents) | guest vCPUs |
+| `--no-project` | (none) | off | mount no project this run, even one this session ran with before. On any verb but `run`, refused by name as a usage error |
+| `-d`, `--detach` | (none) | off | start the sandbox and exit, without attaching. Parses on every verb, but only `run` reads it. On `sh`, `stop`, `rm` and `info` it is silently inert |
+| `--skills` | (none) | off | copy your own `~/.claude` skills and plugins into the guest home. The host copy is never written. Same as `BRIG_SKILLS=1` |
+| `--network MODE` | `shared`, `isolated` or `offline` | `shared`, unless the agent's own profile sets `network:` (none of the shipped agents do) | the sandbox's network posture. See [policies.md](policies.md) |
+| `--offline` | (none) | off | shorthand for `--network offline`: the agent runs, the workspace is there, nothing leaves |
+
+Flag beats an environment setting beats the profile's own field, in that
+order, for every value above with an `env` counterpart in
+[Environment variables](#environment-variables) below.
+
+`--mem` and `--cpus` take a positive whole number. Anything else, including
+`0`, is refused by name rather than silently rounded or ignored.
+
+## `--json` output
+
+The set of verbs that accept `--json` is larger than `brig --help`'s own
+summary line suggests, and it splits by where the flag stands as well as by
+verb.
+
+| Verb | Where `--json` is accepted | Shape |
+| --- | --- | --- |
+| `ls` | global, or local after `ls` | envelope |
+| `info`, `env` | global, or local on the run line | envelope |
+| `doctor` | global, or local after `doctor` | envelope |
+| `run`, `sh` | global, or local on the run line | one compact line, see below |
+| `agent ls` | global, or local after `ls` | envelope |
+| `secret ls` | global, or local after `ls` | envelope |
+| `agent show`, `agent export`, `agent new` | local only, after the subcommand | bare document, no envelope |
+| `policy show` | local only, after the subcommand | bare document, no envelope |
+
+"Global" means left of the verb: `brig --json ls`. "Local" means the flag
+stands after the subcommand, on either side of that subcommand's own
+operand: `brig agent show claude-code --json` and
+`brig agent show --json claude-code` both work.
+
+`agent` accepts `--json` in the global position only when its subverb is
+`ls`. `policy` never does, on any subverb. So the global spelling refuses
+both `agent show` and `policy show`, even though each has a local `--json`
+that works:
+
+```
+brig --json agent show claude-code
+brig: `brig agent` has no --json output. --json is for the read verbs: ls,
+info, agent ls, secret ls, doctor (env takes it too, but env is deprecated;
+prefer info), and for run and sh
+```
+
+The flag has to follow `agent show`, not precede `agent`. Every verb not
+listed in the table above refuses `--json` in both positions, naming the
+verbs that do accept it. `env` is the deprecated spelling of `info` and
+takes the flag on the same terms. Prefer `info`.
+
+**Envelope shape.** A list or report verb prints
+`{"apiVersion": "brig.sh/v1alpha1", "kind": "...", "data": ...}`. Within one
+`apiVersion`, a field is only ever added, never renamed or removed, so a
+script written against it keeps parsing as brig grows. No field carries a
+credential value, names only.
+
+**Bare shape.** `agent show`, `agent export`, `agent new` and `policy show`
+print the document itself, with no envelope, because each renders a file
+meant to be saved and read back by brig:
+
+```bash
+brig agent show claude-code --json
+```
+
+```json
+{
+  "name": "claude-code",
+  "desc": "Claude Code (Anthropic)",
+  "binary": "claude",
+  ...
+}
+```
+
+**`run` and `sh` under `--json`.** The agent runs as a child of brig, and
+after it exits brig prints one compact JSON line with the outcome, the last
+line of stdout:
+
+```json
+{"apiVersion":"brig.sh/v1alpha1","kind":"Run","data":{"ref":"claude","sandbox":"brig-claude-code","stage":"agent","exit":0}}
+```
+
+`data.stage` is one of four values: `"brig"` for a refusal before the agent
+ran, `"agent"` for an agent that ran, `"gui"` for a windowed agent, or
+`"detached"` under `-d`. `data.exit` is the agent's own exit status when
+`stage` is `"agent"`, and one of brig's own exit codes otherwise. See
+[Exit codes](#exit-codes) for what those carve-outs mean for a script.
+
+**Completion under-offers it.** Shell completion does not offer `--json` for
+`ls`, `agent ls` or `secret ls`, even though all three accept it. This is a
+gap in the completion tables, not in what the verbs accept. Type it by hand
+on those three until it is fixed.
+
+## Exit codes
+
+| Code | Meaning |
+| --- | --- |
+| `0` | success |
+| `1` | a general failure |
+| `2` | a usage error: an unknown flag, a stray argument, or a value in the wrong place, as reported by the verb's own parser |
+| `3` | no such thing: an unknown agent, or a sandbox that is not there |
+| `4` | no usable runtime: none installed, an unknown `BRIG_RUNTIME`, or `BRIG_RUNTIME_BIN` (or a profile's own `runtimeBin`) pointing at nothing. The refusal names the setting that caused it |
+| `5` | a boot refused over image verification |
+| `6` | a required secret was not resolved, or the secret store did not open |
+
+This table is asserted end to end by `script/smoke.sh` and
+`cmd/brig/exit_test.go`, and is the one [docs/stability.md](stability.md)
+calls stable enough to script against.
+
+**6 is for required secrets only.** A declared secret marked
+`required: false` produces a warning, not a failure. `claude-code`'s two
+secrets are both optional, so `brig info claude` with neither one set exits
+`0`.
+
+**Two carve-outs under `run --json` and `sh --json`.** The agent runs as a
+child of brig, and its own exit status becomes brig's, read ahead of every
+class above. An exit `3` from `brig --json run claude` can be the agent's
+own `3`, not brig's "no such agent".
+
+Branch on the `Run` object's `data.stage` field, not on the number alone.
+`"agent"` means the code is the agent's. Anything else means it is one of
+the classes in the table.
+
+Separately, a brig refusal under `--json` is written to stdout as the `Run`
+object, the same place as every success case, never to stderr.
+
+**A handful of usage mistakes exit `1` instead of `2`.** An unknown
+top-level command, a run-line verb given no ref, a missing subcommand on
+`agent`, `policy`, `secret` or `telemetry`, and `secret import` or
+`policy check` given no agent, currently return a plain error rather than
+the usage type, and so exit `1`:
+
+```
+brig nosuchverb
+brig: unknown command "nosuchverb" (try `brig help`)
+```
+
+```
+brig run
+brig: run needs a profile, for example `brig run claude`. `brig agent ls`
+lists them
+```
+
+Both exit `1`, while the same class of mistake on `brig ls extra` or
+`brig completion bogus` exits `2`. If a script needs to tell a usage mistake
+apart from a general failure in this specific area, check for a nonzero
+status rather than for exactly `2`.
+
+## Environment variables
+
+Most settings below are read through `BRIG_<KEY>` and also honor
+`BRIG_<AGENT>_<KEY>`, which wins when both are set, so one shell can carry a
+different value per agent. The agent name is upper-cased with dashes turned
+to underscores, so `claude-code` reads `BRIG_CLAUDE_CODE_MEM` ahead of
+`BRIG_MEM`.
+
+A handful of settings have no per-agent form, because they are read once for
+the whole invocation rather than resolved per run: the directories, the
+runtime choice, the boot-asset and gateway paths, and `BRIG_ENV_ARGV`. Each
+is marked "global only" below.
+
+### Sandbox and profile locations
+
+| Variable | Default | Meaning |
+| --- | --- | --- |
+| `BRIG_WORKSPACE` | `~/brig/<agent>` | host directory mounted as the guest home. A named session appends `-<slug>` |
+| `BRIG_NAME` | `brig-<agent>` | the sandbox's own name. Must begin with `brig-`, or `brig ls` and `brig rm --all` cannot find it. A named session appends `-<slug>` |
+| `BRIG_PROFILE_DIR` (global only) | `$XDG_CONFIG_HOME/brig` | where your own agent files live. `BRIG_TEMPLATE_DIR` still works for one release |
+| `BRIG_POLICY_DIR` (global only) | `$XDG_CONFIG_HOME/brig/policies` | where policy files live |
+| `BRIG_STATE_DIR` (global only) | `~/.brig` | where brig keeps what has to outlive one command, including the project each sandbox last ran with |
+
+### Guest resources and network
+
+| Variable | Default | Meaning |
+| --- | --- | --- |
+| `BRIG_IMAGE` | the agent's own | guest image to boot |
+| `BRIG_PULL` | `missing` | `missing` pulls only when the image is not already on the host. `always` re-pulls every run. `never` refuses to boot an image that is not already there |
+| `BRIG_MEM` | the agent's own | guest memory, MB |
+| `BRIG_CPUS` | the agent's own | guest vCPUs |
+| `BRIG_READY_TIMEOUT` | `30` | seconds to wait for the in-guest agent once the runtime reports the sandbox running. The two are not the same moment |
+| `BRIG_NETWORK` | `shared` | `shared`, `isolated` or `offline`. An unrecognized value refuses the run. See [policies.md](policies.md) |
+| `BRIG_SKILLS` | `0` | `1` copies your own `~/.claude` skills and plugins into the guest home. Same as `--skills` |
+| `BRIG_FORWARD_ENV` | (unset) | a space-separated list of environment variable names to carry into the guest, read live on every run |
+| `BRIG_TITLE` | the agent's own | window title for a graphical agent |
+
+`BRIG_FORWARD_ENV` replaces only a profile's own `env:` bindings that
+declare the singular `ref: env.<name>` form. It leaves a binding that names
+its source through a `refs:` chain untouched, even one whose chain includes
+an `env.` entry. A name the profile binds from somewhere else, `secrets.` or
+a literal `value:`, is dropped from the override rather than layered onto
+it, and brig warns about each one it drops. The profile's own binding wins,
+because the profile is what you wrote.
+
+### Credentials and Git
+
+| Variable | Default | Meaning |
+| --- | --- | --- |
+| `BRIG_ALLOW_REFS` | `0` | `1` forwards a value that still looks like an unresolved `scheme://` secret reference |
+| `BRIG_ALLOW_DENIED` | `0` | `1` forwards a variable on the agent's own billing denylist |
+| `BRIG_ALLOW_EXPIRED` | `0` | `1` forwards a host credential even though it reports as expired. Scoped to the deprecated `hostCredential:` field |
+| `BRIG_GIT_CONFIG` | `0` | `1` writes a credential helper and gitconfig into the guest, routing an SSH GitHub remote over HTTPS |
+| `BRIG_GIT_HOSTS` | `github.com` | space-separated hosts the forwarded token applies to |
+| `BRIG_GIT_USER` | resolved on the host | username paired with the forwarded token |
+| `BRIG_GIT_IDENTITY` | `1` | `0` stops brig from forwarding the host commit identity resolved from the invoking directory |
+| `BRIG_GIT_NAME`, `BRIG_GIT_EMAIL` | the host's `git config` | override that identity |
+| `BRIG_TRUST_WORKSPACE` | `1` | pre-answers the agent's own "do you trust this folder" question for the directory a run starts in |
+| `BRIG_ENV_ARGV` (global only) | (unset) | exactly `1` puts a forwarded value on the runtime's own command line, where `ps` can read it. Never applies to a value brig resolved itself, a secret or the host credential, which stay off the command line regardless |
+
+[authentication.md](authentication.md) and [secrets.md](secrets.md) cover
+what each of these does with the credential once it is in the guest.
+
+### Image verification
+
+| Variable | Default | Meaning |
+| --- | --- | --- |
+| `BRIG_VERIFY` | `warn` | `warn`, `require` or `off`. `strict` is an alias for `require`, and `none` and `0` both alias `off`. An unrecognized value refuses the run rather than falling back to `warn` |
+| `BRIG_VERIFY_REGISTRY` | `ghcr.io/brig-sh/` | image prefix treated as brig's own, so a signature is expected |
+| `BRIG_VERIFY_IDENTITY` | brig's own community-images build workflow | certificate identity regexp cosign must match |
+| `BRIG_VERIFY_ISSUER` | GitHub Actions OIDC | certificate OIDC issuer |
+| `BRIG_COSIGN_BIN` | `cosign` on `PATH` | path to the cosign binary |
+
+`warn` reports an unverifiable image and boots anyway, and also stops to ask
+about an image that claims to be brig's own and is not. `require` refuses to
+boot anything it cannot positively verify, cosign missing included. See
+[security.md](security.md) for what verification does and does not catch.
+
+### Runtime and hypervisor
+
+| Variable | Default | Meaning |
+| --- | --- | --- |
+| `BRIG_RUNTIME` (global only) | `hull` on macOS, `nerdctl` on Linux | which backend to drive |
+| `BRIG_RUNTIME_BIN` (global only) | the first of `hull`, `nerdctl`, `docker` found on `PATH` | path to that binary |
+| `BRIG_HYPERVISOR` | the agent's own `hypervisor:` field, else `vz` | macOS only: `vz`, `hvi` or `qemu`. Wins over the agent's own field when set |
+| `BRIG_ROOTFS_TYPE` | the agent's own `rootfsType:` field | `block`, `virtiofs` or `9pfs`, how the guest root reaches the VM under `hull`. `nerdctl` ignores it. A profile's own `rootfsType:` outside that set is refused when the profile loads, but this variable is passed to `hull` unchecked |
+
+`hvi` is the only backend that enforces an attached egress policy or
+`--network isolated`, and it needs macOS 15 or newer. `vz` is the only
+backend with a graphical console. On macOS 14, set `BRIG_HYPERVISOR=vz` to
+run at all, since brig refuses an `hvi` run there rather than falling back
+on its own. See [runtimes.md](runtimes.md).
+
+### Boot assets and the network gateway
+
+| Variable | Default | Meaning |
+| --- | --- | --- |
+| `BRIG_BOOT_ASSETS` (global only) | `~/.hull/assets` on macOS, `$XDG_DATA_HOME/brig/assets` on Linux | directory holding the host kernel and initrd a `genericBoot` agent needs |
+| `BRIG_BOOT_ASSETS_REF` (global only) | `ghcr.io/nofireai/hull-assets:<os>-<arch>` | the bundle brig fetches when the boot assets are missing |
+| `BRIG_GATEWAY_SOCK` (global only) | `<gateway dir>/gateway-<subnet>.sock` | control socket of the shared network gateway |
+| `BRIG_GATEWAY_DIR` (global only) | the directory of `BRIG_GATEWAY_SOCK`, else `~/.brig` | where every gateway socket and log lives, shared and per-sandbox alike |
+
+## See also
+
+[migration.md](migration.md) has every retired verb, subverb, flag,
+position and profile key, and what replaces each one.
+[stability.md](stability.md) says which parts of this page you can write a
+script against today.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -180,7 +180,8 @@ assets, cosign, the profile directory, the secret store and brigd.
 brig doctor claude
 ```
 
-Adds a ninth line, checking that agent's image.
+Fills in the image line, which is otherwise the one check doctor cannot make
+without knowing which agent you mean.
 
 ```bash
 brig doctor --json

--- a/docs/completions.md
+++ b/docs/completions.md
@@ -44,8 +44,10 @@ A brig line has three positions, and completion follows them.
 | `brig run <ref> …` | the project directory, for the first word only |
 | once the agent's arguments have begun | nothing |
 
-The global flags complete only before the verb. `--verbose` and `-q`/`--quiet`
-have no run-line row, so neither is offered beside the ref.
+The global flags complete only before the verb. `--verbose` has no run-line
+row at all. `-q`/`--quiet` has one, but it is the retiring spelling, and
+completion never offers a spelling on its way out, so neither is offered
+beside the ref.
 
 Completion computes what a flag is legal for by its position on the line, not
 by whether the verb does anything with it once parsed. `brig run claude --mem

--- a/docs/completions.md
+++ b/docs/completions.md
@@ -38,21 +38,27 @@ A brig line has three positions, and completion follows them.
 
 | where the cursor is | what is offered |
 | --- | --- |
-| before the verb | the verbs, and the global flags (`--verbose`, `-q`, `--json`) |
-| a flag, either side of the ref | the flags that verb honours -- brig reads its own on both sides |
+| before the verb | the verbs, and the three global flags (`--verbose`, `-q`/`--quiet`, `--json`) |
+| a flag, either side of the ref | the run-line flags that verb accepts -- brig reads those on both sides |
 | a ref | every agent, and every session under one: `claude`, `claude@refactor` |
 | `brig run <ref> …` | the project directory, for the first word only |
 | once the agent's arguments have begun | nothing |
 
-Completion stops exactly where brig's own parsing stops, and not a word before
-it. `brig run claude --mem 4096` is a line brig reads, so `--mem` is offered
-after the ref as readily as before it. The agent's arguments begin at the first
-word or flag brig does not own -- `--`, an unrecognised flag, or a bare word
-past the project -- and from there completion offers nothing, because the
-vocabulary is another program's and brig has no list of it.
+The global flags complete only before the verb. `--verbose` and `-q`/`--quiet`
+have no run-line row, so neither is offered beside the ref.
+
+Completion computes what a flag is legal for by its position on the line, not
+by whether the verb does anything with it once parsed. `brig run claude --mem
+4096` is a line brig reads, so `--mem` is offered after the ref as readily as
+before it, on every verb that reads run-line flags at all. Completion does not
+know, and does not claim, that a given verb acts on the value. The agent's
+arguments begin at the first word or flag brig does not own (`--`, an
+unrecognised flag, or a bare word past the project), and from there completion
+offers nothing, because the vocabulary is another program's and brig has no
+list of it.
 
 `stop` and `rm` act on a sandbox that exists, so they offer the sessions there
-are rather than every agent there could be. `run`, `sh` and `info` take an
+are rather than every agent there is. `run`, `sh` and `info` take an
 agent that has never run, so they offer all of them. `brig rm --all` names no
 session and refuses every argument, so a line carrying it completes nothing
 further.
@@ -67,10 +73,10 @@ Two things are deliberately not offered:
 
 - **Secret names.** Listing them opens your keyring -- on macOS that means
   `security dump-keychain`, and a Linux secret-service backend can raise an
-  unlock prompt. A keystroke should do neither. `brig secret ls` lists them.
-- **The retired spellings.** `brig exec`, `brig env`, `brig create`,
-  `brig reset`, `--name`, `--workspace` and the rest still work and say what
-  replaced them. Completion teaches the spelling that stays.
+  unlock prompt. A keystroke must not do either. `brig secret ls` lists them.
+- **Every retired spelling.** Each one still works and prints one line saying
+  what replaced it. Completion teaches only the spelling that stays. See
+  [migration.md](migration.md) for the full old-to-new list.
 
 ## Session names can be stale
 

--- a/docs/guest-image.md
+++ b/docs/guest-image.md
@@ -14,6 +14,13 @@ Nothing here is a brig-specific format. A stock distribution image satisfies
 all of it without being told about brig, which is the point. What follows
 matters when you are building something smaller than that.
 
+Guest images for the built-in profiles are open source, built in
+[brig-sh/community-images](https://github.com/brig-sh/community-images).
+Building your own from scratch is documented there, at
+[bring-your-own-image.md](https://github.com/brig-sh/community-images/blob/main/docs/bring-your-own-image.md).
+[profiles.md](profiles.md) is the other half of the job: the fields that name
+this image and hand it a credential.
+
 ## The binaries
 
 Resolved through the guest's `PATH` unless the table says otherwise.
@@ -31,7 +38,7 @@ Resolved through the guest's `PATH` unless the table says otherwise.
 | `chmod` | sets the mode a `files:` binding declares, inside the create script | `internal/wrap/secretfiles.go`, `writeSecretFile` |
 | `rm` | `rm -f --` at the credential path before creating it, so a planted symlink is removed rather than followed | `internal/wrap/secretfiles.go`, `writeSecretFile` |
 | `sleep` | **Linux only.** nerdctl runs the container as `sleep infinity`, because a container exits when its command does and the sandbox has to outlive the exec that uses it | `internal/runtime/nerdctl.go`, `runArgs` |
-| `bash` | `brig sh` runs `bash -l`, and `brig sh <agent> '<command>'` runs `bash -lc`. It is also the `binary:` of the `ubuntu` profile | `internal/wrap/run.go`, `Shell` |
+| `bash` | `brig sh` runs `bash -l`, and `brig sh <agent> '<command>'` runs `bash -lc`, for every profile regardless of its `binary:` field | `internal/wrap/run.go`, `Shell` |
 | the profile's `binary:` | `brig run` execs it. `claude` for claude-code, `codex` for codex, and so on | `cmd/brig/main.go`, `runAgent` |
 
 Two of these are conditional, and it is worth knowing which.
@@ -97,6 +104,12 @@ last path element: `/home/claude` means the user `claude` (`GuestUser` in
 `internal/profile/profile.go`). The profile states the home once and the user
 follows from it. There is no field to set the user separately.
 
+One shipped profile breaks that pattern on purpose. `ubuntu`'s `guestHome` is
+`/root/work`, so the derived name is `work`, which is not an account in that
+image. Nothing reads it there: the image already runs as `root`, and the
+derivation only matters for a profile whose workspace sits inside a real
+user's home directory.
+
 Three things follow for the image.
 
 **That account has to exist in the image.** The name is passed to `chown`
@@ -151,12 +164,12 @@ The kernel file is named `Image` on arm64 and `bzImage` on x86_64; the initrd
 is `container-initrd` on both. They come from `BRIG_BOOT_ASSETS` if it is set,
 otherwise from whatever `hull assets dir` reports on macOS, otherwise from
 `$XDG_DATA_HOME/brig/assets` (default `~/.local/share/brig/assets`) on Linux.
-Missing, they are fetched: with hull on macOS, which downloads the same bundle
-for its own use, and with `oras` on Linux, where hull does not build. A
-zero-length file counts as missing rather than passing an existence check and
-failing at boot. The one case brig refuses to fix is `BRIG_BOOT_ASSETS`
-pointing at a directory you chose: it will not download over a build somebody
-is iterating on.
+Missing, they are fetched: with hull on macOS, which downloads the same
+bundle for its own use, and with [`oras`](install.md#linux) on Linux, where
+hull does not build. A zero-length file counts as missing rather than passing
+an existence check and failing at boot. The one case brig refuses to fix is
+`BRIG_BOOT_ASSETS` pointing at a directory you chose: it will not download
+over a build somebody is iterating on.
 
 Two consequences for the image itself:
 
@@ -347,3 +360,10 @@ It is not part of CI, which has no registry access and no runtime to boot
 with, so it is something you run yourself against an image you are building.
 Bear in mind that it is a real run of a real profile: the credentials that
 profile delivers are delivered into the image under test.
+
+Exit status: `0` when every requirement is met, `1` when something is
+missing, `2` when there was nothing to check with at all (no `brig`, no
+runtime, or no such profile). The script never reports a pass it did not
+perform. Set `BRIG_DRY_RUN=1` to print what it would boot and stop before
+booting it, which checks the argument handling and the profile lookup on a
+machine with no runtime.

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,0 +1,227 @@
+# Install brig
+
+This page covers every way to install brig: Homebrew and `install.sh` on
+macOS, the Linux runtime, and building from source. Pick the path for your
+platform, then check what brig found with `brig doctor`.
+
+Every path installs two things: the `brig` CLI itself, and the sandbox runtime
+it drives underneath, `hull` on macOS or `nerdctl` with containerd on Linux.
+Both have to be present before `brig run` works.
+
+## macOS with Homebrew
+
+Outcome: `brig` and `hull` installed and on `PATH`.
+
+Prerequisites: a Mac on Apple silicon, and Homebrew.
+
+```bash
+brew tap brig-sh/brig
+brew trust brig-sh/brig
+brew install --cask brig
+```
+
+`brew trust` is required because the cask comes from a third-party tap, and
+Homebrew refuses to install one that has not been trusted. `brew trust` needs
+a recent Homebrew. If it reports `Unknown command: trust`, run `brew update`
+first, then try the command again.
+
+The cask depends on the `hull` cask, so this one command installs both, and it
+installs the bash, zsh and fish completions with them.
+
+During the `0.1.0-rc` series, the casks in `brig-sh/homebrew-brig` are
+maintained by hand rather than published by the release pipeline. The release
+workflow opens a cask pull request only on a stable tag, and there is no
+stable tag yet. So the tap can lag the newest release.
+
+If `brew install` gives you an older version than you expected, or fails
+outright, use [install.sh](#installsh) instead. Or read `Casks/brig.rb` and
+`Casks/hull.rb` in the tap for what an install currently gives you.
+
+## install.sh
+
+Outcome: the `brig` and `brigd` binaries installed directly, without
+Homebrew.
+
+Prerequisites: `curl` and `tar` on `PATH`.
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/brig-sh/brig/main/install.sh | sh
+```
+
+This downloads the newest release for your OS and architecture. There is no
+stable release yet, so that includes prereleases. It checks the archive
+against the published `checksums.txt` with `sha256sum` or `shasum`, then
+installs `brig` and `brigd` into `BRIG_INSTALL_DIR` or `/usr/local/bin`. It
+uses `sudo` when that directory is not writable.
+
+CAUTION: on a host with neither `sha256sum` nor `shasum` on `PATH`, the
+checksum check is skipped and the install proceeds anyway. If you want the
+check enforced rather than skipped, install `sha256sum` or `shasum` first.
+
+`install.sh` does not check the cosign signature on `checksums.txt`. That
+check needs cosign, which `install.sh` does not require you to have. See
+[Verifying a downloaded release with cosign](#verifying-a-downloaded-release-with-cosign)
+below to check it yourself.
+
+Two variables change what it does:
+
+```bash
+BRIG_INSTALL_DIR=~/bin BRIG_VERSION=v0.1.0-rc18 sh install.sh
+```
+
+- `BRIG_INSTALL_DIR` overrides the destination. Unset, it installs to
+  `/usr/local/bin`.
+- `BRIG_VERSION` pins a release rather than fetching the newest one.
+
+The archive also carries the shell completion scripts, under `completions/`.
+`install.sh` does not install them for you. See [completions.md](completions.md)
+for how.
+
+On macOS, if `hull` is not already on `PATH`, `install.sh` prints the Homebrew
+command to install it. It does not install `hull` itself, since Homebrew is
+the maintained path for a runtime that needs signing.
+
+## Verifying a downloaded release with cosign
+
+Outcome: proof that a downloaded `checksums.txt`, and the archive it covers,
+came from brig's own release workflow rather than somewhere else.
+
+Prerequisites: cosign, and `checksums.txt`, `checksums.txt.pem` and
+`checksums.txt.sig` downloaded alongside the archive from the release page.
+
+```bash
+cosign verify-blob \
+  --certificate checksums.txt.pem \
+  --signature checksums.txt.sig \
+  --certificate-identity-regexp \
+    '^https://github\.com/brig-sh/brig/\.github/workflows/release\.yml@refs/tags/v' \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+  checksums.txt
+
+shasum -a 256 -c checksums.txt --ignore-missing
+```
+
+The first command vouches for `checksums.txt` itself: brig's releases use
+keyless cosign, so there is no key to check against. Instead the certificate
+is short-lived, bound to the release workflow's own identity, and recorded in
+a public transparency log, and `--certificate-identity-regexp` names exactly
+that workflow. The second command ties every archive listed in
+`checksums.txt` to the file the first command already vouched for.
+
+The macOS binaries carry a second, separate proof: they are signed with a
+Developer ID certificate and notarized with Apple. Gatekeeper checks that
+one, not cosign's.
+
+```bash
+spctl -a -vv -t install "$(which brig)"   # source=Notarized Developer ID
+```
+
+[docs/security.md](security.md) covers both checks, and what each one does
+and does not prove, in full.
+
+## Linux
+
+Outcome: a working sandbox runtime on Linux.
+
+Prerequisites: `nerdctl`, containerd, and the `urunc` containerd shim
+installed.
+
+brig drives `nerdctl` over containerd, with `urunc` as the shim that boots the
+container as a microVM instead of a plain process. That combination is what
+makes a Linux sandbox a microVM rather than a container sharing the host
+kernel. What that boundary does and does not keep out is not identical to
+macOS: [docs/security.md](security.md) covers the difference.
+
+`docker` is accepted in `nerdctl`'s place for an image that carries its own
+kernel. A `genericBoot` profile, which is six of the eight shipped ones, is
+refused on `docker` rather than attempted. `docker` does not pass the boot
+annotations `urunc` needs through to the runtime. See
+[runtimes.md](runtimes.md) for the full command surface each runtime needs.
+
+`BRIG_CONTAINERD_RUNTIME=runc` asks for a plain container instead, using
+`runc` directly:
+
+```bash
+BRIG_CONTAINERD_RUNTIME=runc brig run claude
+```
+
+A `runc` sandbox shares the host kernel with the agent, rather than running it
+in its own microVM. That is a weaker boundary, and `brig info` reports which
+one a run got.
+
+`oras` fetches the boot bundle, the kernel and `container-initrd` that let an
+ordinary container image boot as a guest, for a `genericBoot` profile. Six of
+the eight shipped profiles need it: `claude-code`, `codex`, `gemini`, `grok`,
+`opencode` and `ubuntu`. `claude-desktop` and `cursor` do not. Without `oras`
+on `PATH`, a `genericBoot` run on Linux fails, naming the exact artifact to
+fetch by hand and the directory to put it in. `claude-desktop` cannot run on
+Linux at all, for a reason the [platform support matrix](#platform-support)
+below covers.
+
+## Building from source
+
+Outcome: a `brig` and `brigd` binary built from this repository.
+
+Prerequisites: Go 1.25.0 or newer, the floor `go.mod` states.
+
+```bash
+git clone https://github.com/brig-sh/brig
+cd brig
+make build
+```
+
+`make build` writes `brig` and `brigd` into the current directory.
+
+Building brig from source needs no signing and no entitlement: brig reaches
+the hypervisor only by shelling out to `hull`, never directly.
+
+Building `hull` from source on macOS is a different matter. A from-source
+`hull` cannot boot a VM at all without a Developer ID certificate for an
+Apple entitlement. macOS honours that entitlement only on a binary signed
+with a real Apple identity. See
+[runtimes.md#building-hull-from-source-on-macos](runtimes.md#building-hull-from-source-on-macos)
+for exactly what that needs and why.
+
+The released `hull` that Homebrew installs is already signed, notarized and
+stapled. `brew install --cask brig` is the path to prefer unless you are
+working on `hull` itself.
+
+## Platform support
+
+| Host | Supported |
+| --- | --- |
+| Mac, Apple silicon, macOS 15 or newer | Yes |
+| Mac, Apple silicon, macOS 14 | Yes, with `BRIG_HYPERVISOR=vz` |
+| Intel Mac | No |
+| Linux, x86-64 or arm64 | Yes, with `nerdctl`, containerd and the `urunc` shim |
+
+macOS 15 is the floor brig enforces for hull's `hvi` backend. Apple shipped
+the in-kernel interrupt controller `hvi` depends on first in macOS 15. brig
+refuses the run on an older one rather than let the virtual machine monitor
+crash. That refusal needs a version it can read from the host. A host that
+will not report its version proceeds to the boot instead of being refused.
+Six of the eight shipped profiles ask for `hvi`, so a first run on macOS 14
+hits this floor unless you set `BRIG_HYPERVISOR=vz`.
+
+macOS 26 is what the project tests on, which is a separate fact from the
+floor. Nothing in brig or hull refuses macOS 15 or macOS 16 for being older
+than 26.
+
+Nothing in brig's own source checks the host architecture. The release
+publishes a `darwin/amd64` archive of `brig` and `brigd` alongside the
+`arm64` one, and `install.sh` installs it on an Intel Mac without a warning.
+The limit sits in `hull`, the microVM runtime brig drives on macOS: it needs
+Apple silicon. Installing brig on an Intel Mac succeeds. Running an agent
+then fails at the runtime check, because brig finds no `hull` to drive.
+
+`claude-desktop` is the one built-in profile Linux cannot run at all. It is a
+graphical profile. The Linux runtime refuses a graphical profile outright, on
+`nerdctl` and on `docker` alike, and names macOS as where it can run instead.
+
+Its image is also published for `arm64` only, so on macOS it needs Apple
+silicon too. It needs the `vz` backend specifically as well. `vz` is the only
+one of the three backends with a console, and a graphical profile is refused
+on `hvi` and `qemu`.
+
+`brig agent ls` lists `claude-desktop` on every platform with no marker of
+either limit.

--- a/docs/manual-tests/egress-policy.md
+++ b/docs/manual-tests/egress-policy.md
@@ -1,5 +1,11 @@
 # Manual test: is an attached policy actually enforced?
 
+*Historical evidence, not current validation. It evidences whether an attached
+egress policy is enforced at the gateway brig starts. No calendar date was
+recorded. It is identified instead by build: hull from `main` at `a7a5d1e`,
+the first hull to accept the `--egress-*` flags (`0.1.0-rc21` and earlier
+have none), on macOS arm64.*
+
 `docs/policies.md` used to say that nothing read a policy's rules at boot. It
 now says a bound policy is enforced at the gateway brig gives the sandbox.
 This file is the measurement behind that sentence.

--- a/docs/manual-tests/runtime-stdin.md
+++ b/docs/manual-tests/runtime-stdin.md
@@ -1,5 +1,11 @@
 # Manual test: stdin delivery and privileged-mount visibility
 
+*Historical evidence, not current validation. It evidences that a value
+delivered on stdin (`Runtime.Feed`) reaches the guest without appearing in
+argv, and that a mount a privileged exec creates is visible to a later
+unprivileged one (`RunSpec.Tmpfs` / `ExecSpec.User`). Measured 2026-08-17,
+from the `CREATED` column of the recorded `hull ps` output below.*
+
 PR 4 (`internal/runtime`) adds `Runtime.Feed`, which carries a value into the
 guest on stdin instead of argv, and `RunSpec.Tmpfs` / `ExecSpec.User`, which
 let a container runtime create a tmpfs at boot and hull mount one with a

--- a/docs/manual-tests/sandbox-reachability.md
+++ b/docs/manual-tests/sandbox-reachability.md
@@ -1,5 +1,11 @@
 # Manual test: can one sandbox reach another?
 
+*Historical evidence, not current validation. It evidences whether one
+sandbox can reach another, across hvi, vz, and Linux's shared and isolated
+networks. No calendar date was recorded. It is identified instead by
+version: hull `0.1.0-rc21` on macOS, and Amazon Linux 2023 (kernel 6.18.41)
+with nerdctl 2.0.3 and containerd 2.0.2 on Linux.*
+
 `docs/security.md` said that sandboxes share a broadcast domain, and that each
 one can reach what the other listens on. Nothing measured it. This file is the
 measurement. The claim is true on Linux and false on both macOS backends.

--- a/docs/manual-tests/secret-files.md
+++ b/docs/manual-tests/secret-files.md
@@ -1,5 +1,12 @@
 # Manual test: `volumes:` and the credential in an ephemeral `.claude`
 
+*Historical evidence, not current validation. It evidences the delivery
+MECHANISM, as measured on 2026-08-18: that a tmpfs cover over the agent's
+config directory, the paths a profile pins across it, and a `files:` binding
+delivered on stdin behave as designed in a real guest. Measured on macOS
+26.4, arm64, with hull installed, against
+`ghcr.io/brig-sh/claude-code-stock:latest`.*
+
 PR 6 covers the agent's config directory with a tmpfs so that nothing written
 there can reach host disk, pins the paths a profile wants to keep across the
 cover, and writes a `files:` binding into the tmpfs as an ordinary file with

--- a/docs/manual-tests/secret-provenance.md
+++ b/docs/manual-tests/secret-provenance.md
@@ -1,5 +1,12 @@
 # Manual test: the keychain comment attribute
 
+*Historical evidence, not current validation. It evidences the delivery
+MECHANISM: that the keychain's `icmt` comment attribute reads back without a
+decrypt prompt, and that `security -U` actually replaces the comment rather
+than leaving the old one. No calendar date appears in the prose. The recorded
+keychain `cdat`/`mdat` timestamps decode to 2026-08-17, measured on macOS
+26.4 (Darwin 25.4.0, arm64).*
+
 PR 2 (`internal/secret`) stores provenance in the keychain's `icmt` (comment)
 attribute, and D9's design rests on two facts about `security(1)` that
 `go test` cannot check without a real login keychain: that the comment can be

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -1,0 +1,134 @@
+# Moving off the retired spellings
+
+brig renamed most of its commands while it was still a prerelease. Every old
+spelling on this page still works today. Each one prints one line on stderr
+naming its replacement, in this form:
+
+```
+brig: `brig profiles` is now `brig agent ls`
+```
+
+The old spellings are scheduled for removal in 0.3. `brig run` is never
+removed. If you have a script written against an older spelling, this page is
+the whole list of what to change.
+
+To find out whether a script still uses one, run
+[`script/check-retired-spellings.sh`](../script/check-retired-spellings.sh)
+over your own files, or watch stderr for the notice.
+
+## Verbs
+
+| Retired | Current |
+| --- | --- |
+| `brig profiles`, `brig agents` | `brig agent ls` |
+| `brig profile <verb>` | `brig agent <verb>` |
+| `brig template` | `brig agent` |
+| `brig import` | `brig agent import` |
+| `brig export` | `brig agent export` |
+| `brig policies` | `brig policy ls` |
+| `brig create <ref>` | `brig run -d <ref>` |
+| `brig exec <ref> -- <cmd>` | `brig sh <ref> <cmd>` |
+| `brig shell <ref>` | `brig sh <ref>` |
+| `brig env <ref>` | `brig info <ref>` |
+| `brig reset` | `brig rm --all` |
+
+There is deliberately no `brig template edit`. The retired group kept only the
+verbs it already had, so asking for that one is an error rather than a
+deprecation notice.
+
+## Subverbs
+
+| Retired | Current |
+| --- | --- |
+| `brig agent list` | `brig agent ls` |
+| `brig agent save` | `brig agent export` |
+| `brig agent load` | `brig agent import` |
+| `brig policy list` | `brig policy ls` |
+| `brig secret list` | `brig secret ls` |
+| `brig secret rm` | `brig secret delete` |
+
+## Flags
+
+| Retired | Current |
+| --- | --- |
+| `-t IMAGE` | `--image IMAGE` |
+| `-m MB` | `--mem MB` |
+| `-n NAME`, `--name NAME` | `<agent>@<label>` |
+| `-w PATH`, `--workspace PATH` | `--home PATH` |
+
+Each still writes the same value, and the inline form (`-t=myimage:1`) warns
+too. A value that merely looks like a retired flag is left alone, so
+`brig run claude --name -t` warns about `--name` and not about `-t`.
+
+`--memory` is a current spelling of `--mem`. It is not retired, but the help
+text does not teach it and completion does not offer it.
+
+## One flag whose position changed
+
+`-q` and `--quiet` moved to the global position, left of the verb:
+
+```bash
+brig -q run claude      # current
+brig run claude -q      # still works, prints a notice
+```
+
+The notice names the move rather than a new spelling:
+
+```
+brig: brig <verb> <ref> -q is now brig -q <verb> <ref>
+```
+
+`--json` is different. It is accepted on both sides of the verb permanently,
+and prints no notice either way.
+
+## Session names
+
+`--name` is the flag this replaced most visibly. A session is now part of the
+ref:
+
+```bash
+brig run claude@refactor          # current
+brig run claude --name refactor   # still works, prints a notice
+```
+
+`brig run claude` is the default session of the `claude-code` agent, and
+`claude@refactor` is a second one with its own sandbox and its own guest home.
+[docs/sessions.md](sessions.md) explains what each session keeps separate.
+
+`--name` is also Claude Code's own flag. Anything you type to the right of the
+ref goes to the agent untouched, so `brig run claude -- --name x` sends
+`--name x` to Claude Code and brig never sees it.
+
+## Profile keys
+
+These keys still parse in a profile file for one more release. `brig agent
+edit` on an old file is the quickest way to see the current spelling, because
+the header comment documents every field.
+
+| Retired key | Current |
+| --- | --- |
+| `hostCredential:` | declare a secret and run `brig secret import <agent>` |
+| `shell:`, `gui:` booleans | `kind:` |
+| `forward:` | `env:`, with `ref: env.<name>` |
+| `statePaths:` | `volumes:` |
+
+Declaring a retired key and its replacement with values that disagree is an
+error, not a warning. brig refuses the profile rather than guessing which one
+you meant.
+
+`hostCredential:` warns only on a profile backed by a file of your own. No
+built-in profile warns about itself.
+
+## The words `agent` and `profile`
+
+Both are current, and they name different things. The rename landed on the
+command surface only:
+
+- **agent** is the CLI noun. `brig agent ls`, `brig agent edit`, and the `<ref>`
+  every verb takes.
+- **profile** is the file format, the directory and the environment variable.
+  A profile is a YAML file in `$XDG_CONFIG_HOME/brig`, and `BRIG_PROFILE_DIR`
+  points somewhere else.
+
+So you edit a profile file to change an agent. [docs/profiles.md](profiles.md)
+is the reference for the file format.

--- a/docs/non-goals.md
+++ b/docs/non-goals.md
@@ -23,7 +23,7 @@ running. Owning the boot path would mean owning Virtualization.framework, a
 kernel command line, an image store, a snapshotter and the vulnerability
 surface of all of it, in a tool whose reason to exist is that it handles your
 credentials carefully with three direct dependencies. The four things brig adds on
-top, in the README's "What brig is", are the four a runtime has no concept of.
+top, in the README's "How it works", are the four a runtime has no concept of.
 Everything else in the boot path already works.
 
 **Reopens when** a runtime brig can drive refuses upstream to expose something

--- a/docs/non-goals.md
+++ b/docs/non-goals.md
@@ -75,12 +75,14 @@ process.
 brig runs on the machine in front of you, and three of its properties depend on
 that. The workspace is a live host directory, not a copy, which is why there is
 no `cp` verb. Credentials are resolved from your own keychain per invocation.
-An in-sandbox login lives in guest memory and dies with `brig stop`. Point brig
-at a remote host and the workspace becomes a synchronisation problem, the
-credential path becomes a transport with its own threat model, and the login
-that was deliberately memory-only is now sitting on a machine you are not in
-front of. Kubernetes adds a controller, a custom resource, an image pull secret
-story and a scheduler on top of all that. The remote story that works today is
+On the two profiles that declare a tmpfs, `claude-code` and `claude-desktop`,
+an in-sandbox login lives in guest memory and dies with `brig stop`. On the
+rest it is already on the persisted workspace, like everything else there.
+Point brig at a remote host and the workspace becomes a synchronisation
+problem, and the credential path becomes a transport with its own threat
+model. A login that was meant to stay in memory is now sitting on a machine
+you are not in front of. Kubernetes adds a controller, a custom resource, an
+image pull secret story and a scheduler on top of all that. The remote story that works today is
 the boring one: `ssh` to the host and run brig there.
 
 **Reopens when** running the agent on a different machine from the one you edit
@@ -115,9 +117,10 @@ disciplined enough not to need wrapping: stable verbs and exit codes, human
 output on stdout, diagnostics on stderr, and a `--json` mode wherever a program
 is the reader rather than a person. Today that mode covers the read verbs --
 `ls`, `info`, `agent ls`, `agent show`, `agent export`, `agent new`,
-`policy show`, `secret ls` and `doctor` -- and `run`, which under `--json`
-reports the agent's exit status on one line; more verbs get it as callers
-need them, and asking for one is a small issue rather than an argument. For lifecycle control there is
+`policy show`, `secret ls` and `doctor` -- and `run` and `sh`, which under
+`--json` report the agent's exit status on one line (`env`, the deprecated
+spelling of `info`, takes it too). More verbs get it as callers need them,
+and asking for one is a small issue rather than an argument. For lifecycle control there is
 already an interface with no library attached: `brigd` speaks line-delimited
 JSON over a unix socket and is documented in [brigd.md](brigd.md).
 
@@ -146,9 +149,9 @@ becomes reachable only through a screen.
 This one is refused for want of demand rather than on principle. Running
 containers inside the guest needs either nested virtualization or a privileged
 guest, plus a second image store living on host disk inside the workspace, and
-it complicates the sentence the whole tool is built around: one directory is
-the agent's whole world. That is a real cost, and nobody has yet shown it is
-worth paying.
+it complicates the model the whole tool is built around: a small, named set
+of host directories is what the agent can reach. That is a real cost, and
+nobody has yet shown it is worth paying.
 
 **Reopens when** people report the workflows that need it, concretely: a repo
 whose tests bring up containers, a compose file the agent is meant to run. Once

--- a/docs/policies.md
+++ b/docs/policies.md
@@ -1,26 +1,84 @@
-# Writing an egress policy
+# Networking and egress policy
 
-A policy is a named YAML (or JSON) document declaring what an agent may
-reach outbound: a default of `allow` or `deny`, plus `host` or `cidr`
-exceptions on either side. `brig policy create` writes a starter and opens
-it in your editor, the same way `brig agent edit` does:
+By the end of this page you can read the three network postures a sandbox
+runs under. You can also write an egress policy, bind it to a profile or
+one session, and check where brig actually enforces it.
+
+Policy enforcement needs hull's `hvi` backend, which needs macOS 15 or
+newer, and a hull newer than 0.1.0-rc21. On every other backend, including
+every Linux runtime, brig refuses a policy-bound boot rather than running it
+unenforced. See [Where a policy is enforced](#where-a-policy-is-enforced-and-where-it-is-not).
+
+## Network postures
+
+Every sandbox runs under one of three postures: `shared`, `isolated` or
+`offline`. Set one with `--network`, with `BRIG_NETWORK`, or with a
+profile's own `network:` field. A flag beats the setting, and the setting
+beats the profile. Leave all three unset and you get `shared`.
 
 ```bash
-brig policy create no-net   # writes ~/.config/brig/policies/no-net.yaml
-brig policy edit no-net     # change the rules
+brig run claude --network isolated
 ```
 
-**This page is about the document, the commands that manage it, and binding
-it to a profile or a session.** A bound policy is enforced on the `hvi`
-backend, at the network gateway brig gives that sandbox, and a run on a
-backend that cannot enforce one is refused rather than left unconstrained; see
+| posture | what it permits |
+| --- | --- |
+| `shared` | one network for every sandbox on the host. The default |
+| `isolated` | a network of this sandbox's own |
+| `offline` | no route out. The agent runs, the workspace is mounted, nothing leaves |
+
+`shared` is a shared network in name, not in reach. On both macOS backends,
+sandboxes on it cannot reach each other. An ARP broadcast from one guest
+crosses to the other, but the reply does not cross back, so neither guest
+ever learns the other's address. On Linux, sandboxes on the shared network
+can reach each other. `brig info` prints the posture as one of these three
+lines:
+
+```
+NETWORK      shared (one network for every sandbox on this host)
+NETWORK      isolated (a network of this sandbox's own)
+NETWORK      offline (no egress)
+```
+
+`isolated` needs the `hvi` backend on macOS. `vz` and `qemu` take their
+network from vmnet, which brig does not own, so brig refuses `--network
+isolated` there. On Linux, nerdctl creates a network per sandbox for
+`isolated`, so the posture works on any Linux host.
+
+Binding an egress policy to a sandbox forces the `isolated` posture, whether
+or not `--network` asked for it. See
+[Where a policy is enforced](#where-a-policy-is-enforced-and-where-it-is-not).
+
+An unrecognized value refuses the run rather than picking a posture nobody
+asked for, and names where the value came from:
+
+```console
+$ BRIG_NETWORK=bogus brig info claude-code
+brig: BRIG_NETWORK "bogus" is not a posture: use shared, isolated or offline
+```
+
+## Writing a policy
+
+A policy is a named YAML (or JSON) document declaring what an agent can
+reach outbound. It sets a default of `allow` or `deny`, plus `host` or
+`cidr` exceptions on either side. `brig policy create` writes a starter and
+opens it in your editor, the same way `brig agent edit` does:
+
+```bash
+brig policy create locked-down   # writes ~/.config/brig/policies/locked-down.yaml
+brig policy edit locked-down     # change the rules
+```
+
+This page covers the document, the commands that manage it, and binding it
+to a profile or a session. A bound policy is enforced on the `hvi` backend,
+at the network gateway brig gives that sandbox. A run on a backend that
+cannot enforce one is refused rather than left unconstrained. See
 [Where a policy is enforced](#where-a-policy-is-enforced-and-where-it-is-not).
 
 ## Where policies live
 
 One file per policy in `$XDG_CONFIG_HOME/brig/policies`, default
-`~/.config/brig/policies`, flat: `~/.config/brig/policies/no-net.yaml`.
-`BRIG_POLICY_DIR` overrides the location outright, taken as given -- unlike
+`~/.config/brig/policies`, flat: `~/.config/brig/policies/locked-down.yaml`.
+`BRIG_POLICY_DIR` overrides the location outright, taken as given. Unlike
 `$XDG_CONFIG_HOME`, an explicit override is not second-guessed for
 absoluteness. This follows the
 [XDG Base Directory Specification, version 0.8](https://specifications.freedesktop.org/basedir/latest/):
@@ -31,12 +89,12 @@ to. `brig policy create` and `brig policy edit` are the only commands that
 write to it.
 
 `name:` inside the file wins over the filename, the same rule a profile
-already follows -- a file need not be named after the policy it declares,
+already follows. A file need not be named after the policy it declares,
 though `create` always names them the same way. A directory can hold any
-number of policies, and one file that fails to parse does not stop the
-others from loading: `brig policy ls` reports it on stderr and lists
-everything that did load. Two files declaring the same name is a mistake
-with no winner worth having, and is reported the same way.
+number of policies. One file that fails to parse does not stop the others
+loading: `brig policy ls` reports it on stderr, and lists everything that
+did load. Two files declaring the same name is a mistake with no winner
+worth having, and is reported the same way.
 
 ## The document
 
@@ -44,7 +102,7 @@ A complete example:
 
 ```yaml
 apiVersion: brig.sh/v1alpha1
-name: no-net
+name: locked-down
 desc: only Anthropic's API and one internal range
 egress:
   default: deny
@@ -55,32 +113,32 @@ egress:
 
 | field | required | what it is |
 | --- | --- | --- |
-| `apiVersion` | yes | Pins the document shape. `brig.sh/v1alpha1` is the only value this build knows; anything else is refused rather than guessed at |
-| `name` | yes | The policy's identifier. Wins over the filename, and follows the same character rule as a profile name -- see [Naming a policy](#naming-a-policy) |
+| `apiVersion` | yes | Pins the document shape. `brig.sh/v1alpha1` is the only value this build knows. Anything else is refused rather than guessed at |
+| `name` | yes | The policy's identifier. Wins over the filename, and follows the same character rule as a profile name. See [Naming a policy](#naming-a-policy) |
 | `desc` | no | One line, shown by `brig policy ls` |
 | `egress.default` | yes | `allow` or `deny`, applied to any traffic neither list below names |
 | `egress.allow` | no | Exceptions to a `deny` default |
-| `egress.deny` | no | Always wins over `allow` and over `default`: a host named here is refused regardless, and no other settings source restores it |
+| `egress.deny` | no | A host or range to refuse regardless. At the gateway that enforces the rules, `deny` takes priority over `allow` and over `default`. brig applies no priority of its own: it passes every rule through as a flag. See [Where a policy is enforced](#where-a-policy-is-enforced-and-where-it-is-not) |
 
-Each entry in `allow` or `deny` names exactly one of `host:` or `cidr:` --
-both, or neither, is refused. `host:` is a domain, or a glob such as
-`"*.githubusercontent.com"`; `cidr:` is a network range such as
-`10.0.0.0/8`, checked with Go's own `net.ParseCIDR`, so a typo like
+Each entry in `allow` or `deny` names exactly one of `host:` or `cidr:`. Both,
+or neither, is refused. `host:` is a domain, or a glob such as
+`"*.githubusercontent.com"`. `cidr:` is a network range such as
+`10.0.0.0/8`, checked with Go's own `net.ParseCIDR`. A typo like
 `10.0.0/8` (an octet short) is refused rather than accepted and silently
 doing nothing at the gateway that enforces it.
 
-`host:` is not held to a pinned glob grammar here -- which wildcard forms an
-enforcer honours is that enforcer's business, and this document format is
-deliberately independent of it (see the intro above). A host is refused only
-for what is unambiguously wrong however it ends up read: whitespace or a
-control character. The gateway that enforces it today matches the glob against
-the name the guest asks its resolver for.
+`host:` is not held to a pinned glob grammar here. Which wildcard forms an
+enforcer honors is that enforcer's business, and this document format is
+deliberately independent of it. A host is refused only for what is
+unambiguously wrong however it ends up read: whitespace or a control
+character. The gateway that enforces it today matches the glob against the
+name the guest asks its resolver for.
 
-Parsing is strict throughout: a field this format does not recognise --
-`engine:`, `mode:`, a plain typo like `dsc:` -- fails to parse rather than
-being silently dropped. The format carries no field naming how a rule gets
-applied; that is a deliberate limit, not an oversight, and stays that way as
-this feature grows.
+Parsing is strict throughout. A field this format does not recognize, such
+as `engine:`, `mode:`, or a plain typo like `dsc:`, fails to parse rather
+than being silently dropped. The format carries no field naming how a rule
+gets applied. That is a deliberate limit, and it stays that way as this
+feature grows.
 
 ## Naming a policy
 
@@ -90,12 +148,12 @@ checked before a path is built from it, so a bad name never gets as far as
 touching disk.
 
 One rule is particular to policies. A bare word like `no`, `true` or `123`
-is inside that character set, but YAML reads an *unquoted* one of those as a
-boolean or a number rather than as the string you typed -- so a policy named
-`no` would actually be named `false`, unreachable by the name you gave it.
+is inside that character set. But YAML reads an *unquoted* one of those as
+a boolean or a number rather than as the string you typed. A policy named
+`no` is actually named `false`, unreachable by the name you gave it.
 `brig policy create` checks a name by writing it the way the starter
-template would and reading it back, and refuses one that does not come back
-as itself:
+template writes it, then reading the result back. It refuses one that does
+not come back as itself:
 
 ```console
 $ brig policy create no
@@ -106,155 +164,196 @@ brig: name "no" reads as false when written unquoted in YAML, not as itself; pic
 
 | verb | what it does |
 | --- | --- |
-| `brig policy ls` | every policy that parses, by name and description, and -- for one bound to anything -- what binds it. `brig policies` still works, with a note naming this spelling |
+| `brig policy ls` | every policy that parses, by name and description, and, for one bound to anything, what binds it |
 | `brig policy create <name>` | write a starter document, then open it: `$VISUAL`, then `$EDITOR`, then `vi` |
-| `brig policy edit <name> [--force]` | open an existing one, and only replace it if the save still parses and validates. Refuses a rename that would orphan anything bound to it -- inline or attached -- unless `--force` |
+| `brig policy edit <name> [--force]` | open an existing one, and only replace it if the save still parses and validates. Refuses a rename that orphans anything bound to it, inline or attached, unless `--force` |
 | `brig policy show <name> [--json]` | print the parsed document |
-| `brig policy rm <name> [--force]` | delete it. Refuses one that is bound to anything -- inline, or attached -- unless `--force` |
-| `brig policy attach <policy> <profile> [-n NAME]` | bind it to every run of a profile, or -- with `-n` -- to one session by name instead |
+| `brig policy rm <name> [--force]` | delete it. Refuses one that is bound to anything, inline or attached, unless `--force` |
+| `brig policy attach <policy> <profile> [-n NAME]` | bind it to every run of a profile, or, with `-n`, to one session by name instead |
 | `brig policy detach <policy> <profile> [-n NAME]` | reverse an attach |
-| `brig policy check <profile> [-n NAME]` | list what is effectively bound to a run of the profile (or `-n` session), and whether brig can enforce anything against it at all |
+| `brig policy check <profile> [-n NAME]` | list what is effectively bound to a run of the profile (or `-n` session), and report whether brig can enforce anything against it at all |
+
+Complete command lines for all eight:
+
+```bash
+brig policy ls
+brig policy create locked-down
+brig policy edit locked-down
+brig policy show locked-down --json
+brig policy attach locked-down claude-code
+brig policy detach locked-down claude-code
+brig policy check claude-code
+brig policy rm locked-down --force
+```
 
 `create` refuses to overwrite a file that is already at the target path,
 unless you pass `--force`. It refuses a name already taken by some *other*
-file regardless of `--force` -- forcing would only leave two files
-declaring the same name, which is the thing this check exists to prevent.
+file regardless of `--force`. Forcing leaves two files declaring the same
+name, which is the thing this check exists to prevent.
 
-`attach` and `detach` write to `attachments.yaml` in the same directory,
-not to the policy or the profile. `attach` refuses, and writes nothing, if
-either name does not exist, if the profile is `kind: shell` or `kind: gui`
-(no agent to hook an egress rule into), or if the profile already declares
-the policy inline in its own `policy:` list -- attaching it again would only
-add an entry `detach` could never remove:
+`attach` and `detach` write to `attachments.yaml` in the same directory, not
+to the policy or the profile. `attach` refuses, and writes nothing, in
+three cases. Either name does not exist. The profile is `kind: shell` or
+`kind: gui`, which has no agent to hook an egress rule into. Or the profile
+already declares the policy inline in its own `policy:` list. Attaching it
+again adds an entry `detach` can never remove:
 
 ```console
-$ brig policy attach no-net claude-code
-attached no-net to claude-code
+$ brig policy attach locked-down claude-code
+attached locked-down to claude-code
 note: enforced on the hvi backend, which gives the sandbox a network of its own; a run on any other backend is refused rather than left unenforced
-$ brig policy attach no-net claude-code -n work
-attached no-net to claude-code -n work
+$ brig policy attach locked-down claude-code -n refactor
+attached locked-down to claude-code -n refactor
 note: enforced on the hvi backend, which gives the sandbox a network of its own; a run on any other backend is refused rather than left unenforced
-$ brig policy attach no-net ubuntu
-brig: cannot attach no-net to ubuntu: ubuntu is kind: shell, which has no agent to hook an egress rule into. Nothing was written
+$ brig policy attach locked-down ubuntu
+brig: cannot attach locked-down to ubuntu: ubuntu is kind: shell, which has no agent to hook an egress rule into. Nothing was written
 ```
 
-Both `attach` and `check` say that last line, because "attached" and a
-`check` that prints a policy name both read as a rule that is in force
-everywhere, and where it is in force depends on the backend the run lands on
--- see
+Both `attach` and `check` print that last line, because "attached" and a
+`check` that prints a policy name both read as a rule in force everywhere.
+Where it is in force depends on the backend the run lands on. See
 [Where a policy is enforced](#where-a-policy-is-enforced-and-where-it-is-not).
 It goes to stderr, where this CLI puts every advisory, so stdout stays the
-command's answer. Both commands print the same constant from `internal/policy`, so
-the two cannot drift into saying different things.
+command's answer. Both commands print the same constant from
+`internal/policy`, so the two cannot drift into saying different things.
+
+`detach` reverses `attach`:
+
+```console
+$ brig policy detach locked-down claude-code -n refactor
+detached locked-down from claude-code -n refactor
+```
 
 `detach` refuses a policy the profile declares inline, the same way: it was
 never `attach`'s to add, so it is not `detach`'s to remove. Edit the
-profile's `policy:` list directly instead. A `-n` detach is unaffected --
-inline binds every run, `-n` narrows to one session, and the two do not
+profile's `policy:` list directly instead. A `-n` detach is unaffected.
+Inline binds every run, `-n` narrows to one session, and the two do not
 name the same binding.
 
-`check` resolves the same union `attach`/`detach` write to -- inline,
-profile-level, session-level -- for one profile (or, with `-n`, one of its
-sessions), lists what applies, and runs the same `CheckCoverage` refusal
-`attach` does. It does not check anything about the rules those policies
-contain (see [Where a policy is enforced](#where-a-policy-is-enforced-and-where-it-is-not)):
-the only two things it can fail over are a `kind: shell`/`kind: gui`
-profile, which nothing could ever enforce against no matter what is
-bound, and a name bound to nothing -- `--force` on `rm`, or on this
-edit's rename check, can leave one behind, and `check` refuses to call
-that enforceable:
+`check` resolves the same union `attach`/`detach` write to (inline,
+profile-level, session-level) for one profile, or, with `-n`, one of its
+sessions. It lists what applies, and runs the same `CheckCoverage` refusal
+`attach` does:
 
 ```console
 $ brig policy check claude-code
-no-net
+locked-down
 note: enforced on the hvi backend, which gives the sandbox a network of its own; a run on any other backend is refused rather than left unenforced
 $ brig policy check ubuntu
 no policy applies to ubuntu
 brig: cannot enforce any policy on ubuntu: ubuntu is kind: shell, which has no agent to hook an egress rule into
-$ brig policy rm no-net --force
-removed /home/you/.config/brig/policies/no-net.yaml
+```
+
+"Whether brig can enforce it" means exactly two structural checks. Is the
+profile `kind: shell` or `kind: gui`? Nothing can ever enforce a policy
+against either. Does every bound name still resolve to a policy that
+loaded?
+
+`check` does not resolve the current runtime, the current hypervisor, or
+the runtime's version. It cannot tell you whether the host you are on
+right now will boot the run or refuse it. That answer only appears at boot
+time, from the checks in
+[Where a policy is enforced](#where-a-policy-is-enforced-and-where-it-is-not).
+
+`--force` on `rm`, or on a rename, can leave a binding pointing at a name
+nothing loads under any more:
+
+```console
+$ brig policy rm locked-down --force
+removed /home/you/.config/brig/policies/locked-down.yaml
 $ brig policy check claude-code
-no-net (not loaded)
-brig: claude-code is bound to no-net, which no policy loads under -- nothing can enforce what did not load
+locked-down (not loaded)
+brig: claude-code is bound to locked-down, which no policy loads under -- nothing can enforce what did not load
 ```
 
 `brig policy ls` prints what binds a policy right under it, when anything
-does -- an inline `policy:` entry, a profile-level attach, or
+does. That is an inline `policy:` entry, a profile-level attach, or
 `<profile> -n <session>` for a session-level one:
 
 ```console
 $ brig policy ls
-no-net          only Anthropic's API and one internal range
-                bound to: claude-code, claude-code -n work
-```
-
-`--force` on `rm`, or on a rename, leaves a binding pointing at a name
-nothing loads under any more. Both say so at the time, and then nothing
-does, so the listing is where that leftover reappears:
-
-```console
-$ brig policy rm no-net --force
-removed /home/you/.config/brig/policies/no-net.yaml
-$ brig policy ls
-no-net          (not loaded; bound to claude-code)
+locked-down     only Anthropic's API and one internal range
+                bound to: claude-code, claude-code -n refactor
 ```
 
 "not loaded" rather than "no such policy", because there are two ways to
-get there and brig cannot always tell them apart: either nothing declares
-that name, or the file that declares it did not parse -- and in that
-second case the file and its parse error are named separately on stderr.
+get there, and brig cannot always tell them apart. Either nothing declares
+that name, or the file that declares it did not parse. In that second case
+the file and its parse error are named separately on stderr.
 
-`rm` refuses a policy that is bound to anything -- an inline `policy:`
-entry, a profile-level attach, or a session-level one -- unless you pass
-`--force`: the file would be gone, but whatever named it would still be
-pointing at nothing. `--force` removes it anyway and leaves that now-
-dangling reference in place -- `rm`'s job is the file, not what points
-at it:
+`rm` refuses a policy that is bound to anything (an inline `policy:` entry,
+a profile-level attach, or a session-level one) unless you pass `--force`.
+The file is gone either way, but whatever named it is still pointing at
+nothing:
 
 ```console
-$ brig policy rm no-net
-brig: no-net is bound to claude-code. Detach it first, or pass --force to remove it anyway
-$ brig policy rm no-net --force
-removed /home/you/.config/brig/policies/no-net.yaml
+$ brig policy rm locked-down
+brig: locked-down is bound to claude-code. Detach it first, or pass --force to remove it anyway
+$ brig policy rm locked-down --force
+removed /home/you/.config/brig/policies/locked-down.yaml
 ```
 
-The instruction fits what is actually bound: "detach it" for an attach,
-"edit the profile's `policy:` list" for an inline entry, or both when a
-policy is bound both ways -- detach explicitly refuses to touch an inline
-entry (below), so telling you to detach one would be a dead end.
-
-Unlike `brig policy ls`, which only degrades to a plainer listing if
-`attachments.yaml` cannot be read, `rm` without `--force` refuses outright
-in that case: it would rather stop than delete something it could not
-confirm was safe to.
+The instruction fits what is actually bound. It says "detach it" for an
+attach, "edit the profile's `policy:` list" for an inline entry, or both
+when a policy is bound both ways. `detach` explicitly refuses to touch an
+inline entry, so telling you to detach one is a dead end.
 
 `edit` never touches the real file until the new content is known to be
-good: it opens a scratch copy, and only if that copy still parses and
-validates does it replace the original -- via a temp file and a rename in
-the same directory, so a crash or a full disk mid-write cannot leave the
-real file half written. A save that does not validate leaves the real file
-untouched and says where your edit still is, so it is not lost, only not
-yet saved:
+good. It opens a scratch copy, and only replaces the original if that copy
+still parses and validates. The replace goes through a temp file and a
+rename in the same directory. A crash or a full disk mid-write cannot
+leave the real file half written:
 
 ```console
-$ brig policy edit no-net
-brig: not saved, /home/you/.config/brig/policies/no-net.yaml is unchanged: cidr "10.0.0/8" is not a valid CIDR: invalid CIDR address: 10.0.0/8
+$ brig policy edit locked-down
+brig: not saved, /home/you/.config/brig/policies/locked-down.yaml is unchanged: cidr "10.0.0/8" is not a valid CIDR: invalid CIDR address: 10.0.0/8
 your edit is still at /tmp/brig-policy-edit-2427992151.yaml
 ```
 
-Renaming it (changing `name:` to something else) is refused the same way
-if the old name is bound to anything -- an attach, or a profile's own
-inline `policy:` entry -- since the binding would then be pointing at a
-name nothing declares:
+Renaming it (changing `name:` to something else) is refused the same way if
+the old name is bound to anything. The binding then points at a name
+nothing declares:
 
 ```console
-$ brig policy edit no-net
-brig: not saved, /home/you/.config/brig/policies/no-net.yaml is unchanged: renaming no-net to totally-new would leave claude-code pointing at a name nothing declares. Detach it first, or pass --force to rename it anyway
+$ brig policy edit locked-down
+brig: not saved, /home/you/.config/brig/policies/locked-down.yaml is unchanged: renaming locked-down to totally-new would leave claude-code pointing at a name nothing declares. Detach it first, or pass --force to rename it anyway
 your edit is still at /tmp/brig-policy-edit-2427992151.yaml
 ```
 
 A save that keeps the same name never triggers this check: the file a
-binding points at is still right here either way.
+binding points at is still right there either way.
+
+## Binding one session, not every run
+
+`policy attach` and `policy detach` take `-n NAME` to bind or unbind one
+session instead of every run of a profile. `policy check` takes it to ask
+about that one session instead of the profile as a whole.
+
+`-n NAME` must already be the slug form of the name: lowercase letters,
+digits, dot, dash and underscore. `attach -n Refactor` is refused outright,
+naming the slug it must become. This is stricter than the retired
+<!-- retired-ok -->`brig run --name`, which sanitizes a name and reports the
+directory it landed on.
+
+That difference matters when a session started with `--name` picks up its
+policy. The `<agent>@<label>` ref form is unaffected. `ParseRef` refuses
+any label that is not already slug-clean, so `claude@refactor` can only
+ever reach a session whose stored name is `refactor`. That matches what
+`attach -n refactor` requires.
+
+A session opened with `brig run claude --name Refactor` <!-- retired-ok --> is
+a different case. `brig run` accepts and sanitizes `Refactor` to the slug `refactor`
+for the sandbox itself. But the policy binding is looked up under the name
+exactly as typed, `Refactor`, not the slug. Because `attach -n` never
+accepts anything but a slug, no attachment is ever filed under `Refactor`.
+That session's policy lookup never finds one, even after `brig policy
+attach locked-down claude-code -n refactor`.
+
+Until this is fixed, scope any per-session policy claim to the `@` form.
+Use `claude@refactor` when you need a policy bound to one session, and
+attach it with `brig policy attach locked-down claude-code -n refactor`.
+Do not rely on `-n` matching a session opened with `--name` unless the name
+you passed to `--name` was already lowercase, slug-clean text.
 
 ## A worked example
 
@@ -266,20 +365,20 @@ no policies yet; your own live in /home/you/.config/brig/policies
 brig policy create <name> writes a starter one
 ```
 
-Create one. The starter opens in your editor; here it has already been
+Create one. The starter opens in your editor. Here it has already been
 filled in:
 
 ```console
-$ brig policy create no-net
-/home/you/.config/brig/policies/no-net.yaml created
+$ brig policy create locked-down
+/home/you/.config/brig/policies/locked-down.yaml created
 $ brig policy ls
-no-net          only Anthropic's API and one internal range
+locked-down     only Anthropic's API and one internal range
 ```
 
 Show it, as YAML or as JSON:
 
 ```console
-$ brig policy show no-net
+$ brig policy show locked-down
 apiVersion: brig.sh/v1alpha1
 desc: only Anthropic's API and one internal range
 egress:
@@ -287,11 +386,11 @@ egress:
   - host: api.anthropic.com
   - cidr: 10.0.0.0/8
   default: deny
-name: no-net
-$ brig policy show no-net --json
+name: locked-down
+$ brig policy show locked-down --json
 {
   "apiVersion": "brig.sh/v1alpha1",
-  "name": "no-net",
+  "name": "locked-down",
   "desc": "only Anthropic's API and one internal range",
   "egress": {
     "default": "deny",
@@ -304,16 +403,16 @@ $ brig policy show no-net --json
 ```
 
 `show` prints the parsed document back out, not the file verbatim, which is
-why the field order differs from what you typed -- YAML's own marshalling
+why the field order differs from what you typed. YAML's own marshalling
 sorts keys, the same way `brig agent show --json` does.
 
 Edit it, and remove it:
 
 ```console
-$ brig policy edit no-net
-/home/you/.config/brig/policies/no-net.yaml updated
-$ brig policy rm no-net
-removed /home/you/.config/brig/policies/no-net.yaml
+$ brig policy edit locked-down
+/home/you/.config/brig/policies/locked-down.yaml updated
+$ brig policy rm locked-down
+removed /home/you/.config/brig/policies/locked-down.yaml
 ```
 
 ## Errors you are likely to meet
@@ -322,7 +421,7 @@ removed /home/you/.config/brig/policies/no-net.yaml
 | --- | --- |
 | ``unknown policy "x". `brig policy ls` lists them`` | `show`, `edit` or `rm` on a name that is not there |
 | `name "x" may use only lowercase letters, digits, dot, dash and underscore, and must start with a letter or digit` | see [Naming a policy](#naming-a-policy) |
-| `name "x" reads as false when written unquoted in YAML, not as itself; pick a different name` | the name is a bare YAML boolean, null or number word -- see [Naming a policy](#naming-a-policy) |
+| `name "x" reads as false when written unquoted in YAML, not as itself; pick a different name` | the name is a bare YAML boolean, null or number word. See [Naming a policy](#naming-a-policy) |
 | `<path> already exists. Edit it directly with brig policy edit x, or pass --force to replace it with a fresh starter` | `create` on a name whose file is already there |
 | `policy "x" already exists, declared in <path>. Edit it directly with brig policy edit x, or remove that file first` | `create` on a name a *different* file already declares. `--force` does not help here |
 | `a rule needs host: or cidr:` | a rule in `allow:`/`deny:` named neither |
@@ -330,7 +429,7 @@ removed /home/you/.config/brig/policies/no-net.yaml
 | `cidr "x" is not a valid CIDR: …` | a typo in a `cidr:` value, such as a missing octet |
 | `host "x" contains whitespace or a control character` | a `host:` value that cannot be a domain or glob under any grammar |
 | `apiVersion is required, and must be "brig.sh/v1alpha1"` | a document with no `apiVersion:`, or the wrong one |
-| `not saved, <path> is unchanged: …` | `edit`'s save did not parse or validate, or renamed a name that is bound to something, without `--force`. The real file is untouched; the error names where your edit still is |
+| `not saved, <path> is unchanged: …` | `edit`'s save did not parse or validate, or renamed a name that is bound to something, without `--force`. The real file is untouched. The error names where your edit still is |
 | ``unknown profile "x". `brig agent ls` lists them`` | `attach`, `detach` or `check` naming a profile that is not there |
 | `cannot attach x to y: y is kind: shell, which has no agent to hook an egress rule into. Nothing was written` | `attach` to a `kind: shell` or `kind: gui` profile |
 | `cannot enforce any policy on x: x is kind: shell, which has no agent to hook an egress rule into` | `check` on a `kind: shell` or `kind: gui` profile |
@@ -338,77 +437,133 @@ removed /home/you/.config/brig/policies/no-net.yaml
 | `x is already declared inline in y's policy: list, which binds every run already. Nothing was written` | `attach` naming a policy the profile's own `policy:` list already declares |
 | `x is declared inline in y's policy: list, not attached; edit the profile directly to remove it` | `detach` naming a policy the profile's own `policy:` list declares, without `-n` |
 | `x is bound to y. Detach it first, or pass --force to remove it anyway` | `rm` on a policy attached to a profile or a session (a policy declared only inline says "edit the profile's policy: list" instead) |
+| ``a policy applies to this sandbox, but <bin> cannot enforce one (its network-gateway has no --egress-default). Upgrade the runtime, or detach the policy`` | the runtime is older than the hull that added the `--egress-*` gateway flags |
 
 ## The default is no policy at all
 
-A sandbox nobody attached a policy to has **unrestricted egress**, exactly as
-it did before any of this existed. No profile brig ships binds a policy, `brig
-run <agent>` on a fresh install filters nothing, and no gateway is given a rule
+Read from the source rather than assumed: the default egress stance is
+allow everything, with no filtering applied at all. It is not a deny-all
+default, and it is not an empty allow list either. A sandbox nobody
+attached a policy to has unrestricted egress, exactly as it did before any
+of this existed. No profile brig ships binds a policy, and `brig run
+<agent>` on a fresh install filters nothing. No gateway is given a rule
 until a policy is attached to that profile or that session by hand.
 
 That is deliberate, and it is a test rather than an intention
 (`TestNoShippedProfileBindsAPolicy`, `TestASandboxWithNoPolicyIsUnfilteredAndShared`).
-An agent that cannot reach its own API is not a safer agent, it is a broken
-one, and a default that broke every sandbox on upgrade would be paid for by
-everyone to benefit the few runs that want a rule.
+An agent that cannot reach its own API is not a safer agent. It is a
+broken one, and a default that broke every sandbox on upgrade costs
+everyone, to benefit the few runs that want a rule.
 
 Note the shape of the two defaults, which are easy to confuse. Attaching no
-policy means **no filtering**. Attaching a policy whose `default:` is `deny`
-means the opposite -- everything is refused except what its `allow` list names
--- and an empty `allow` list under it is a sandbox with no way out. The first
-is what you get; the second is what you ask for.
+policy means no filtering. Attaching a policy whose `default:` is `deny`
+means the opposite: everything is refused except what its `allow` list
+names. An empty `allow` list under it is a sandbox with no way out. The
+first is what you get. The second is what you ask for.
 
 ## Where a policy is enforced, and where it is not
 
-On the `hvi` backend, a boot reads every policy bound to the run and puts the
-rules on the network gateway it gives that sandbox. That gateway is the
-sandbox's only way out, so the rules are the sandbox's only way out. Measured
-in a real guest in
-[docs/manual-tests/egress-policy.md](manual-tests/egress-policy.md): an allowed
-name reaches, a denied name does not resolve, and an address dialled directly
-does not connect.
+Exactly one backend can enforce an egress policy: hull's `hvi` backend, at
+the user-mode network gateway brig gives that sandbox. `vz` and `qemu` take
+their network from vmnet, and every Linux runtime takes its network from
+the container network. Neither of those is something brig filters.
 
-Everywhere else the boot is **refused** rather than left unenforced. `vz` and
-`qemu` take their network from vmnet and the Linux runtimes from the container
-network, neither of which brig filters; booting there with a policy attached
-would give a sandbox that reports one and enforces nothing, which is worse than
-no policy at all, because someone would rely on it. The refusal names the
-backend that does enforce.
+On the `hvi` backend, a boot reads every policy bound to the run and puts
+the rules on the network gateway it gives that sandbox. That gateway is the
+sandbox's only way out, so the rules are the sandbox's only way out.
+Measured in a real guest in
+[docs/manual-tests/egress-policy.md](manual-tests/egress-policy.md): an
+allowed name reaches, a denied name does not resolve, and an address
+dialled directly does not connect.
 
-The runtime has to be new enough, too. The gateway's rule flags arrived after
-hull 0.1.0-rc21, so brig asks the binary whether it takes them and says so
-plainly if it does not, rather than letting the sandbox come up with no network
-and the reason in a log file.
+On every backend that cannot enforce a policy, brig refuses the boot rather
+than running unenforced. `vz`, `qemu` and every Linux runtime refuse a
+filtered run outright, naming the backend that does enforce. Refusing it
+beats booting a sandbox that reports a policy and filters nothing. There is
+one exception: a policy-carrying run whose posture is `offline` is not
+refused on any backend. A sandbox with no route out satisfies every rule
+set, regardless of who is watching.
+
+That refusal is checked before anything starts, and again on the path that
+finds the sandbox already running. A policy cannot be waved through by the
+accident of the sandbox being up already. Every runtime brig ships refuses
+a policy it cannot enforce. This is a guarantee about the runtimes brig
+ships today, not a property of the interface. A runtime that never answers
+the question is never asked, and stays unrefused.
+
+The runtime has to be new enough, too. The gateway's `--egress-*` flags
+arrived after hull 0.1.0-rc21. brig probes the binary itself, `<bin>
+network-gateway --help`, rather than checking a version number. The exact
+release does not matter: a hull newer than 0.1.0-rc21 works. An older one
+is refused by name once a policy applies to the run:
+
+```console
+$ brig policy attach locked-down claude-code
+attached locked-down to claude-code
+note: enforced on the hvi backend, which gives the sandbox a network of its own; a run on any other backend is refused rather than left unenforced
+$ brig run claude
+brig: a policy applies to this sandbox, but hull cannot enforce one (its network-gateway has no --egress-default). Upgrade the runtime, or detach the policy -- brig will not boot a sandbox that reports a policy nothing enforces
+```
+
+This probe has a gap, worth stating plainly rather than hiding. If the
+probe command itself fails to run, brig draws no conclusion from that
+failure, and the boot proceeds anyway. The reasoning is that a runtime too
+broken to print its own help produces a clearer error later in the boot.
+But the probe cannot tell a broken binary from one that exits non-zero on
+`--help` for some other reason. In that one case, the capability check
+fails open. A policy can reach a gateway that does not take the flags,
+with no refusal from this check first.
 
 Three properties worth stating outright:
 
 - **The rules are fixed when the sandbox boots.** They go on the gateway's
-  command line and it reads them once. Editing a policy changes what the next
-  boot enforces, never what a running sandbox is already under, and no
-  environment variable overrides it. A policy an agent could ask to have
-  relaxed mid-run is not a policy.
-- **A policy takes the network posture with it.** Rules belong to a gateway and
-  cover every member of its network, so a sandbox answering to rules of its own
-  gets a network of its own: the run is `isolated` whether or not it asked to
-  be, and the `NETWORK` row of the execution envelope says so. That only ever
-  narrows what was asked for.
-- **Several policies at once are unioned.** A rule in any of them is a rule of
-  the run's, and the default is the strictest any of them names -- one `deny`
-  makes the run deny-by-default. Note what the union costs: a host allowed by
-  the second policy is reachable even though the first alone would have denied
-  it. Attaching is granting. `deny` still beats `allow` across the whole set.
+  command line and it reads them once. Editing a policy changes what the
+  next boot enforces, and no environment variable overrides a running
+  gateway's rules. A sandbox that is already up when the rules change does
+  not keep running under the old ones. brig detects the mismatch, stops,
+  removes and reboots the sandbox, and warns that any other session on it
+  will be disconnected.
+- **A policy takes the network posture with it.** Rules belong to a
+  gateway and cover every member of its network. A sandbox answering to
+  rules of its own gets a network of its own: the run is `isolated`,
+  whether or not it asked to be. The `NETWORK` row of the execution
+  envelope says so. That only ever narrows what was asked for.
+- **Several policies at once are unioned.** A rule in any of them is a
+  rule of the run's. The default is the strictest any of them names: one
+  `deny` makes the run deny-by-default. A host the second policy allows is
+  reachable even when the first policy alone denies it. Attaching is
+  granting. At the gateway that enforces the rules, `deny` still takes
+  priority over `allow` across the whole set. See the precedence note
+  below.
 
-### What this still does not do
+### What this does not do yet
 
 `attach` and `check` refuse what brig knows it cannot enforce at all (a
-`kind: shell`/`kind: gui` profile) and a name bound to nothing, but neither
-inspects the rules a policy contains: they cannot tell you that an `allow` glob
-matches nothing you meant, only that the document parses.
+`kind: shell`/`kind: gui` profile), and a name bound to nothing. Neither
+inspects the rules a policy contains. Neither can tell you that an `allow`
+glob matches nothing you meant. They can only tell you that the document
+parses.
 
-A `host` rule is enforced through the gateway's own resolver, so what it covers
-depends on the default. Under `default: deny` the resolver answers only names
-an `allow` glob covers, and the guest reaches nothing it did not resolve there
--- which is also why traffic sent straight to an address, DNS-over-HTTPS and
-DNS-over-TLS do not get out. Under `default: allow` a `host` deny is best
-effort, because traffic sent straight to an address never asks for a name. A
-`cidr` rule is matched on the address either way.
+Deny-over-allow-over-default ordering, and the host-rule behavior below,
+are the enforcing gateway's documented behavior, not something brig
+verifies itself. brig's own merge applies no priority. It concatenates the
+`allow` and `deny` lists from every bound policy. Each rule reaches the
+gateway as an `--egress-allow` or `--egress-deny` flag on its command
+line.
+
+The one measurement in this repository,
+[docs/manual-tests/egress-policy.md](manual-tests/egress-policy.md), covers
+a `default: deny` policy with one `host` allow. The allowed name reaches, a
+denied name fails to resolve, and an address dialled directly fails to
+connect. It does not exercise a `deny` rule overriding an `allow` rule, and
+it does not exercise a `default: allow` policy. Treat deny-over-allow
+ordering as hull's documented gateway behavior, evidenced historically by
+that one measurement, and not as something brig's own tests confirm.
+
+A `host` rule is enforced through the gateway's own resolver, so what it
+covers depends on the default. Under `default: deny`, the resolver answers
+only names an `allow` glob covers, and the guest reaches nothing it did not
+resolve there. That is also why traffic sent straight to an address, DNS
+over HTTPS and DNS over TLS do not get out. Under `default: allow`, a
+`host` deny is best effort, because traffic sent straight to an address
+never asks for a name. A `cidr` rule is matched on the address either way.

--- a/docs/policies.md
+++ b/docs/policies.md
@@ -7,7 +7,8 @@ one session, and check where brig actually enforces it.
 Policy enforcement needs hull's `hvi` backend, which needs macOS 15 or
 newer, and a hull newer than 0.1.0-rc21. On every other backend, including
 every Linux runtime, brig refuses a policy-bound boot rather than running it
-unenforced. See [Where a policy is enforced](#where-a-policy-is-enforced-and-where-it-is-not).
+unenforced. A run with `--network offline` is the exception: it reaches no
+network at all, so it satisfies any egress rule and is never refused. See [Where a policy is enforced](#where-a-policy-is-enforced-and-where-it-is-not).
 
 ## Network postures
 

--- a/docs/profiles.md
+++ b/docs/profiles.md
@@ -174,7 +174,7 @@ with the same parser and neither has to guess.
 | `runtimeBin` | no | The runtime binary to drive instead of the one on `PATH`, `~` expanded. Unlike every other field this is about your machine rather than the workload, so it does not travel usefully to anyone else -- it is how you pin a profile to a build you are working on without exporting a variable in every shell. `BRIG_RUNTIME_BIN` wins over it |
 | `rootfsType` | no | How the guest root reaches the VM: `block`, `virtiofs` or `9pfs`. Left unset the runtime picks its own default, which is what a profile that only runs an agent wants. Set `block` when the sandbox installs packages and needs a real writable disk rather than a share sized to the image |
 | `genericBoot` | no | The image was never built to be a guest -- a plain OCI image with no kernel and no urunc metadata. The runtime supplies the kernel and initrd and boots it unmodified, on macOS and Linux alike. See below |
-| `hostConfigDir`, `projectPaths` | no | Where the user's own agent configuration lives on the host, and which subdirectories of it to seed into the workspace. Both are required together, and only `claude-code` declares them: see [What this costs](#what-this-costs) below |
+| `hostConfigDir`, `projectPaths` | no | Where the user's own agent configuration lives on the host, and which subdirectories of it to seed into the workspace, and only when the run passes `--skills` or sets `BRIG_SKILLS=1`. Both fields are required together, and only `claude-code` declares them, so `--skills` does nothing on the other seven: see [What this costs](#what-this-costs) below |
 | `onboarding` | no | A first-run state file to seed. See below |
 | `hostCredential` | no | **Deprecated, removed next release**, see [migration.md](migration.md#profile-keys). A credential read from the host keychain on every run when the environment carries none. Replaced by `secrets` with `sources`, filled once by `brig secret import`. See below |
 | `reserved` | no | Marks a profile that owns the workspace a session name could otherwise slug onto. See below |
@@ -566,7 +566,7 @@ is no host directory named to copy.
 hostmounts, which is what lets a `--skills` copy land somewhere that
 survives. `claude-desktop` covers `.claude` with the same kind of tmpfs but
 carves out no exception for `.claude/skills`, only for `settings.json`,
-`CLAUDE.md`, `sessions`, `projects` and `history.jsonl`. This is unrelated to
+`CLAUDE.md`, `sessions`, `projects`, `plugins` and `history.jsonl`. This is unrelated to
 `--skills`, which is already a no-op there for the reason above: whatever the
 bundled desktop app itself writes under `.claude/skills` is thrown away at
 shutdown, where the same path persists for `claude-code`.
@@ -627,8 +627,8 @@ trade.
 
 ## `reserved`, so a session name cannot land on the wrong workspace
 
-`claude-desktop` owns the Desktop app's workspace, so `brig run claude --name
-desktop` is refused rather than quietly landing a Claude Code session there.
+`claude-desktop` owns the Desktop app's workspace, so `brig run claude@desktop`
+is refused rather than quietly landing a Claude Code session there.
 That protection is `reserved: true` on the `claude-desktop` profile.
 
 The trailing word is reserved too, not just the full name: `claude-desktop`

--- a/docs/profiles.md
+++ b/docs/profiles.md
@@ -1,7 +1,14 @@
 # Writing an agent profile
 
+**Two words, and they mean different things.** The command is `brig agent`:
+`brig agent ls`, `brig agent edit`, and the `<ref>` every verb takes. *Profile*
+names the other half: the file format this page documents, the directory it
+lives in (`$XDG_CONFIG_HOME/brig`), and the variable that points somewhere
+else (`BRIG_PROFILE_DIR`). Both words are correct at once. You run an agent;
+you edit a profile.
+
 brig boots an agent from an OCI image. Any Linux CLI that runs in one already
-works, so a profile is not a requirement -- it just saves you spelling out
+works, so a profile is not a requirement, it just saves you spelling out
 the image, the guest home and the credential variables on every invocation.
 
 The quickest way to write one is to start from the closest existing profile
@@ -72,6 +79,41 @@ together, one namespace -- and marks where each came from: unmarked is
 embedded, `(file)` is a profile that exists only as a file, and
 `(file, overrides built-in)` is a file shadowing an embedded one.
 
+## The eight built-in profiles
+
+| profile | alias | kind | image |
+| --- | --- | --- | --- |
+| `claude-code` | `claude` | agent | `ghcr.io/brig-sh/claude-code-stock:latest` |
+| `claude-desktop` | `desktop` | gui | `ghcr.io/nofireai/urunc-claude-desktop:aarch64` |
+| `codex` |  | agent | `ghcr.io/brig-sh/codex-stock:latest` |
+| `cursor` |  | agent, example profile | `ghcr.io/brig-sh/cursor:latest` |
+| `gemini` |  | agent, example profile | `ghcr.io/brig-sh/gemini-stock:latest` |
+| `grok` |  | agent, example profile | `ghcr.io/brig-sh/grok-stock:latest` |
+| `opencode` |  | agent, example profile | `ghcr.io/brig-sh/opencode-stock:latest` |
+| `ubuntu` |  | shell | `docker.io/library/ubuntu:latest` |
+
+"example profile" is the profile's own `desc:`, and `brig agent ls` prints it.
+`claude-code` and `codex` carry no such marker.
+
+Seven of the eight name an image brig expects to be pullable. `cursor` is the
+one that does not: it declares `unpublished: true`, `brig run` refuses it
+before the registry is reached, and `brig agent ls` appends
+`(no published image)`. Pass your own `--image` to run it. Whether the other
+seven are pullable today is a registry fact rather than a brig fact; this
+table states only what each profile declares.
+
+Five of those seven, `claude-code`, `codex`, `gemini`, `grok` and `opencode`,
+are brig's own multi-architecture `:latest` builds under `ghcr.io/brig-sh`,
+the registry brig can verify a signature against. `claude-desktop` and
+`ubuntu` point outside it, at `ghcr.io/nofireai/` and Docker Hub, so brig
+cannot check their signature and warns on every boot
+([security.md](security.md)). `claude-desktop`'s image is also single-arch,
+`aarch64` only.
+
+`claude-desktop` is the one shipped `kind: gui` profile and `ubuntu` the one
+shipped `kind: shell` profile; the other six are `kind: agent`, the default.
+See [`kind`, and what each one does](#kind-and-what-each-one-does) below.
+
 ## Export and import
 
 ```bash
@@ -113,17 +155,17 @@ with the same parser and neither has to guess.
 | `name` | yes | The profile name. It becomes the workspace directory and the sandbox name, so it is restricted to lowercase letters, digits, dot, dash and underscore |
 | `image` | yes | The guest image to boot |
 | `guestHome` | yes | Absolute path where the workspace is mounted. The agent's state lands here, which is what makes the workspace the unit of persistence |
-| `kind` | no | `agent` (the default), `shell` or `gui`. An `agent` needs a `binary`; the other two have nothing to pass arguments to |
+| `kind` | no | What sort of workload this is: `agent` (the default), `shell` or `gui`. See [`kind`, and what each one does](#kind-and-what-each-one-does) below |
 | `binary` | yes, for `kind: agent` | The agent CLI inside the guest |
 | `mem`, `cpus` | yes | Guest size. Both must be greater than zero |
 | `desc` | no | One line, shown by `brig agent ls` |
 | `secrets` | no | Names this profile wants out of brig's own secret store, checked before the sandbox is created. Each entry says whether a run without it should stop, and where `brig secret import` may find it. See below |
 | `env` | no | The variables the guest sees, and where each one's value comes from: a literal, a stored secret, or brig's own environment. See below |
-| `forward` | no | Deprecated spelling of `env` for the environment case. Still works; folded into `env` when the file is read. See below |
+| `forward` | no | Deprecated, see [migration.md](migration.md#profile-keys). Still works; folded into `env` when the file is read. See below |
 | `files` | no | Credential files the guest sees: which stored secret fills each one, and where under `guestHome` it is written. See below |
 | `volumes` | no | What is mounted inside `guestHome`: a `tmpfs` that nothing written to can reach host disk, how big it may grow, and the `hostmount` exceptions kept across boots. See below |
 | `deny` | no | Variables never bound, whatever `env` or `forward` says. See below |
-| `statePaths` | no | Deprecated: `volumes` says the same thing and is acted on. Still read, so an older file keeps parsing; declaring both is an error rather than a merge |
+| `statePaths` | no | Deprecated, see [migration.md](migration.md#profile-keys). Still parses; declaring it alongside `volumes:` is an error, not a merge. Five shipped profiles declare only this, and nothing outside this package reads it: see [What this costs](#what-this-costs) below |
 | `staleCredentialFiles` | no | Paths an older wrapper used to write a credential into. brig never does, so finding one is worth a warning rather than a deletion |
 | `headless` | no | The agent supports a non-interactive run |
 | `guiTitle` | no | Window title, for a `kind: gui` profile |
@@ -132,9 +174,9 @@ with the same parser and neither has to guess.
 | `runtimeBin` | no | The runtime binary to drive instead of the one on `PATH`, `~` expanded. Unlike every other field this is about your machine rather than the workload, so it does not travel usefully to anyone else -- it is how you pin a profile to a build you are working on without exporting a variable in every shell. `BRIG_RUNTIME_BIN` wins over it |
 | `rootfsType` | no | How the guest root reaches the VM: `block`, `virtiofs` or `9pfs`. Left unset the runtime picks its own default, which is what a profile that only runs an agent wants. Set `block` when the sandbox installs packages and needs a real writable disk rather than a share sized to the image |
 | `genericBoot` | no | The image was never built to be a guest -- a plain OCI image with no kernel and no urunc metadata. The runtime supplies the kernel and initrd and boots it unmodified, on macOS and Linux alike. See below |
-| `hostConfigDir`, `projectPaths` | no | Where the user's own agent configuration lives on the host, and which subdirectories of it to seed into the workspace. Only when the run passes `--skills` or sets `BRIG_SKILLS=1`. See below |
+| `hostConfigDir`, `projectPaths` | no | Where the user's own agent configuration lives on the host, and which subdirectories of it to seed into the workspace. Both are required together, and only `claude-code` declares them: see [What this costs](#what-this-costs) below |
 | `onboarding` | no | A first-run state file to seed. See below |
-| `hostCredential` | no | **Deprecated, removed next release.** A credential read from the host keychain on every run when the environment carries none. Replaced by `secrets` with `sources`, filled once by `brig secret import`. See below |
+| `hostCredential` | no | **Deprecated, removed next release**, see [migration.md](migration.md#profile-keys). A credential read from the host keychain on every run when the environment carries none. Replaced by `secrets` with `sources`, filled once by `brig secret import`. See below |
 | `reserved` | no | Marks a profile that owns the workspace a session name could otherwise slug onto. See below |
 | `unpublished` | no | We ship the profile but not an image for it. `brig run` says so and stops, rather than letting the pull fail against the registry with a 404 that reads like an outage. Pass `--image` with one you built, and `brig agent ls` marks it. `cursor` is the one that carries it |
 | `policy` | no | Names of policies attached to this profile inline: every run carries all of them, unioned with whatever is attached separately by name |
@@ -143,6 +185,36 @@ A misspelled field is refused rather than ignored. `forwards:` instead of
 `forward:` would otherwise decode into nothing, forward no credentials, and
 look exactly like a broken sandbox.
 
+## `kind`, and what each one does
+
+Three values, and each changes what `brig run` does once the guest is up.
+
+- **`kind: agent`**, the default. `brig run` execs `binary:` and passes your
+  trailing arguments to it. `binary:` is required.
+- **`kind: shell`**. `brig run` opens a login shell, and trailing words run as
+  one command instead. There is no CLI to pass arguments to: `brig sh` always
+  execs `bash -l` (or `bash -lc` for a command), never `binary:`, so the field
+  is not required and not read for this kind. `ubuntu` sets `binary: bash`
+  anyway, which documents the shell without brig acting on it.
+- **`kind: gui`**. The VM boots with a graphical console and there is nothing
+  to attach to: starting the sandbox is the whole command, and `brig run`
+  refuses a trailing argument rather than discarding it. `guiTitle:` names the
+  window. Only the `vz` hypervisor shows a console, so brig refuses to boot a
+  `kind: gui` profile on `hvi` or `qemu`.
+
+The older `shell:` and `gui:` booleans still parse and fold into `kind:` when
+the file is read; see [migration.md](migration.md#profile-keys).
+
+Two of the eight shipped profiles are not agents: `claude-desktop` is
+`kind: gui`, and `ubuntu` is `kind: shell`. The `agent` group's own help text
+calls the group "the agents you can run" (`brig agent --help`), which holds
+for six of the eight and not for those two: `brig agent ls` still lists them,
+but running one opens a window or a shell rather than an agent CLI.
+
+A `kind: shell` or `kind: gui` profile cannot carry `policy:`. Neither has an
+agent process to hook an egress rule into, and brig refuses the profile at
+parse time rather than accepting a rule nothing enforces.
+
 ## `secrets` and `env`, for a credential brig resolves itself
 
 `secrets:` is what a profile requires out of brig's own secret store.
@@ -150,8 +222,8 @@ look exactly like a broken sandbox.
 literal, one of those secrets, or brig's own environment:
 
 ```yaml
-name: alex
-image: ghcr.io/brig-sh/claude-code:latest
+name: mine
+image: ghcr.io/brig-sh/claude-code-stock:latest
 guestHome: /home/claude
 binary: claude
 mem: 4096
@@ -249,17 +321,16 @@ makes the profile portable.
 The run fails before any sandbox is created, and the error names the secret,
 the sandbox it was needed for, and the command that creates it:
 
-```
-$ brig
-brig: missing secret "gh_token" needed by the brig-alex sandbox -- create it first with: brig secret create gh_token
+```console
+$ brig run mine
+brig: missing secret "gh_token" needed by the brig-mine sandbox, create it first with: brig secret create gh_token
 ```
 
 A profile missing more than one gets every name in the same error, not one
 failed run per secret:
 
 ```
-$ brig
-brig: missing 2 secrets needed by the brig-alex sandbox -- create them first:
+brig: missing 2 secrets needed by the brig-mine sandbox, create them first:
   brig secret create gh_token
   brig secret create npm_token
 ```
@@ -485,9 +556,30 @@ The corollary for `--skills`: those host directories are copied into the
 workspace, so a profile that covers the directory they land in needs a
 `hostmount` for each, or the copy is hidden and the flag does nothing.
 
-`volumes:` replaces `statePaths:`, which was reference-only documentation.
-Declaring both is an error rather than a merge: two lists that can disagree
-about what persists is worse than the duplication.
+That corollary only applies once `--skills` runs at all, and today it runs on
+one shipped profile. `hostConfigDir:` and `projectPaths:` are required
+together, and `claude-code` is the only shipped profile that declares either.
+On the other seven, `--skills` and `BRIG_SKILLS=1` parse and do nothing: there
+is no host directory named to copy.
+
+`claude-code`'s tmpfs carves out `.claude/skills` and `.claude/plugins` as
+hostmounts, which is what lets a `--skills` copy land somewhere that
+survives. `claude-desktop` covers `.claude` with the same kind of tmpfs but
+carves out no exception for `.claude/skills`, only for `settings.json`,
+`CLAUDE.md`, `sessions`, `projects` and `history.jsonl`. This is unrelated to
+`--skills`, which is already a no-op there for the reason above: whatever the
+bundled desktop app itself writes under `.claude/skills` is thrown away at
+shutdown, where the same path persists for `claude-code`.
+
+`volumes:` replaces `statePaths:`, which was reference-only documentation
+even before it was deprecated: nothing outside this package ever read it.
+Five shipped profiles, `codex`, `cursor`, `gemini`, `grok` and `opencode`,
+declare only `statePaths:` and no `volumes:` at all, so none of them has
+anything memory-only. Their whole guest home is the workspace share, on host
+disk. A login an agent writes there persists across `brig stop` like any
+other file in the workspace. `claude-code` and `claude-desktop` are the only
+two shipped profiles with a `volumes:` tmpfs. They are the only two where an
+in-guest login lives in memory and does not survive a stop.
 
 ### What is not here yet
 
@@ -500,14 +592,14 @@ agent); the verb is not.
 `brig info <profile>` reports what the guest would be handed, by name --
 never a value, on any path. A variable sourced from the secret store is
 annotated `(secret)`; one from the deprecated `hostCredential:` is annotated
-`(host)`; an ambient or literal one is reported bare:
+`(host)`; an ambient or literal one is reported bare. No test pins the exact
+wording, so treat this as the shape rather than a literal transcript:
 
-```
-$ brig info alex
-...
-brig: workspace /Users/alex/brig/alex (sandbox brig-alex)
+```console
+$ brig info mine
+brig: workspace /Users/you/brig/mine (sandbox brig-mine)
 brig: runtime hull (/opt/homebrew/bin/hull)
-brig: image ghcr.io/brig-sh/claude-code:latest (pull missing)
+brig: image ghcr.io/brig-sh/claude-code-stock:latest (pull missing)
 brig: forwarding to guest:
 brig:   GH_TOKEN(secret)
 brig:   CI
@@ -686,6 +778,10 @@ Two things matter for a guest brig can drive. Install the CLI outside the home
 directory, because the workspace gets mounted over it at boot. And bake no
 credential into the image, since the agent authenticates at runtime and its
 state belongs in the home directory brig persists.
+
+[guest-image.md](guest-image.md) is the full contract: every binary brig execs
+inside the guest, the account it expects, and a script that checks an image
+you built against it.
 
 ## `genericBoot`, for an image that is not a guest image
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,118 +1,127 @@
 # Quickstart
 
-One agent, running in a sandbox, on a Mac that meets the requirements. This is
-the shortest path from nothing to a working Claude Code session. Everything
-else brig can do is in the [README](../README.md) and the rest of
-[docs/](.); this page is only the first run.
+This page takes you from an empty terminal to Claude Code running inside a
+sandbox, on a throwaway project. It also shows you how to stop it when you
+are done. It is one path, start to finish. The [README](../README.md) and
+the rest of [docs/](.) cover everything else brig can do.
 
-You need a Mac. brig boots the sandbox as a microVM over
-Virtualization.framework, and macOS 26 is what it is tested on.
+## Prerequisites
 
-## Install
+You need a Mac with Apple silicon. The default agent profiles, including
+`claude-code`, ask for hull's `hvi` backend, and `hvi` needs macOS 15 or
+newer. On macOS 14, set `BRIG_HYPERVISOR=vz` before you run one. See
+[docs/support.md](support.md) for the full platform matrix.
 
-```bash
-brew tap brig-sh/brig
-brew trust brig-sh/brig       # brew refuses untrusted third-party taps
-brew install --cask brig
-```
+brig itself must already be installed. [docs/install.md](install.md) covers
+every platform, and how to verify a download.
 
-The cask depends on [hull](https://github.com/brig-sh/hull), the microVM
-runtime brig drives, so installing brig brings it along. `cosign` is optional.
-Without it brig cannot verify the guest image and says so on every boot; with
-it the boot is checked. `brew install cosign` if you want the check.
-
-## Run
+## Check what brig found
 
 ```bash
-brig run claude
+brig doctor
 ```
 
-That boots the sandbox and starts Claude Code inside it. `claude` is the short
-name for the `claude-code` profile.
-
-## What the first run does
-
-The first run is the slow one. In order:
-
-- **The boundary is named, if you ask.** `brig info claude` prints the
-  execution envelope without starting anything, and `brig --verbose run` prints
-  it before the boot:
-
-  ```
-  PROFILE      claude-code
-  SANDBOX      brig-claude-code (hull)
-  ISOLATION    microVM (hull, hvi backend)
-  WORKSPACE    /Users/you/brig/claude-code (read-write)
-  IMAGE        ghcr.io/brig-sh/claude-code-stock:latest (pull missing)
-  VERIFY       warn, against brig's own trust policy
-  CREDENTIALS  claude-credentials
-  NETWORK      shared (one network for every sandbox on this host)
-  ```
-
-  Credentials are named, never printed. An ordinary run goes straight to the
-  work rather than printing this first.
-- **The image is pulled.** The guest image comes down from the registry once.
-  Later runs use the copy already on disk.
-- **The image is verified.** brig checks that the image, and the kernel it
-  boots, were built by the workflow that publishes them. The run says so in one
-  line:
-
-  ```
-  brig: image and boot assets verified
-  ```
-
-  The `VERIFY` row above names the policy that line held under. A check that
-  did **not** hold prints at every level, `-q` included. The per-check detail
-  is `--verbose`'s:
-
-  ```
-  brig: image ghcr.io/brig-sh/claude-code-stock:latest: signature verified
-  ```
-
-  Then it starts the sandbox, which is another line `--verbose` carries:
-
-  ```
-  brig: starting sandbox brig-claude-code...
-  ```
-
-- **The agent asks you to log in.** The sandbox boots with no credential, so
-  Claude Code prompts you to log in exactly as it would on a fresh machine.
-  That login happens inside the sandbox.
-
-The login lives in the sandbox's memory. It lasts as long as the sandbox does,
-and never reaches your disk. Stop the sandbox and the next run asks again. To
-carry the login you already have on this Mac into the sandbox, and keep it
-across stops, see [Credentials](../README.md#credentials).
-
-## The one directory the agent can see
-
-The agent's whole world is one host directory, mounted as its home:
+brig prints one line per fact, in this shape:
 
 ```
-~/brig/claude-code
+  ok  host      macOS 26.5 on arm64
+  ok  virtual   Hypervisor.framework available
+  ok  runtime   hull 0.1.0-rc21 at /opt/homebrew/bin/hull
+  !!  boot      assets missing at /Users/you/.hull/assets
+          run any agent once to fetch them, or set BRIG_BOOT_ASSETS to a directory that has them
+  ok  verify    cosign at /opt/homebrew/bin/cosign, BRIG_VERIFY=warn
+  ok  profiles  8 built in, 0 in /Users/you/.config/brig
+  ok  secrets   keychain reachable
+  --  brigd     not running (no socket at /Users/you/.brig/brigd.sock)
+  --  image     pass an agent to check its image: brig doctor claude
 ```
 
-Nothing else on your machine is reachable from inside the sandbox. Put the
-projects the agent should work on in that directory. It cannot reach your
-keychain, your SSH agent, or any other folder. That directory holds the
-agent's settings, its history, and your projects, and it stays on the host
-across restarts.
+`ok` means brig found what that line checks. `virtual` reports only whether
+this Mac can host a microVM at all, not which backend a run uses. `!!`
+prints a fix beside the line and does not stop you here. brig fetches
+missing boot assets itself, the first time an agent needs them. `--` means
+brig looked and found nothing to report, not a failure. `brigd` is an
+optional daemon this quickstart does not need.
 
-## Keep going, or stop
-
-The sandbox stays up between commands, so a second `brig run claude` is
-immediate. When you are done:
+## Run it
 
 ```bash
-brig stop claude    # stop the sandbox, keep it
-brig rm claude      # stop and remove the sandbox
+mkdir -p ~/code/demo && cd ~/code/demo
+brig run claude ~/code/demo
 ```
 
-`brig stop` keeps the sandbox so starting it again is a boot, not a fresh
-creation. It takes the in-sandbox login with it. `brig rm` removes the sandbox
-as well. Neither touches `~/brig/claude-code`: your projects and the agent's
-saved state stay where they are. To drop those too, remove the directory by
-hand.
+`claude` is the default session of the `claude-code` agent. `~/code/demo`
+is the project this run mounts.
 
-If a run fails, [troubleshooting.md](troubleshooting.md) is organised by what
-you saw on the terminal.
+The first run is the slow one: brig pulls the guest image once, and later
+runs reuse the copy already on disk. `brig --verbose run` prints the
+execution envelope before it boots, and `brig info claude` prints the same
+thing without running anything:
+
+```
+PROFILE      claude-code
+SANDBOX      brig-claude-code (hull)
+ISOLATION    microVM (hull, hvi backend)
+WORKSPACE    /Users/you/brig/claude-code (read-write)
+IMAGE        ghcr.io/brig-sh/claude-code-stock:latest (pull missing)
+VERIFY       warn, against brig's own trust policy
+CREDENTIALS  (none)
+NETWORK      shared (one network for every sandbox on this host)
+```
+
+`claude-code` asks for hull's `hvi` backend, which is why `ISOLATION` names
+it: `hvi` drives Apple's Hypervisor.framework directly, not
+Virtualization.framework. `WORKSPACE` here is brig's own label for the
+guest home, the row this page calls the guest home everywhere else.
+
+Once brig verifies the image and the boot assets, it prints one line and
+starts the sandbox:
+
+```
+brig: image and boot assets verified
+```
+
+Then Claude Code asks you to log in, because the sandbox holds no
+credential. That login happens inside the sandbox. On `claude-code` it
+lands on a memory-backed mount, not disk, so `brig stop` takes it with the
+VM and the next run asks again. Not every agent works this way: see
+[sessions.md](sessions.md#what-survives) for which do.
+
+## Where the agent's files live
+
+Two host directories are reachable from inside the sandbox, and nothing
+else is:
+
+- The **guest home**, `~/brig/claude-code`, mounted as the agent's home.
+  Its settings and its history live there, and it survives everything
+  short of you deleting it by hand.
+- The **project**, `~/code/demo` in the run above, mounted read-write at
+  `/work/demo`. The agent starts there.
+
+The agent can change anything under `/work/demo`, because that mount is
+read-write and those are your real files. It cannot reach your keychain,
+your SSH agent, or any host directory you did not name.
+[sessions.md](sessions.md) explains the full model: what a session is,
+what each mount keeps separate, and what survives which command.
+
+## You know it worked
+
+The agent's prompt appears, and inside it `pwd` prints `/work/demo`. Leave
+the agent running and the sandbox stays up, so a second `brig run claude`
+is immediate.
+
+## Stop it
+
+```bash
+brig stop claude   # stop the sandbox, keep its name
+brig rm claude      # stop and remove it
+```
+
+`brig stop` keeps the sandbox's name, its row in `brig ls`, and what brig
+recorded about the session. `brig rm` drops the last of those too. Neither
+touches `~/brig/claude-code` or `~/code/demo`: your project and the
+agent's saved state stay where they are.
+
+If a run does not do what you expected,
+[troubleshooting.md](troubleshooting.md) is organized by what you saw on
+the terminal.

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -30,6 +30,17 @@ it, in order.
   opens a **draft** release for the tag. `draft: true` is deliberate: a tag
   never publishes itself before someone has read the notes.
 
+- Two different signing paths run here, and only one needs a stored secret.
+  `cosign` signs the checksum file keylessly. It gets a short-lived
+  certificate from Sigstore's OIDC flow, and no key exists anywhere. Signing
+  and notarizing the macOS binaries needs repository secrets instead: a
+  Developer ID certificate, its password, a notary API key, a key ID and an
+  issuer ID. `.goreleaser.yaml` gates notarization on the certificate secret
+  being set, so a release run without it still succeeds, and ships an
+  unsigned macOS binary. Publishing the Homebrew cask needs one more
+  credential: a token for the separate tap repository, because the built-in
+  `GITHUB_TOKEN` cannot write there.
+
 ## Publish the draft
 
 - Read the draft's generated notes. Fix anything the changelog grouped wrong.
@@ -78,6 +89,12 @@ it, in order.
   At least `VERSION`, the compatibility window named in README's deprecation
   section (the hull version brig can pin against), and anything else that
   quotes a version number.
+
+  This grep exists because a version quoted in a comment survives copy-paste.
+  As of `0.1.0-rc18`, `install.sh`'s own `BRIG_VERSION` example still named
+  the previous release, `rc17`: the exact staleness this step is meant to
+  catch. Run the grep everywhere a version might hide, not just where you
+  expect one.
 
 ## Check before you walk away
 

--- a/docs/runtimes.md
+++ b/docs/runtimes.md
@@ -34,6 +34,33 @@ not brig-shaped. nerdctl, containerd and urunc predate brig, are used far
 outside it, and brig is an ordinary caller of all three: it passes flags any
 other caller could pass.
 
+## The three macOS backends
+
+hull accepts three values for its `--hypervisor` flag: `vz`, `hvi` and
+`qemu`. brig passes through whichever one the profile names, or
+`BRIG_HYPERVISOR` when that is set.
+
+`vz` talks to Virtualization.framework through the `vz-runner` helper. It is
+hull's own default when nothing else names a backend. It is also the only
+backend that can show a graphical console, so a `kind: gui` profile is
+refused on `hvi` and `qemu`.
+
+`hvi` talks to Hypervisor.framework directly, through the `hvi` VM monitor.
+It is the only backend that runs a network gateway of its own. An attached
+egress policy and `--network isolated` both refuse to run on anything else.
+Six of the eight shipped profiles set `hypervisor: hvi`. In practice most
+runs use `hvi`, not `vz`, even though `vz` is what hull picks when a profile
+is silent.
+
+`qemu` is a third value hull accepts. Which framework it uses, if any, and
+what it needs on the host are questions for hull's own documentation.
+Nothing in brig's source answers them.
+
+`brig doctor`'s `Hypervisor.framework available` line is not a report on any
+of these three backends. It is the pass string of one `kern.hv_support`
+sysctl read, which asks only whether this Mac can back a microVM at all. It
+never gates the exit status.
+
 ## Where the boundary sits
 
 brig decides, and the runtime never sees the reasoning:

--- a/docs/runtimes.md
+++ b/docs/runtimes.md
@@ -41,16 +41,17 @@ hull accepts three values for its `--hypervisor` flag: `vz`, `hvi` and
 `BRIG_HYPERVISOR` when that is set.
 
 `vz` talks to Virtualization.framework through the `vz-runner` helper. It is
-hull's own default when nothing else names a backend. It is also the only
+what brig falls back to when neither the profile nor `BRIG_HYPERVISOR` names a
+backend. brig always passes `--hypervisor` explicitly, so hull's own default
+never decides it. It is also the only
 backend that can show a graphical console, so a `kind: gui` profile is
 refused on `hvi` and `qemu`.
 
 `hvi` talks to Hypervisor.framework directly, through the `hvi` VM monitor.
 It is the only backend that runs a network gateway of its own. An attached
 egress policy and `--network isolated` both refuse to run on anything else.
-Six of the eight shipped profiles set `hypervisor: hvi`. In practice most
-runs use `hvi`, not `vz`, even though `vz` is what hull picks when a profile
-is silent.
+Six of the eight shipped profiles set `hypervisor: hvi`, so most runs use
+`hvi` rather than the `vz` fallback.
 
 `qemu` is a third value hull accepts. Which framework it uses, if any, and
 what it needs on the host are questions for hull's own documentation.

--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -1,9 +1,11 @@
 # Keeping secrets in your keyring
 
-`brig secret` is brig's own store, and it is the **only** store a run reads. A
-profile declares the names it wants under `secrets:`, and what is in this store
-under those names reaches the sandbox -- as a file where the agent reads one,
-as an environment variable where it does not.
+`brig secret` is brig's own store, and it is the **only** store a run reads, on
+every profile brig ships. A profile of your own still carrying the deprecated
+`hostCredential:` field is the exception: it reads the host item it names on
+every run. A profile declares the names it wants under `secrets:`, and what is
+in this store under those names reaches the sandbox -- as a file where the
+agent reads one, as an environment variable where it does not.
 
 Most people never fill it by hand. One command carries the login already on
 your Mac into it:
@@ -125,12 +127,13 @@ brig: deleting "gh-token" cannot be undone, and there is no terminal to ask on. 
 
 `brig secret import <profile>` reads where your host already keeps that
 profile's credentials and copies them into brig's store, so that every run
-afterwards reads only the store:
+afterwards reads only the store. No test pins the exact wording brig prints,
+so treat this as the shape rather than a literal transcript:
 
 ```console
 $ brig secret import claude-code
 claude-code: importing 1 secret
-  claude-credentials: stored from keychain:Claude Code-credentials (expires in 11h)
+  claude-credentials: stored from keychain:Claude Code-credentials, expires 2026-08-19 01:31
   gh-token: no source on your host, so it is one you supply: brig secret create gh-token
 note: claude-desktop also declares claude-credentials, so this fills it there too
 ```
@@ -139,6 +142,12 @@ Where it looks is data in the profile, not knowledge in brig: each secret
 carries a `sources:` list and the first that exists wins. `brig agent ls` shows
 which names a profile can import and which it cannot, and
 [profiles.md](profiles.md) is how to declare them in one of your own.
+
+A profile can still declare a credential with the deprecated `hostCredential:`
+field instead of `secrets:` and `sources:`. It keeps working, but reads the
+named host keychain item on every run rather than once at import.
+[migration.md](migration.md#profile-keys) has the replacement. This page
+assumes `secrets:`.
 
 | flag | what it does |
 | --- | --- |
@@ -150,9 +159,10 @@ which names a profile can import and which it cannot, and
 
 Four rules worth knowing before you build anything on it:
 
-- **It reads your host when you type it, and never again.** That is the whole
-  point of the verb: a run performs no host read, so it raises no keychain
-  approval dialog. The dialog you may see belongs to `import` itself, once.
+- **It reads your host's own credential stores when you type it, and never
+  again.** A run afterwards reads only brig's own keychain item, which carries
+  the default ACL, so it raises no approval dialog. That dialog belongs to
+  `import` itself, once.
 - **The copy does not track its source.** Renewing the login on the host does
   not update brig's copy, and revoking it does not invalidate it. Re-import to
   refresh; `brig secret delete` to be rid of it.
@@ -185,9 +195,9 @@ fresh machine with a red exit code for a state that is perfectly normal.
 
 A stored value is capped at about 3KB (see [the size limit](#the-size-limit)),
 and that is enough for every API key, every OAuth credential document and every
-ed25519 key. It is **not** enough for `codex`: its `~/.codex/auth.json` carries
-two JWTs and runs to 4-8KB, so it does not fit and cannot be delivered as a
-file today.
+ed25519 key. It is **not** enough for a credential document the size of
+`codex`'s `~/.codex/auth.json`, which carries two JWTs, so it does not fit and
+cannot be delivered as a file today.
 
 This is not a constant to raise. The limit is a *line length* in `security -i`,
 which is how brig keeps a value out of `argv`; lifting it means changing how
@@ -331,12 +341,14 @@ base64 spends four characters for every three bytes of value.
 
 | name | longest value `create` takes | `update` |
 | --- | --- | --- |
-| `a` (1 character) | 3012 bytes | 3009 bytes |
-| `gh-token` (8 characters) | 3003 bytes | 3000 bytes |
-| `deploy-key` (10 characters) | 3000 bytes | 2997 bytes |
-| a 43-character name | 2949 bytes | 2946 bytes |
+| `a` (1 character) | 3012 bytes | 3006 bytes |
+| `gh-token` (8 characters) | 3003 bytes | 2994 bytes |
+| `deploy-key` (10 characters) | 3000 bytes | 2991 bytes |
+| a 43-character name | 2949 bytes | 2943 bytes |
 
-`update` is three bytes tighter throughout because its command carries `-U`.
+`update` is tighter because its command carries `-U` and an empty `-j` that
+clears the previous provenance. Base64's four-for-three then rounds that gap
+to six or nine bytes, depending on the name's length.
 
 Every API key and every SSH key you are likely to have fits: an ed25519
 private key is 387 bytes. A 4096-bit RSA private key does not, and is refused
@@ -344,7 +356,7 @@ with both numbers named rather than stored short:
 
 ```console
 $ brig secret create deploy-key -f rsa4096.pem
-brig: the value for "deploy-key" is 3272 bytes, and the keychain takes at most 3000
+brig: the value for "deploy-key" is 3272 bytes, and with its provenance the keychain takes at most 3000
 ```
 
 The check is there because the failure it replaces was invisible. The first
@@ -402,7 +414,7 @@ point of the table: the error is the second entry point into these docs.
 | `no value on stdin. Pipe one in, or pass -f <file>: …` (and prints two examples) | `create` at a prompt with nothing piped in. It refuses rather than waiting, because typing the value there would put it in your scrollback |
 | ``-f was given an empty path. Leave it out to read stdin, or pass `-f -` to say so`` | `-f "$KEYFILE"` with the variable unset. Falling through to stdin would store whatever the script had on it, under your name, and report success |
 | `--stdin and -f name two different sources; pass one` | both given, and guessing which you meant would silently store the wrong one |
-| `the value for "x" is N bytes, and the keychain takes at most M` | over [the size limit](#the-size-limit) |
+| `the value for "x" is N bytes, and with its provenance the keychain takes at most M` | over [the size limit](#the-size-limit) |
 | `deleting "x" cannot be undone, and there is no terminal to ask on. Pass -y to answer in advance: …` | a cron job or a unit file. `-y` is the answer given ahead |
 | `a secret name holds letters, digits, - and _, ...` | see [Naming a secret](#naming-a-secret) |
 | `no secret store on this platform: … no Secret Service answers on it …` | Linux with no keyring on the session bus. Install `gnome-keyring` or KWallet and log in to a session that starts it |
@@ -415,7 +427,9 @@ point of the table: the error is the second entry point into these docs.
 
 ## A worked example
 
-Storing a GitHub token, using it, rotating it and removing it.
+Storing a GitHub token, using it, rotating it and removing it. The commands
+are real. The exact wording brig prints is illustrative, since no test pins it
+byte for byte.
 
 Store it. `printf %s` rather than `echo`, so no newline is stored, and the
 value comes down a pipe rather than sitting in your history:
@@ -440,6 +454,12 @@ brig: never forwarded for claude-code: ANTHROPIC_API_KEY ANTHROPIC_AUTH_TOKEN (t
 
 `(secret)` says the value came from brig's store rather than from your shell.
 `brig info` reports; `brig run claude-code` does it.
+
+That denylist covers environment forwarding only. It does not check a
+`files:` binding. It does not stop an agent that reads a credential inside the
+guest from sending it over the network.
+[security.md](security.md#what-file-delivery-buys-and-what-it-costs) explains
+why the guard is scoped that way.
 
 An exported `GH_TOKEN` still wins, because the profile binds the name as a
 chain -- `refs: [env.GH_TOKEN, secrets.gh-token]` -- so

--- a/docs/security.md
+++ b/docs/security.md
@@ -2,11 +2,15 @@
 
 The reason to run an agent in a sandbox is that the agent runs code you did
 not write, against a machine that holds everything you have. brig narrows what
-"everything" means: the agent sees one directory and the credentials you chose
-to give it, and nothing else on the host.
+"everything" means. What the agent can reach on the host is its workspace,
+any project you name on the run line, and the credentials you gave it. No
+other host directory is mounted, and no host credential source is read on
+the run path. What the agent can reach over the network is a separate
+question, with a much weaker answer, covered below.
 
-This page is about where that boundary actually is. Some of it is weaker than
-it looks, and we would rather write that down than let someone find out later.
+This page states what is isolated first, then what an agent can still do.
+Some of it is weaker than it looks, and we would rather write that down than
+let someone find out later.
 
 If you have found a flaw in one of these boundaries, [SECURITY.md](../SECURITY.md)
 is how to report it privately. The section below on
@@ -40,11 +44,20 @@ promises. A shim brig does not recognise may well boot a VM, and brig cannot
 establish that from a name, so the row says it cannot tell instead of claiming
 the stronger boundary.
 
-Inside it, the guest has your workspace mounted as its home. It does not have
-your keychain, your SSH agent, your secret manager, or any other directory on
-the host. That inaccessibility is the isolation boundary, and it is also the
-reason credentials have to be forwarded in explicitly: the guest cannot fetch
-them for itself.
+Inside it, the guest has your workspace mounted as its home, read-write. Name
+a project on the run line and that project is a second host directory, also
+mounted read-write, at `/work/<name>`. The agent can change those files too.
+
+A profile's own hostmount volumes are further shares. Every one in a shipped
+profile lives inside the workspace already, so nothing extra is exposed
+today. That is a property of the shipped profiles, not a guarantee. A
+hostmount your own profile declares outside a tmpfs cover is a host path the
+guest can see.
+
+Beyond those, the guest does not have your keychain, your SSH agent, your
+secret manager, or any other directory on the host. That inaccessibility is
+the isolation boundary for everything else. It is also the reason credentials
+have to be forwarded in explicitly: the guest cannot fetch them for itself.
 
 ## Credentials
 
@@ -174,8 +187,8 @@ file is not an environment variable and does not appear in that list at all.
 The credential file is the part that does not. It lands on a `tmpfs` mount
 covering `~/.claude`, checked to be `tmpfs` with no swap before anything is
 written, so `~/.claude/.credentials.json` and the temp file the agent renames
-onto it never touch your disk. `brig stop` takes that mount with the VM, which
-is why an in-sandbox login does not outlive a stop.
+onto it never touch your disk. `brig stop` takes that mount with the VM,
+which is why an in-sandbox login on this profile does not outlive a stop.
 
 The rest of `~/.claude` is not on that mount. Seven paths under it are
 hostmounted, so they live in the workspace on host disk and persist across
@@ -350,11 +363,26 @@ microVM boundary stops this: the write is on the host side of it.
 
 So every host-side read and write brig makes inside the workspace goes through
 an `os.Root` opened on the workspace. It resolves each path itself, refuses an
-absolute symlink outright, will not let a relative one climb past the root,
-and leaves no window between the check and the open for the guest to swap the
-file in. A symlink that stays *inside* the workspace is refused too: brig
-writes only regular files in there, so a link where a state file belongs was
-put there rather than left there.
+absolute symlink outright, and will not let a relative one climb past the
+root. A symlink that escapes the workspace this way is refused everywhere,
+on a read or a write. There is no window between the check and the open for
+the guest to swap the file in.
+
+A symlink that stays *inside* the workspace is a different story, and reading
+and writing do not treat it alike. Where brig writes a state file, the
+symlink is refused even though it does not escape. brig writes only regular
+files there, so a link where a state file belongs was put there rather than
+left there.
+
+Where brig reads a file, an internal symlink is followed instead. A
+`.gitconfig` symlinked to your own dotfiles, inside the workspace, has to
+keep working. The refusal it replaced used to claim such a link "leads out
+of" the workspace, which was never true for one that stays inside.
+
+Either way, brig decides from what it actually opened, not from a check made
+beforehand. A fifo, socket, device or directory where a regular file belongs
+is refused there. That closes the window where the guest renames one file
+type over another between the two.
 
 The one escape a root cannot see is a symlink *at* the workspace or on the
 way to it, since resolving that still leaves every path below it honestly
@@ -431,7 +459,13 @@ The identity is anchored on the repository and the workflow file, so a
 signature from anywhere else fails -- including one from another workflow in
 the same repository.
 
-What brig does with the answer:
+`BRIG_VERIFY` has three modes: `off`, `warn` and `require`. `warn` is the
+default. The table below is `warn`'s behavior: it reports what it found, then
+boots anyway, except for the one row with no innocent reading. `require`
+refuses anything it cannot positively verify, third-party images included.
+`off` skips the check entirely.
+
+What `warn` does with the answer:
 
 | situation | behaviour |
 | --- | --- |
@@ -446,10 +480,8 @@ check" is not the same as "failed". The one case with no innocent reading is
 an image sitting under our registry whose signature does not verify, and that
 is the case that stops.
 
-`BRIG_VERIFY=require` refuses anything that cannot be positively verified,
-third-party images included. `BRIG_VERIFY=off` skips the check. A typo in that
-setting refuses the run, naming the three values, rather than being read as
-either of them.
+A typo in `BRIG_VERIFY` refuses the run, naming the three values, rather than
+being read as either of them.
 
 Point `BRIG_VERIFY_REGISTRY`, `BRIG_VERIFY_IDENTITY` and `BRIG_VERIFY_ISSUER`
 at your own registry and workflow if you publish signed images yourself.
@@ -484,8 +516,7 @@ brig therefore verifies and boots the tag on such a hull, prints one line
 saying so, and the gap remains there until you upgrade: under the default
 `missing` pull policy cosign checks the tag in the registry, not necessarily
 the copy hull already holds, and `BRIG_PULL=always` is the workaround. brig
-never prints the digest-named line on a boot that did not pin a digest, so the
-message never claims more than the runtime delivered.
+does not name a digest on a boot that did not pin one.
 
 Two things are still narrower on macOS than on Linux. An image pulled under an
 older hull has no index digest on record, and a multi-arch tag resolves to its
@@ -495,9 +526,34 @@ image is pulled again. And hull does not yet expose the digest its store holds
 for a reference, so the report that the local copy differs from what the
 registry serves is Linux-only for now. The boot is pinned either way.
 
-`claude-desktop` and `ubuntu` still point at `ghcr.io/nofireai` images, which
-brig has no signing policy for, so they warn on every boot until those images
-move.
+`claude-desktop` points at a `ghcr.io/nofireai/` image, and `ubuntu` at
+`docker.io/library/ubuntu`. brig has no signing policy for either registry, so
+both warn on every boot until those images move.
+
+### The kernel, not only the image
+
+Six of the eight shipped profiles boot a kernel and an initrd brig downloads,
+rather than one baked into the image. They are `claude-code`, `codex`,
+`gemini`, `grok`, `opencode` and `ubuntu`. `cursor` and `claude-desktop` boot
+their own image and skip everything below.
+
+That bundle is checked too, under the same `BRIG_VERIFY` setting, but as a
+second and separately-rooted check. Its trust root is its own: registry
+prefix `ghcr.io/nofireai/`, signing identity the `build-assets.yml` workflow
+in `NOFireAI/hull-assets`, the same issuer as the image check. A signature
+that fails stops the boot outright, in every mode except `off`. There is no
+`[y/N]` prompt the way there is for the image, because there is no reading of
+a bad kernel signature worth asking about.
+
+One thing the check does not buy: nothing is pinned from the result. The
+check verifies a registry reference, not the
+bytes that boot. What actually starts the guest is whatever kernel and
+initrd sit in `BRIG_BOOT_ASSETS`, or failing that the runtime's own asset
+directory, or the platform default. Only existence and being non-empty are
+checked there. brig does not bind the kernel on disk to the artifact it just
+verified. `BRIG_VERIFY_REGISTRY`, `BRIG_VERIFY_IDENTITY` and
+`BRIG_VERIFY_ISSUER` repoint the image's trust policy only: the kernel's
+identity is fixed.
 
 ## brig's own binaries
 
@@ -613,10 +669,22 @@ fresh install. `--network offline` is the one posture with no route out at
 all, on every backend.
 
 Attach one and that changes, on `hvi`: the rules are enforced at the network
-gateway brig gives that sandbox, and a run that cannot enforce them is refused
-rather than booted unconstrained -- see [docs/policies.md](policies.md). On
-`vz`, on `qemu` and on Linux there is no policy to be had at all, and outbound
-traffic is whatever the runtime allows.
+gateway brig gives that sandbox. Every runtime brig ships refuses to boot a
+policy it cannot enforce, rather than booting it unconstrained (see
+[docs/policies.md](policies.md)). That refusal is each adapter's own choice,
+not a guarantee brig imposes on every runtime it will ever drive. The
+one exception is `--network offline`: a policy-carrying sandbox with no route
+out satisfies every rule set, so it is not refused on any backend. Short of
+that, on `vz`, on `qemu` and on Linux there is no policy to be had at all.
+Outbound traffic there is whatever the runtime allows.
+
+It does not say whether the guest can reach services bound on the host
+itself. That covers a dev server, a local model, an MCP server, a metadata
+endpoint. brig adds nothing to narrow that. What the guest's network reaches
+is the runtime's default, and whether that includes the host is unmeasured
+on every backend. The one control that exists is an egress policy on `hvi`,
+with `default: deny` and no `cidr` allow for the host's own ranges. There is
+no equivalent on `vz`, `qemu` or Linux.
 
 It does not promise that one sandbox cannot reach another under the default
 `shared` network. What happens there depends on the backend: brig asks the
@@ -628,7 +696,7 @@ is the runtime's own behaviour, not brig's. The measurements are in
 | --- | --- |
 | `hvi` on macOS | no. A packet capture in both guests shows why: an ARP broadcast from one guest does reach the other, and the other answers, but the gateway does not forward that unicast reply back. The first guest never learns the second's MAC address, so it never sends a packet, and the second guest sees no TCP at all |
 | `vz` on macOS | no. vmnet does not carry traffic from one guest to another in the mode hull uses |
-| Linux | **yes.** The CNI bridge is an ordinary layer 2 segment, and two sandboxes on it reach each other the way two containers do |
+| Linux, measured with plain containers on the nerdctl bridge | **yes.** The CNI bridge is an ordinary layer 2 segment, and two sandboxes on it reach each other the way two containers do. The shipped default shim, `io.containerd.urunc.v2`, puts a microVM behind that same bridge, and nothing here has measured whether that changes the answer. Assume it does not |
 
 So on Linux, two agents you gave *different* credentials sit on one broadcast
 domain, each able to reach whatever the other is listening on. That is a real
@@ -683,3 +751,29 @@ writable by design, since that is the work.
 It does not stop an agent from spending your money. The `deny` list keeps a
 metered key from being forwarded by accident, which is a different and much
 smaller promise.
+
+## Trust assumptions
+
+Everything above narrows what an agent can reach. None of it removes the need
+to trust four things, and it is worth naming them in one place.
+
+**The guest image, and whoever publishes it.** An image under
+`ghcr.io/brig-sh/` is checked against a specific build workflow. An image brig
+did not publish boots on a warning under the default mode, and
+`BRIG_VERIFY=off` turns the check off for either kind. Either way, the image
+is code that runs with your credentials.
+
+**The profile author.** A profile names the image, the volumes it hostmounts,
+and any `files:` binding. A `files:` binding is the one channel the deny list
+does not cover. A profile is only as careful as whoever wrote it.
+
+**hull or nerdctl.** The kernel boundary, the shared-network separation on
+macOS, and every device and namespace decision belong to the runtime, not to
+brig. brig reports what it resolved. It neither hardens nor weakens what the
+runtime does.
+
+**brig itself.** brig runs as you, on the host, outside the sandbox. A
+resolved credential sits in its process memory as plaintext for the run's
+lifetime. brig clears that memory on the way out. That is defence in depth,
+not a control. A process already holding your credentials in memory is not
+something this page claims to protect against.

--- a/docs/security.md
+++ b/docs/security.md
@@ -4,8 +4,10 @@ The reason to run an agent in a sandbox is that the agent runs code you did
 not write, against a machine that holds everything you have. brig narrows what
 "everything" means. What the agent can reach on the host is its workspace,
 any project you name on the run line, and the credentials you gave it. No
-other host directory is mounted, and no host credential source is read on
-the run path. What the agent can reach over the network is a separate
+other host directory is mounted, and, on every profile brig ships, no host
+credential source is read on the run path. A profile of your own carrying the
+deprecated `hostCredential:` key is the exception: it reads the macOS keychain
+item it names on every run. See [secrets.md](secrets.md). What the agent can reach over the network is a separate
 question, with a much weaker answer, covered below.
 
 This page states what is isolated first, then what an agent can still do.

--- a/docs/sessions.md
+++ b/docs/sessions.md
@@ -1,0 +1,136 @@
+# Sessions, homes and projects
+
+A `brig run` or `brig sh` line names a session: an agent, optionally a
+label, and optionally a project. This page explains what each of those
+words means, what brig keeps separate per session, and what survives which
+command. [quickstart.md](quickstart.md) is the walkthrough. This page is
+the reference underneath it.
+
+## The ref
+
+Every verb takes a ref, `<agent>` or `<agent>@<label>`. An empty label
+means the agent's default session, so `claude` and `claude@refactor` are
+two independent sessions of one agent. Each gets its own guest home and
+its own sandbox.
+
+`claude` and `desktop` are aliases, resolved to the built-in agents
+`claude-code` and `claude-desktop`. Those are the only two aliases brig
+resolves. A real agent always wins over an alias. If you create a profile
+of your own literally named `claude`, it takes the word outright. The
+built-in `claude-code` is then reachable only by its full name.
+
+## The guest home
+
+The guest home is a host directory mounted as the agent's home:
+
+```
+~/brig/<resolved agent name>[-<label>]
+```
+
+The resolved name is the agent's own, not the alias you typed, so
+`claude`'s guest home is `~/brig/claude-code`. `claude@refactor`'s is
+`~/brig/claude-code-refactor`, a sibling of the default, not a directory
+inside it. The guest home is host-backed. It is an ordinary directory on
+your disk, and it survives every command this page covers, until you
+remove it by hand.
+
+`brig info` and `brig ls` both call this directory `WORKSPACE` in their own
+output. This page calls it the guest home everywhere else. They are the
+same thing under two names, one brig's internal label and one this page's.
+
+## The project
+
+Name a directory on the run line:
+
+```bash
+brig run claude ~/code/demo
+```
+
+brig mounts `~/code/demo` read-write at `/work/demo`, and the agent starts
+there. Name no project, and brig remounts whatever this session last ran
+with, read back from its session index. `--no-project` mounts none.
+`--no-project` is refused alongside a project named on the same line, and
+refused on every verb but `run`.
+
+Run the same session against a different project than it last used, and
+brig recreates the sandbox. It warns you, stops the running sandbox,
+removes it, and starts a new one with the new project mounted. A mount
+cannot be attached to a live guest. The same recreate happens the first
+time you name a project on a session that had none, and when
+`--no-project` drops one it had. Because it is a fresh sandbox, the
+recreate takes everything inside the old guest with it, including a
+`claude-code` login that had landed on memory.
+
+A remembered project that has since gone off disk does not refuse the run.
+The run proceeds with no project, and names the missing directory in the
+restart warning.
+
+## What survives
+
+Four things can hold state for a session. They are the guest home on host
+disk, a memory-backed mount inside the guest, the sandbox itself, and what
+brig recorded about the session. Only two of the eight built-in agents,
+`claude-code` and `claude-desktop`, declare a memory-backed mount at all.
+For the other six, `codex`, `cursor`, `gemini`, `grok`, `opencode` and
+`ubuntu`, the whole guest home is the host-backed share above. An in-guest
+login for those agents lands on host disk and survives every stop.
+
+| Event | Guest home | Memory-backed mount (`claude-code`, `claude-desktop`) | The sandbox | What brig recorded |
+| --- | --- | --- | --- | --- |
+| The agent exits | kept | kept, the sandbox is still up | still running | unchanged |
+| `brig stop` | kept | gone with the VM | stopped, still named in `brig ls` | kept |
+| `brig rm` | kept | gone | removed | dropped |
+| `brig rm --all` | kept, every session | gone | every sandbox removed | dropped, every session |
+| A host reboot | kept, an ordinary host directory | gone, guest memory cannot survive a reboot | the runtime's own business, not established here | kept as host files |
+
+`brig stop` keeps the sandbox's name, its row in `brig ls`, and what brig
+recorded about the session. `brig rm` drops the last of those too. Neither
+touches the guest home.
+
+A host reboot cannot take your work: the guest home is a host directory,
+and what brig recorded is host files. It does take everything inside the
+sandbox, including a `claude-code` login that had landed on memory.
+Whether the sandbox itself is still listed afterward is the runtime's own
+business. If it has gone, the next `brig ls` forgets it, and the next run
+boots a new one.
+
+brig keeps its own bookkeeping, the session index among it, under
+`~/.brig`. That layout is not a stable interface: do not build a script
+against its files directly.
+
+## What a label can contain
+
+A label is turned into a slug: lowercased, and every character outside
+`[A-Za-z0-9._-]` replaced with a dash. Runs of dashes are collapsed, and
+leading and trailing dots and dashes are trimmed. Nothing is shortened.
+Lowercasing matters because macOS filesystems are case-insensitive.
+Without it, `Foo` and `foo` name two different sandboxes that collide on
+one directory.
+
+The `<agent>@<label>` form is strict. If a label is not already its own
+slug, brig refuses it and names the slug it maps to, instead of rewriting
+it for you. It also refuses more than one `@`, a ref naming no agent, a
+trailing `@` with no label, and a label with no usable characters. A
+label that names another agent's own default session is refused too.
+
+The retiring `--name` flag is the lenient spelling. It sanitizes the name
+itself and warns which directory it actually used, so `--name "Refactor
+Sprint"` becomes `refactor-sprint` with a warning, not a refusal. Only the
+`@` form insists you already typed the slug.
+
+## The label and the agent's own display name
+
+A label always picks the guest home and the sandbox name, for every
+agent. Reaching the agent itself as a display name is narrower. brig
+passes the label to the agent only when the resolved profile is literally
+`claude-code`, and only on `brig run`, never on `brig sh`. No other
+profile, not even `claude-desktop`, receives it this way.
+
+## Printing the ref
+
+`brig ls` prints the canonical agent name plus the label, not the alias
+you typed: a session started as `claude@refactor` shows as
+`claude-code@refactor`. `run --json`'s Run object instead prints the ref
+exactly as typed, so `brig --json run claude` reports `"ref": "claude"`,
+not `"claude-code"`. A script reading both commands sees two different
+strings for the same session.

--- a/docs/stability.md
+++ b/docs/stability.md
@@ -1,0 +1,55 @@
+# What is stable, and what is not
+
+brig is a prerelease. Every published version so far is a `0.1.0-rc` tag, and
+the grammar is still settling. This page says which parts you can write a
+script against today and which parts are expected to move.
+
+## Not stable yet
+
+Nothing in brig carries a compatibility guarantee before 1.0. The command
+grammar was renamed once already, during the 0.1 series, and
+[docs/migration.md](migration.md) is the record of that change.
+
+Treat the following as subject to change without a deprecation cycle:
+
+- Profile file fields other than those the current `brig agent export` header
+  documents.
+- The layout of `~/.brig`, brig's state directory, and its session index.
+- The wording of any human-readable output. Parse `--json`, not prose.
+- Anything marked "example profile" in `brig agent ls`.
+
+## Stable enough to script against
+
+Three surfaces are built to be depended on, and each has tests that pin it.
+
+**The `--json` envelope.** Within one `apiVersion`, the JSON only gains
+fields. It never renames or drops one, and no field carries a credential value.
+A script written against it keeps parsing, and a machine-readable dump stays a
+place a secret cannot leak. `--json` works on the read verbs, and on `run` and
+`sh` it reports the agent's own exit status.
+
+**Exit codes.** The numbers a script branches on are pinned end to end by
+`script/smoke.sh`. See [docs/cli.md](cli.md#exit-codes) for the table.
+
+**Retired spellings.** Every retired command, subverb and flag on this page
+still works and prints one line naming its replacement. They are scheduled for
+removal in 0.3. `brig run` is never removed.
+
+## The deprecation window
+
+A spelling brig retires keeps working for at least one release after the notice
+appears. The notice goes to stderr, so it does not corrupt piped output:
+
+```
+brig: `brig profiles` is now `brig agent ls`
+```
+
+The current window closes at 0.3, which removes the spellings listed in
+[docs/migration.md](migration.md).
+
+## Reporting a break
+
+If a version bump breaks a script that used only the surfaces above, that is a
+bug worth filing. Open an issue with the command, the version from
+`brig version`, and the output. For anything security-related, follow
+[SECURITY.md](../SECURITY.md) instead of opening a public issue.

--- a/docs/support.md
+++ b/docs/support.md
@@ -1,18 +1,32 @@
-# What brig runs on
+# Support
 
-brig boots each coding agent inside its own lightweight virtual machine. That
-needs a Mac with Apple Silicon, or a Linux machine.
+Where to ask a question, file a bug, or report a vulnerability.
 
-| Your computer | Does brig run? |
-| --- | --- |
-| Mac with Apple Silicon (M1 or newer), macOS 15 or later | Yes |
-| Mac with Apple Silicon (M1 or newer), macOS 14 | Yes, if you start it with `BRIG_HYPERVISOR=vz` |
-| Intel Mac | No, brig needs Apple Silicon |
-| Linux, x86-64 or ARM64 | Yes, with `nerdctl` and containerd installed |
+## Ask a question
 
-On macOS the virtual machine is booted by [hull](https://github.com/brig-sh/hull),
-which the Homebrew cask installs with brig; a from-source brig needs hull on
-`PATH`. On Linux it uses nerdctl and containerd with the urunc shim. Docker is
-accepted in nerdctl's place for an image that carries its own kernel; a profile
-marked `genericBoot`, which is six of the eight shipped ones, is refused on
-Docker because it does not pass the boot annotations through to the runtime.
+Open an issue: [github.com/brig-sh/brig/issues](https://github.com/brig-sh/brig/issues).
+There is no other channel yet.
+
+## File a bug
+
+Open an issue and pick the bug report template. Include:
+
+- The command you ran.
+- The output of `brig version`.
+- The output of `brig doctor`.
+
+`brig doctor` reports the host, the hypervisor, the runtime, the boot assets,
+cosign, the profiles, the secret store and brigd, one line per fact.
+[../CONTRIBUTING.md#issues](../CONTRIBUTING.md#issues) lists what else helps:
+logs, your environment, and the steps to reproduce.
+
+If brig or its runtime will not install or start, check whether your platform
+is supported first: [install.md](install.md#platform-support) has the full
+matrix.
+
+## Report a vulnerability
+
+Do not open a public issue for a security problem. Follow
+[../SECURITY.md](../SECURITY.md) instead: it routes the report through
+GitHub's private vulnerability reporting, so nothing is disclosed while a fix
+is worked out.

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -1,0 +1,158 @@
+# What brig counts, and how to turn it off
+
+brig keeps no telemetry store and runs no collector of its own. The sandbox
+runtime it drives is what actually counts anything and sends it, so what
+follows is true on macOS, where the runtime is `hull`, and not on Linux,
+where the runtime is `nerdctl` and nothing is sent at all.
+
+## Turn it off
+
+```bash
+brig telemetry off
+```
+
+Durable, on this machine, whether brig is the one asking again or not.
+`DO_NOT_TRACK=1` in your environment does the same thing without recording
+anything, and beats any answer already on disk:
+
+```bash
+DO_NOT_TRACK=1 brig run claude
+```
+
+## What is counted
+
+Exactly two things, each once per brig command:
+
+- **A sandbox boot.**
+- **The command that hands your terminal to the agent**, which is `run`
+  without `--json`, `sh`, or the `--json` child path either one takes.
+
+Nothing else brig does on its own behalf is ever counted. A reachability
+probe, a `ps` lookup, cleanup work, and the telemetry query itself are all
+run with counting suppressed, so one command you typed counts at most once,
+never once per internal step it happens to take.
+
+## Until an answer is on file
+
+hull ships with telemetry on by default and asks on first use. Left alone,
+that sends an event for a fresh install's first boot before anyone has
+answered anything, with the question then appearing later, on an unrelated
+interactive step.
+
+brig closes that gap for everything it does on your behalf. A sandbox boot
+runs with no terminal attached, so there is nobody to ask, and brig
+suppresses counting for it until hull reports a recorded answer.
+
+The one exception is the command that hands your terminal to the agent.
+There, brig lets the question through instead of suppressing it, so hull can
+put it to you before anything is sent. Suppressing that invocation too
+leaves the prompt never appearing, and the question stays unanswered
+forever rather than answered once.
+
+Whether hull's own prompt genuinely precedes every send on that one
+invocation is a fact about hull's code, which lives in its own repository
+and is not part of this checkout.
+
+A recorded answer stops being read as an answer when hull widens what it
+collects: `brig telemetry status` then reports the same unanswered state a
+fresh install gets, and nothing from the wider list is sent until you answer
+again.
+
+## `brig telemetry status`, `on`, `off`
+
+```bash
+brig telemetry status
+```
+
+`status` is the default when you give no verb, and a bare `brig telemetry`
+changes nothing. `on` and `off` record an answer, then `brig telemetry`
+reports the state that resulted rather than echoing what you asked for,
+because the two can differ: recording `on` while `DO_NOT_TRACK` is set in
+your shell still reports off, with the variable named.
+
+The report is one of four states, in brig's own words:
+
+```
+telemetry: on
+A sandbox boot and the command that takes your terminal each count
+once. `brig telemetry off` stops it.
+```
+
+```
+telemetry: off
+DO_NOT_TRACK=1 in this environment turns it off, and beats any
+answer recorded on this machine.
+```
+
+```
+telemetry: not answered yet
+Nothing goes out for a sandbox boot until you answer, and the first
+command that hands your terminal to an agent asks the question.
+`brig telemetry on` or `brig telemetry off` answers it now.
+```
+
+```
+telemetry: cannot tell
+The sandbox runtime did not report a state this version of brig
+recognises. Boots are not counted while that is true.
+```
+
+The last of the four is deliberate rather than a guess. brig reads one line
+from the runtime, and a phrase it does not recognize, an older or a newer
+runtime speaking a dialect this brig has never seen, is read as unanswered
+in effect (nothing is counted) and reported as `cannot tell` rather than
+being assumed to mean either on or off.
+
+Neither the report nor `brig telemetry --help` names the runtime underneath.
+The point of the command is that opting out does not require knowing which
+binary is doing the sending.
+
+On a backend that implements no telemetry reporting at all, which is
+`nerdctl` on Linux today, the report is direct instead of an error:
+
+```
+telemetry: off
+The sandbox runtime on this host sends nothing, so there is nothing
+to turn off.
+```
+
+`brig telemetry` takes no `--json` form. Every report above is the whole
+answer, in one of the four shapes.
+
+## Where an event goes, and what it carries
+
+hull is what sends, so
+[hull's own telemetry docs](https://github.com/brig-sh/hull/blob/main/docs/telemetry.md)
+are the field-by-field reference. What follows is the shape brig's earlier
+README carried, moved to this page rather than checked against hull's
+source, which is a separate repository this checkout does not include.
+
+An event carries an envelope of product name and version, the OS version and
+CPU architecture, an install identifier generated on your machine, a
+timestamp and a checksum. On top of that: which runtime operation ran and
+whether it succeeded, with a failure bucketed into a coarse class such as
+`network` or `permission` rather than its error text, which hypervisor
+backend booted and whether the boot worked, how long a sandbox lived, and,
+if brig or the runtime panics, the panic type with a stack trace whose paths
+are trimmed.
+
+What is never collected, as hull's own commitment rather than a description
+of one build:
+
+- workspace paths, or any host path
+- repository names, branches or remotes
+- command arguments, including the agent's own
+- agent prompts, or anything the agent read or wrote
+- secret names, secret values, or which credentials were forwarded
+- image names and registry references
+- network destinations the guest reached
+- file metadata: names, sizes, timestamps, counts
+
+`HULL_TELEMETRY_DISABLED=1` reaches hull the same way `DO_NOT_TRACK=1` does,
+untouched, and both beat an answer already recorded on disk.
+
+## See also
+
+[docs/cli.md](cli.md) has the flags and exit codes for every verb, including
+`brig telemetry`. [docs/security.md](security.md) covers the rest of the
+boundary a sandbox keeps.

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -21,9 +21,11 @@ DO_NOT_TRACK=1 brig run claude
 
 ## What is counted
 
-Exactly two things, each once per brig command:
+Three things, each once per brig command:
 
 - **A sandbox boot.**
+- **A sandbox stop**, including the stop inside a restart, when brig recreates
+  a sandbox whose shares or policy went stale. `brig rm` is not counted.
 - **The command that hands your terminal to the agent**, which is `run`
   without `--json`, `sh`, or the `--json` child path either one takes.
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -481,8 +481,10 @@ brig: Renew it, then store it again: brig secret import claude-code <name> --fro
 
 ## The sandbox restarted when I ran sh
 
-Two different things trigger this, and both recreate the sandbox rather than
-fail it. All persistent state lives in the guest home on the host
+Three different things trigger this, and each recreates the sandbox rather
+than failing it: a stale share, a stale policy, and a session run against a
+different project than it last used (see
+[sessions.md](sessions.md)). All persistent state lives in the guest home on the host
 either way. Any other session on that sandbox is disconnected when it
 restarts.
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -5,34 +5,49 @@ read the likely cause, run the check, apply the fix.
 
 Some of these messages are brig's own. Others come from the layer underneath:
 the microVM runtime (`hull` on macOS, `nerdctl` on Linux), cosign, or
-Homebrew. Where a message is not brig's, it says so, because that is the first
+Homebrew. Where a message is not brig's, it says so. That is the first
 thing to know when the wording does not match anything in brig.
 
 Before reading further, run `brig doctor`. It checks the host, the
 hypervisor, the runtime and its version, the boot assets, cosign, the
-profiles, the secret store and brigd, one line each, and says what to do
-about a line that is not `ok`; `brig doctor <agent>` checks that agent's
-image too. `--json` is for a script or a bug report.
+profiles, the secret store and brigd, one line each. It names the fix for
+a line that is not `ok`. `brig doctor <agent>` checks that agent's image too.
+`--json` prints the same report as one document, for a script or a bug
+report.
 
 ## Exit codes
 
-A script does not have to parse the message. Every failure is reported on
-`stderr` with one of these codes, which are stable across releases:
+Every failure exits with one of a small, stable set of codes. The full table,
+and what each one means, is at
+[docs/cli.md#exit-codes](cli.md#exit-codes).
 
-| code | meaning |
-| --- | --- |
-| `0` | success |
-| `1` | general failure -- something ran and did not finish |
-| `2` | usage error -- an unknown flag, a stray argument, a value in the wrong place |
-| `3` | no such profile or sandbox -- the name resolves to nothing. `brig rm` and `brig logs` on a ref with no sandbox exit here rather than handing the runtime's "instance not found" back as `1` |
-| `4` | runtime unavailable -- none is installed, `BRIG_RUNTIME_BIN` points at nothing, or the runtime could not be asked |
-| `5` | image verification refused the boot |
-| `6` | a credential the run needed could not be resolved |
+One thing that page does not say: `brig rm` and `brig logs` on a ref with no
+sandbox exit `3`, naming the ref you typed. They do not pass the runtime's
+own "instance not found" back as a general failure (`1`).
 
-`brig stop` on a sandbox that is not running exits `0`: stopped is the state
-it asked for. `brig run --json` prints one JSON line with the agent's own exit
-status after it exits, so a caller can tell "brig refused" from "the agent
-failed".
+## What `brig doctor` does not catch
+
+Only two lines in `brig doctor` change its exit status: a missing or broken
+runtime, and a secret store that will not open. Every other line, a `!!`
+included, prints its fix and leaves the exit status at `0`.
+
+That includes verification. A `BRIG_VERIFY` value brig does not recognize,
+and `BRIG_VERIFY=require` with no cosign installed, both print `!!` with the
+right fix. Neither one stops `brig doctor` from exiting `0`, and both stop a
+real run cold. A script that checks only the exit status, not the lines,
+misses both.
+
+Check the setting yourself before you rely on it:
+
+```bash
+echo "$BRIG_VERIFY"
+```
+
+`require` also refuses any image outside brig's own registry,
+`ghcr.io/brig-sh/`. `claude-desktop` and `ubuntu` are both outside it.
+`brig doctor claude-desktop` reports that image as `--`, informational,
+whatever `BRIG_VERIFY` is set to. It does not simulate the refusal a
+`require` run hits.
 
 ## The sandbox never became ready
 
@@ -89,7 +104,7 @@ For good, put `BRIG_HYPERVISOR=vz` in your shell profile, or upgrade to macOS
 15 or newer. macOS 26 is what hull is developed and tested on.
 
 Current releases do not get this far. brig reads the macOS version before it
-asks the runtime for anything, and refuses an `hvi` run on macOS 14 with the
+asks the runtime for anything. It refuses an `hvi` run on macOS 14, with the
 cause and the way past it:
 
 ```
@@ -98,7 +113,9 @@ interrupt controller does not exist here. Set BRIG_HYPERVISOR=vz for this run,
 or upgrade macOS
 ```
 
-The `dyld` log above is what an older brig left you to find.
+The `dyld` log above is what an older brig left you to find. Confirm by
+running the agent again. With `BRIG_HYPERVISOR=vz` set, or on macOS 15 or
+newer, the run reaches the agent's prompt instead of dying at `dyld`.
 
 ## No runtime found on PATH
 
@@ -113,13 +130,12 @@ On Linux the second half is different, because the runtime there is `nerdctl`:
 brig: no runtime found on PATH: install nerdctl, or point BRIG_RUNTIME_BIN at one
 ```
 
-Either way the exit code is `4`. A `BRIG_RUNTIME_BIN` or a profile
-`runtimeBin` that names something missing is the same code with the setting
-named: `BRIG_RUNTIME_BIN is hull2, which is not on PATH`.
+Either way the exit code is `4`.
 
-brig delegates every boot to a runtime it does not ship, and could not find
-one. On macOS the cask depends on hull, so this usually means a from-source
-install without hull on PATH.
+brig delegates every boot to a runtime it does not ship, and none was there.
+On macOS the cask depends on hull, so this usually means a from-source
+install without hull on PATH. Full install instructions, both platforms, are
+at [docs/install.md](install.md).
 
 Check whether the runtime is there:
 
@@ -135,19 +151,108 @@ have a build somewhere off PATH, point brig at it:
 BRIG_RUNTIME_BIN=/path/to/hull brig run claude
 ```
 
+Confirm:
+
+```bash
+brig doctor
+```
+
+The `runtime` line reads `ok` and names the binary it found.
+
+## unknown BRIG_RUNTIME
+
+```
+brig: runtime unavailable: unknown BRIG_RUNTIME "podman" (want hull or nerdctl)
+```
+
+This is not the same failure as a missing runtime. brig treats it as a
+different mistake on purpose: `BRIG_RUNTIME` names something brig does not
+drive. `brig ls` and `brig info` fail this same way rather than reporting
+no sandboxes, because reading a typo as "you have none" hides it.
+
+Check what is set:
+
+```bash
+echo "$BRIG_RUNTIME"
+```
+
+Set it to `hull` or `nerdctl`, or unset it so brig looks on PATH instead:
+
+```bash
+unset BRIG_RUNTIME
+```
+
+Confirm:
+
+```bash
+brig doctor
+```
+
+The `runtime` line reads `ok` again.
+
+## this profile's runtimeBin is ... which is not there
+
+```
+brig: runtime unavailable: this profile's runtimeBin is /old/path/hull, which is
+not there: stat /old/path/hull: no such file or directory
+```
+
+Your own profile's `runtimeBin:` field names a binary that moved or was
+removed. `brig doctor` does not catch this: its `runtime` line reads
+`BRIG_RUNTIME_BIN`, never a single profile's own field. A broken
+`runtimeBin` in `mine` reads `ok` there, and fails only when you run `mine`.
+
+Open the profile and fix or remove the line:
+
+```bash
+brig agent edit mine
+```
+
+Confirm:
+
+```bash
+brig info mine
+```
+
+No runtime error means the field is fixed.
+
+## assets missing at ...
+
+Seen in `brig doctor`, not from a run:
+
+```
+!!  boot      assets missing at /Users/pmoust/.hull/assets
+        run any agent once to fetch them, or set BRIG_BOOT_ASSETS to a directory that has them
+```
+
+Six of the eight built-in profiles boot an unmodified OCI image rather than
+their own. They need a shared kernel and initrd, which brig calls the boot
+assets. Nothing has downloaded that bundle yet. This is normal before a first
+boot and does not stop one: the next `brig run` on any of those profiles
+fetches it.
+
+Confirm it downloaded:
+
+```bash
+brig doctor
+```
+
+The `boot` line reads `ok  boot  assets present at ...`.
+
 ## The image could not be pulled, or the architecture does not match
 
 ```
 brig: could not start the sandbox: <runtime error>
 ```
 
-The detail after the colon is the runtime's, not brig's: a registry that could
-not be reached, an image reference that does not exist, or a manifest with no
-build for your architecture. The published agents default to `:latest`, a
-multi-arch index covering `linux/arm64` and `linux/amd64`, so one reference is
-right on both an Apple Silicon Mac and an x86 Linux host. A mismatch usually
-means a `--image` or `BRIG_IMAGE` pinned to a single-architecture tag that is
-not yours.
+The detail after the colon is the runtime's, not brig's. It is a registry
+brig cannot reach, an image reference that does not exist, or a manifest
+with no build for your architecture. The five published agents default to
+`:latest`, which `brig-sh/community-images` publishes as a multi-arch index
+covering `linux/arm64` and `linux/amd64`. One reference is meant to work on
+both an Apple Silicon Mac and an x86 Linux host. A mismatch usually means a
+`--image` or `BRIG_IMAGE` pinned to a single-architecture tag (`:arm64` or
+`:amd64`) that is not yours.
 
 Check the reference you are booting:
 
@@ -166,8 +271,39 @@ BRIG_PULL=always brig run claude
 ```
 
 If the image is one brig does not publish, such as `cursor`, brig says so
-before it reaches the registry rather than failing on a 404: build the image
-yourself and pass `--image`.
+before it reaches the registry. It does not fail with a 404. Build the
+image yourself and pass `--image`.
+
+## docker does not carry annotations through to the runtime
+
+Linux only, and only for a profile that boots an unmodified image (six of the
+eight built-in ones):
+
+```
+brig: could not start the sandbox: this profile boots an unmodified image,
+which needs the kernel passed as an OCI annotation; docker does not carry
+annotations through to the runtime. Use nerdctl, or point BRIG_RUNTIME_BIN at
+it
+```
+
+brig accepts Docker where it looks for nerdctl, and most of what it needs
+works either way. Passing the kernel as an OCI annotation does not: Docker
+drops it, so the guest starts with no kernel to boot. brig refuses
+rather than let that fail somewhere further from the cause.
+
+Install nerdctl, or point brig at one you already have:
+
+```bash
+BRIG_RUNTIME_BIN=/path/to/nerdctl brig run claude
+```
+
+Confirm:
+
+```bash
+brig doctor
+```
+
+The `runtime` line names `nerdctl`, not `docker`.
 
 ## cosign is not installed
 
@@ -176,18 +312,45 @@ brig: cannot verify image ghcr.io/brig-sh/claude-code-stock:latest: cosign is no
 installed (`brew install cosign`). Booting it unchecked
 ```
 
-This is a warning, not a failure. brig verifies the guest image before booting
-it, and without cosign it cannot run the check. "Could not check" is not the
-same as "failed": the boot goes ahead.
+That is `BRIG_VERIFY=warn`, the default. brig checked the image against its
+own registry, found no way to run the check, and says so before it boots
+anyway. A check that did not run is not a check that failed.
 
-If you want the check, install cosign:
+Under `BRIG_VERIFY=off` cosign is never looked up, and the only line is:
 
-```bash
-brew install cosign
+```
+brig: BRIG_VERIFY=off, so the guest image is not checked before it boots
 ```
 
-If you would rather boot without it and stop the warning, that is
+Under `BRIG_VERIFY=require` the same missing-cosign message appears, with the
+mode named. This time it refuses the boot instead of continuing (exit
+`5`), even though the wording still reads "Booting it unchecked":
+
+```
+brig: cannot verify image ghcr.io/brig-sh/claude-code-stock:latest: cosign is not
+installed (`brew install cosign`). Booting it unchecked (BRIG_VERIFY=require)
+```
+
+Read the exit code, not the last clause of the message: `require` with no
+cosign refuses every image, brig's own included.
+
+Install cosign to get the check:
+
+```bash
+brew install cosign         # macOS
+```
+
+Linux: no package covers every distro. Install a release from
+[sigstore/cosign](https://github.com/sigstore/cosign) and put it on PATH.
+
+To boot without the check and stop the warning, set
 `BRIG_VERIFY=off`. Leaving cosign installed is the safer choice.
+
+Confirm:
+
+```bash
+cosign version
+```
 
 ## The signature did not verify
 
@@ -197,10 +360,10 @@ brig-sh, but its signature DID NOT VERIFY: <detail>
 brig: Boot it anyway? [y/N]
 ```
 
-This is not the same as "could not check". cosign ran and the answer was no:
-the image sits under brig's own registry and its signature does not match the
-workflow that should have built it. That combination has no innocent reading,
-so brig stops and asks. With no terminal to ask, it refuses:
+This is not the same as a check that did not run. cosign ran and the answer
+was no. The image sits under brig's own registry, and its signature does not
+match the workflow that is meant to have built it. That combination has no
+innocent reading, so brig stops and asks. With no terminal to ask, it refuses:
 
 ```
 brig: not a terminal, so there is nobody to ask: refusing. Set
@@ -216,43 +379,53 @@ or set BRIG_IMAGE to a digest you have checked yourself
 
 The usual innocent cause is a stale local copy. Pull the image again
 (`BRIG_PULL=always brig run claude`) and let the check run against the current
-registry. If it still fails and you do not know why, do not boot it; naming a
-digest you have checked yourself is the deliberate way past it, and
-`BRIG_VERIFY=off` is not offered here because disabling the control that
-caught it is not a remedy. An image
-published by someone else warns rather than stopping, because bring-your-own
-images are supported; a failure under brig's registry is the one case that
-stops.
+registry.
+
+If it still fails and you do not know why, do not boot it. Naming a digest
+you checked yourself is the deliberate way past it. The abort message above
+does not offer `BRIG_VERIFY=off`, because disabling the control that caught
+it is not a remedy. The no-terminal refusal earlier in this section names
+that setting only because a scripted run has no other way to say yes in
+advance.
+
+An image published by someone else warns rather than stopping: bring-your-own
+images are supported. A failure under brig's own registry is the one case
+that stops.
 
 ## The agent asked me to log in again after a stop
 
 There is no error here. The agent shows its login screen on a sandbox you had
 already logged into.
 
-The in-sandbox login lives in the sandbox's memory. It is written to a
-memory-backed mount that never reaches host disk, so `brig stop` takes it with
-the VM and the next `brig run` starts fresh. That is by design.
+On `claude-code` and `claude-desktop`, the in-guest login lives in the
+sandbox's memory. It is written to a memory-backed mount that never reaches
+host disk. `brig stop` takes it with the VM, and the next `brig run` starts
+fresh. That is by design, and it is specific to those two profiles. The other
+six mount the guest home from host disk, so a login written there survives a
+stop.
 
-To make a login survive a stop, import the one already on this Mac into brig's
-own store, once:
+To make a `claude-code` or `claude-desktop` login survive a stop, import the
+one already on this Mac into brig's own store, once:
 
 ```bash
 brig secret import claude-code
 ```
 
-After that brig writes the login back in on every boot, so a stop no longer
-loses it. See [Credentials](../README.md#credentials).
+After that brig delivers the login on every command that reaches the
+sandbox, so a stop no longer loses it. See
+[Carry your host login in, once](authentication.md#2-carry-your-host-login-in-once).
 
 ## My credential did not arrive
 
-First, ask brig what it would forward, by name:
+First, ask brig what it forwards, by name:
 
 ```bash
 brig info claude
 ```
 
 That reports what reaches the guest and whether the guest will be
-authenticated. If the variable you expected is not listed, one of these is why.
+authenticated. If the variable you expected is not listed, one of these is
+why.
 
 **It is on the denylist.**
 
@@ -263,9 +436,9 @@ onto metered billing without saying so. Set BRIG_ALLOW_DENIED=1 if that is
 what you want
 ```
 
-A key that would switch the sandbox from your subscription onto metered
-billing is refused by default. Forward it only if metered billing is genuinely
-what you want, with `BRIG_ALLOW_DENIED=1`.
+A key that switches the sandbox from your subscription onto metered
+billing is refused by default. Forward it only when metered billing is
+genuinely what you want, with `BRIG_ALLOW_DENIED=1`.
 
 **It looks like an unresolved reference.**
 
@@ -283,8 +456,11 @@ holds the real token, then run again. A stored secret or a profile literal is
 exempt from this check, because it was put there on purpose.
 
 **It is empty, or it expired.** An unset or empty variable is skipped so it
-cannot shadow a value baked into the image. A stored login that has expired is
-withheld, with:
+cannot shadow a value baked into the image.
+
+A stored credential that has expired is not withheld. brig forwards it as it
+is and warns before boot. Dropping it silently looks exactly
+like an unexplained login failure with nothing to act on:
 
 ```
 brig: the imported credential claude-credentials (claude-code) expired 3d ago.
@@ -295,7 +471,22 @@ Renew the login on the host and import it again, as the second line says.
 Renewing on the host alone does not help: a run reads brig's stored copy, and
 nothing re-reads the host until an import says so.
 
+A secret you stored with `--from-command` prints a different second line,
+naming that command instead of an import:
+
+```
+brig: the imported credential <name> (claude-code) expired 3d ago.
+brig: Renew it, then store it again: brig secret import claude-code <name> --from-command '<command>'
+```
+
 ## The sandbox restarted when I ran sh
+
+Two different things trigger this, and both recreate the sandbox rather than
+fail it. All persistent state lives in the guest home on the host
+either way. Any other session on that sandbox is disconnected when it
+restarts.
+
+**A different guest home than the one remembered.**
 
 ```
 brig: the running sandbox is not mounting /Users/alex/work -- its share went
@@ -303,23 +494,39 @@ stale (the directory was renamed or replaced, or the workspace changed).
 Restarting it; any other session using this sandbox will be disconnected.
 ```
 
-brig compares the workspace the running sandbox has against the one this
-command asked for, and restarts the sandbox when they differ. Passing an
-explicit `--home` (or `BRIG_WORKSPACE`) that does not match the default
-the sandbox was started with trips this: brig reads it as the share having
-gone stale and recreates the VM.
+brig compares the guest home the running sandbox has against the one this
+command asked for. Passing an explicit `--home` (or `BRIG_WORKSPACE`) that
+does not match what the sandbox already has trips this.
 
-Check which workspace the sandbox is on:
+Check which guest home a sandbox is mounting, in the `WORKSPACE` column:
 
 ```bash
-brig ls               # shows each sandbox and its workspace
+brig ls
 ```
 
-If you did not mean to change the workspace, drop the `--home` flag so
-`sh` addresses the same session the sandbox already has. There is no flag today
-that runs against a different workspace without this restart; a fix is in
-flight, and until it lands the honest description is that an explicit
-`--home` that differs from the remembered default restarts the sandbox.
+If you did not mean to change it, drop the `--home` flag so `sh` addresses
+the same session the sandbox already has. There is no flag today that runs
+against a different guest home without this restart. Until one lands, an
+explicit `--home` that differs from the remembered default restarts the
+sandbox.
+
+**A network policy that no longer matches what is running.**
+
+```
+brig: this sandbox is running under a different network policy than the one
+that applies now. Rules are fixed when a sandbox boots, so it is being
+restarted; any other session using this sandbox will be disconnected.
+```
+
+Egress rules are fixed at boot. Attaching or detaching a policy after a
+sandbox is already up changes nothing it can reach until the next restart.
+The next `brig sh` or `brig run` on that session triggers one.
+
+Check what a profile has bound, and whether brig can enforce it:
+
+```bash
+brig policy check claude
+```
 
 ## brew trust is not a command
 
@@ -327,8 +534,8 @@ flight, and until it lands the honest description is that an explicit
 Error: Unknown command: trust
 ```
 
-This message is Homebrew's, not brig's. `brew trust` was added to Homebrew at a
-certain version, and an older Homebrew does not have it.
+This message is Homebrew's, not brig's. `brew trust` needs a recent Homebrew,
+and an older one does not have it.
 
 Check your version and update:
 
@@ -340,7 +547,7 @@ brew update
 After updating, `brew trust brig-sh/brig` works and you can carry on with the
 install.
 
-## A symlinked or moved workspace was refused
+## A symlinked or moved guest home was refused
 
 ```
 brig: refusing to write /Users/alex/brig/claude-code/.claude.json: it is a
@@ -349,17 +556,26 @@ files inside the workspace. The workspace is mounted read-write as the
 sandbox's home, so that link was put there from inside the sandbox, to have
 brig -- which runs as you, on the host -- reach a file the sandbox cannot.
 Nothing was written; inspect /Users/alex/brig/claude-code/.claude.json and
-remove it before running brig again
+remove it before running brig again: a symlink in the workspace leads out of it
 ```
 
-brig writes state files into the workspace from the host, as you. A symlink
-where one of those files belongs points brig at a host path the sandbox itself
-cannot reach, so brig refuses rather than following it. It writes only regular
-files in there, so a link in the way was put there on purpose or by the
-sandbox reaching for the host. Nothing was written.
+brig writes state files into the guest home from the host, as you. A
+symlink where one of those files belongs points brig at a host path the
+sandbox itself cannot reach. brig refuses rather than following it. It
+writes only regular files there, so a link in the way was put there on
+purpose, or by the sandbox reaching for the host. Nothing was written.
 
-This is not a case for retrying. Inspect the path the message names and remove
-the link, or point the workspace somewhere else. Pointing `--home` at a
-symlink is refused the same way, and is fixed by naming the real directory.
+This is not a case for retrying. Inspect the path the message names and
+remove the link, or point the guest home somewhere else. Pointing `--home`
+at a symlink is refused the same way, and is fixed by naming the real
+directory.
+
+Confirm:
+
+```bash
+brig run claude
+```
+
+The run reaches the agent instead of refusing.
 [docs/security.md](security.md#writing-into-the-workspace) explains why the
 refusal exists.

--- a/internal/exitcode/exitcode.go
+++ b/internal/exitcode/exitcode.go
@@ -1,7 +1,7 @@
 // Package exitcode maps a finished run's error to the stable exit status brig
 // promises a script.
 //
-// The set is the exit-code table in README.md beside the command reference: 1 a
+// The set is the exit-code table in docs/cli.md, "Exit codes": 1 a
 // general failure, 2 a usage error, 3 no such profile or sandbox, 4 a runtime
 // that is missing or broken, 5 a boot verification refused, 6 a credential that
 // could not be resolved. A caller that only checked "zero or not" keeps working;
@@ -22,7 +22,7 @@ import (
 	"github.com/brig-sh/brig/internal/wrap"
 )
 
-// The exit statuses, matching README.md's table. A code no path returns is
+// The exit statuses, matching docs/cli.md's table. A code no path returns is
 // worse than no code at all, so the set is only the failure shapes brig's paths
 // -- and brigd's -- actually produce.
 const (

--- a/script/check-retired-spellings.sh
+++ b/script/check-retired-spellings.sh
@@ -73,6 +73,12 @@ names=(
 
 # Print "<line>:<command text>" for every place a reader could copy a command
 # from: each inline-code span, and each line inside a fenced code block.
+#
+# An inline span can wrap across a line break, and a `brig run claude --name
+# desktop` split that way went unseen until a reviewer caught it by eye. So a
+# line holding an odd number of backticks has an open span, and the next line
+# is joined to it before matching. The pair is reported at the first line's
+# number, which is where a reader looks.
 extract_commands() {
 	awk '
 		/^[[:space:]]*```/ { fence = !fence; next }
@@ -80,9 +86,15 @@ extract_commands() {
 		fence { print NR ":" $0; next }
 		{
 			line = $0
+			start = NR
+			# gsub returns the count, which is what says the span is open.
+			probe = line
+			if (gsub(/`/, "`", probe) % 2 == 1) {
+				if ((getline nextline) > 0) line = line " " nextline
+			}
 			while (match(line, /`[^`]+`/)) {
 				span = substr(line, RSTART + 1, RLENGTH - 2)
-				print NR ":" span
+				print start ":" span
 				line = substr(line, RSTART + RLENGTH)
 			}
 		}

--- a/script/check-retired-spellings.sh
+++ b/script/check-retired-spellings.sh
@@ -15,8 +15,17 @@
 # hvi" uses "profiles" as an ordinary noun and is left alone, and so is prose
 # about exec'ing into a container.
 #
-# Two files are exempt. docs/migration.md exists to teach the old-to-new
-# mapping, and a changelog is allowed to quote what a release retired.
+# Three files are exempt, because naming the retired spellings is their job:
+# docs/migration.md holds the old-to-new mapping, docs/stability.md documents
+# the deprecation window and quotes the notice, and a changelog is allowed to
+# say what a release retired.
+#
+# Elsewhere, a single PROSE line can opt out with a `retired-ok` marker in an
+# HTML comment, for a passage that names an old spelling to describe it rather
+# than to teach it: explaining a limitation that only the retired spelling has,
+# for instance. Keep these rare. A marker on a line that is really teaching the
+# old spelling defeats the check. The marker does not work inside a fenced
+# block, where it would become part of the code a reader copies.
 #
 # Short flags are scoped to the run line. `-n` is retired on `brig run`, where
 # it became `<agent>@<label>`, and is current on `brig policy attach`, so the
@@ -31,7 +40,7 @@ set -uo pipefail
 
 is_exempt() {
 	case "$1" in
-	docs/migration.md | CHANGELOG.md) return 0 ;;
+	docs/migration.md | docs/stability.md | CHANGELOG.md) return 0 ;;
 	esac
 	return 1
 }
@@ -67,6 +76,7 @@ names=(
 extract_commands() {
 	awk '
 		/^[[:space:]]*```/ { fence = !fence; next }
+		/retired-ok/ { next }
 		fence { print NR ":" $0; next }
 		{
 			line = $0
@@ -120,7 +130,8 @@ The commands above teach a spelling that brig removes in 0.3.
 Every current spelling, and the whole mapping, is in docs/migration.md.
 
 If a passage legitimately needs to name a retired spelling, put that discussion
-in docs/migration.md, which is exempt from this check.
+in docs/migration.md, or mark the one prose line with an HTML comment
+containing `retired-ok`.
 EOF
 fi
 

--- a/script/check-retired-spellings.sh
+++ b/script/check-retired-spellings.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+# Refuse documentation that teaches a command spelling brig is about to remove.
+#
+# brig renamed most of its verbs during the 0.1 series. Every old spelling still
+# works and prints one line naming its replacement, and all of them are
+# scheduled for removal in 0.3. That grace period is exactly what makes the
+# problem invisible: a doc teaching `brig profiles` is not broken today, so
+# nothing fails and no reader complains, and it becomes wrong on the release
+# that drops the alias. Issue #111 asks for this to be checked rather than
+# reviewed by eye, so it does not rot the first time a doc is edited after 0.3.
+#
+# Only COMMANDS are checked, not prose. A retired spelling is reported when it
+# appears inside inline code or in a fenced code block, because that is where a
+# reader copies from. The sentence "six of the shipped brig profiles ask for
+# hvi" uses "profiles" as an ordinary noun and is left alone, and so is prose
+# about exec'ing into a container.
+#
+# Two files are exempt. docs/migration.md exists to teach the old-to-new
+# mapping, and a changelog is allowed to quote what a release retired.
+#
+# Short flags are scoped to the run line. `-n` is retired on `brig run`, where
+# it became `<agent>@<label>`, and is current on `brig policy attach`, so the
+# verb has to be part of the pattern.
+#
+# Usage: check-retired-spellings.sh [file...]
+#        With no argument, every tracked Markdown file is checked.
+#
+# macOS ships bash 3.2, so there is no mapfile here and no associative array.
+
+set -uo pipefail
+
+is_exempt() {
+	case "$1" in
+	docs/migration.md | CHANGELOG.md) return 0 ;;
+	esac
+	return 1
+}
+
+patterns=(
+	'brig (profiles|agents|template)\b|brig profile [a-z]'
+	'brig policies\b'
+	'brig (create|reset|env)\b'
+	'brig (exec|shell)\b'
+	'brig (import|export)\b'
+	'brig agent (list|save|load)\b'
+	'brig policy list\b'
+	'brig secret (list|rm)\b'
+	'brig (run|sh|create)\b.* (-t|-m|-n|-w)( |=|$)'
+	'brig (run|sh|create)\b.* (--name|--workspace|--memory)( |=|$)'
+)
+
+names=(
+	'brig profiles / brig agents / brig template / brig profile <verb> -> brig agent <verb>'
+	'brig policies -> brig policy ls'
+	'brig create / brig reset / brig env -> brig run -d / brig rm --all / brig info'
+	'brig exec / brig shell -> brig sh'
+	'brig import / brig export -> brig agent import / brig agent export'
+	'brig agent list|save|load -> brig agent ls|export|import'
+	'brig policy list -> brig policy ls'
+	'brig secret list|rm -> brig secret ls|delete'
+	'the run-line short flags -t -m -n -w -> --image --mem <agent>@<label> --home'
+	'--name / --workspace / --memory on the run line -> <agent>@<label> / --home / --mem'
+)
+
+# Print "<line>:<command text>" for every place a reader could copy a command
+# from: each inline-code span, and each line inside a fenced code block.
+extract_commands() {
+	awk '
+		/^[[:space:]]*```/ { fence = !fence; next }
+		fence { print NR ":" $0; next }
+		{
+			line = $0
+			while (match(line, /`[^`]+`/)) {
+				span = substr(line, RSTART + 1, RLENGTH - 2)
+				print NR ":" span
+				line = substr(line, RSTART + RLENGTH)
+			}
+		}
+	' "$1"
+}
+
+if [ "$#" -gt 0 ]; then
+	files=$(printf '%s\n' "$@")
+else
+	# Tracked Markdown only. An untracked scratch file is not the project's problem.
+	files=$(git ls-files '*.md')
+fi
+
+status=0
+while IFS= read -r f; do
+	[ -n "$f" ] || continue
+	[ -f "$f" ] || continue
+	is_exempt "$f" && continue
+	commands=$(extract_commands "$f")
+	[ -n "$commands" ] || continue
+	i=0
+	while [ "$i" -lt "${#patterns[@]}" ]; do
+		hits=$(printf '%s\n' "$commands" | grep -E ":.*${patterns[$i]}" || true)
+		if [ -n "$hits" ]; then
+			while IFS= read -r hit; do
+				[ -n "$hit" ] || continue
+				printf '%s:%s: retired spelling (%s)\n' \
+					"$f" "${hit%%:*}" "${names[$i]}"
+				printf '    %s\n' "${hit#*:}"
+				status=1
+			done <<-EOH
+				$hits
+			EOH
+		fi
+		i=$((i + 1))
+	done
+done <<EOF
+$files
+EOF
+
+if [ "$status" -ne 0 ]; then
+	cat <<'EOF'
+
+The commands above teach a spelling that brig removes in 0.3.
+Every current spelling, and the whole mapping, is in docs/migration.md.
+
+If a passage legitimately needs to name a retired spelling, put that discussion
+in docs/migration.md, which is exempt from this check.
+EOF
+fi
+
+exit "$status"


### PR DESCRIPTION
Closes #111.

The docs described a model brig has outgrown, and the README had grown to 9162 words. This rewrites the set against the source at d11ba32 (0.1.0-rc18, which is also the newest tag, so nothing here documents an unreleased command).

## The correction that matters most

Pages still said one host directory is the agent whole world. A run mounts the guest home and, separately, the project named on the command line, read-write at `/work/<name>`. **An agent can change those files.** Every page that described the boundary understated it, including the diagram.

## Other accuracy fixes

- **Verification modes are `off`, `warn` and `require`, and `warn` is the default.** An unverifiable image is reported and booted unless the user asks for `require`. The tag path cannot pin a digest.
- **Three macOS backends, not two.** Six of the eight shipped profiles ask for `hvi`, which needs macOS 15 and is the only backend that enforces egress policy or `isolated` networking. `vz` is the default and the only one that can show a window. doctor `Hypervisor.framework available` line is the `kern.hv_support` probe, not a backend.
- **Persistence is per profile.** The login-in-memory behavior belongs to `claude-code` and `claude-desktop`, the two that declare a tmpfs. The other five write to host disk.
- **Only a required secret fails a run**, and no shipped profile declares one.
- **`brig stop` does not keep a bootable instance.** There is no start path, so the docs now say what it actually keeps.

## Structure

README is 1251 words and links out. New pages carry what it used to hold: `install.md`, `sessions.md`, `authentication.md`, `cli.md`, `telemetry.md`, plus `migration.md`, `stability.md` and a `docs/README.md` index. The manual-test reports are labeled historical, with their dates and results intact.

`docs/stability.md` is also the stability statement #47 notes is missing from the repository. It does not settle #60; it records what is true today.

## One new check

`script/check-retired-spellings.sh` fails when a doc teaches a spelling that 0.3 removes. Every retired spelling still works and prints its replacement, so such a doc is not broken today and becomes wrong at 0.3, which is what #111 asks to automate. It reads commands rather than prose, so "six of the shipped brig profiles" is left alone while `brig profiles` is caught. Not yet wired into CI.

## Go changes

Comments and help text only, no behavior. Moving the exit-code and environment tables out of the README left nine pointers aimed at sections that no longer exist, including a user-facing `brig telemetry status` string and a line-number reference. They now name the pages that hold those facts. Filed separately as #180, since the coupling will recur.

## Defects found, not papered over

Checking these claims turned up 33 issues, filed as #164 to #196 rather than smoothed away in the wording. The docs describe the behavior as it is and link the issue where one exists. The ones that shape this PR text: #167 (verification messages), #169 (`--skills` is a no-op on seven of eight profiles), #170 (`statePaths:` is inert), #172 (a `--name` session cannot carry a policy), #173 (`brig stop`), #196 (the session label reaches one agent).

## Validation

- `go test ./...` passes, 13 packages.
- `go vet ./...`, `gofmt -l` clean.
- `script/smoke.sh` PASS.
- `script/check-retired-spellings.sh` passes, and still catches all 9 planted cases in a self-test.
- Every relative link and anchor resolves, checked by script across all Markdown in the repo. The paths cited from Go source and shell scripts still resolve, including `docs/policies.md` "What this does not do yet" and `docs/runtimes.md#building-hull-from-source-on-macos`.
- No orphan pages.

**Not validated at runtime.** No sandbox was booted, so nothing here is evidence that a documented run works end to end. Claims were checked against the implementation, its tests, and read-only commands against a build of this commit. Untested paths: Linux, Intel Mac, macOS 14, and any flow needing real credentials.

## Review notes

Best read as: README, then `docs/README.md`, then `cli.md` and `sessions.md`, which carry the most new material. The manual-test reports have header-only changes.

Two accuracy passes were still running when this went up; anything they find will land as follow-up commits here.