### PR TITLE
fix(release): Bring the cask description under the length brew enforces

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -193,7 +193,9 @@ homebrew_casks:
       # repository.
       token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
     homepage: https://github.com/brig-sh/brig
-    description: Run a coding agent in a sandbox, with the credentials it needs and none of the ones it does not
+    # Under 80 characters, which is what `brew style` enforces (Cask/Desc)
+    # and the one offence in a generated cask that it cannot autocorrect.
+    description: Run a coding agent in a microVM sandbox with only the credentials it needs
     # Paths inside the archive above. brew puts each one where its shell reads
     # completions from, so a cask install has completion without a second step
     # -- which is the whole point of the closed flag sets: they only help a
@@ -209,9 +211,9 @@ homebrew_casks:
       # The microVM runtime brig drives on macOS. It lives in the same public
       # tap as this cask, so `brew install --cask brig` brings it along.
       #
-      # Both casks land in the tap on their first stable release: brig's from
-      # this config, hull's from its own sign-and-notarize workflow. Until
-      # then neither is published, so nothing here is half-wired.
+      # Both casks land in the tap on their first stable release, each from
+      # its own .goreleaser.yaml. Until then the tap carries hand-written
+      # ones, pinned to the newest release candidate.
       - cask: brig-sh/brig/hull
     # auto: never on a prerelease. An rc should not move what `brew upgrade`
     # follows.


### PR DESCRIPTION
## Summary

The cask description in `.goreleaser.yaml` is 95 characters. `brew style`
fails a cask whose description runs over 80 (`Cask/Desc`), and that is the one
offence in a generated cask that rubocop cannot autocorrect. So the pull
request GoReleaser opens against the tap on the first stable tag would land
red, on the release that matters most.

The shortened wording keeps what the old one said. `Casks/brig.rb` in the tap
now carries the same string, so the hand-written cask and the generated one do
not disagree.

Also drops a stale comment. It describes hull's cask as coming from "its own
sign-and-notarize workflow"; there is no such workflow, and hull releases from
`release.yml` through GoReleaser exactly as this repository does.

## Related issues

None.

## Changes

- `.goreleaser.yaml`: shorten the cask `description:` to 74 characters, with a
  comment naming the limit and why this particular offence matters.
- `.goreleaser.yaml`: correct the comment on the `cask:` dependency, which
  named a workflow that does not exist.

## Checklist

- [x] `make all` passes (vet, test, build)
- [x] `script/smoke.sh` passes
- [ ] ~~I have added or updated tests covering the change~~ -- the check for this file is `goreleaser check` plus `brew style` on the generated cask, both run rather than added
- [ ] ~~I have run `go test ./... -race`, if the change touches concurrency, subprocesses or the daemon~~ -- touches none of them
- [ ] ~~I have exercised the change against a real runtime (`brig run <agent>`), if it touches the run, exec or credential path~~ -- release config only, no code
- [ ] ~~I have updated the affected docs~~ -- nothing else quotes the description; checked with a repo-wide grep

## Notes for the reviewer

Measured, not argued. `goreleaser release --snapshot --clean
--skip=publish,sign,sbom,validate` writes `dist/homebrew/Casks/brig.rb`, and
`brew style` on it went from 8 offences including the `Cask/Desc` failure to 7,
all of which `brew style --fix` clears.

The remaining 7 are GoReleaser's own indentation of the `depends_on` hash. They
are unavoidable from here and expected on the cask pull request; the tap's
README documents `brew style --fix Casks/*.rb` as the step.

Companion pull requests: brig-sh/homebrew-brig#8 adds the cask checks that
catch this class of problem, and brig-sh/hull#67 fixes the same file in hull,
where the cask was missing its `cosign` dependency entirely.
