### PR TITLE
feat(install): Install hull and cosign, and refuse an Intel Mac

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,8 +59,10 @@ macOS 15. On macOS 14 brig refuses the run and names `BRIG_HYPERVISOR=vz` as
 the way past it. macOS 26 is what the project tests on.
 
 `cosign` is optional. Without it brig cannot check a guest image signature and
-says so on every boot. Full instructions, including Linux and building from
-source, are in [docs/install.md](docs/install.md).
+says so on every boot. Both install paths bring it: the cask depends on it, and
+`install.sh` installs it when there is none on `PATH`. Full instructions,
+including Linux and building from source, are in
+[docs/install.md](docs/install.md).
 
 ## Quickstart
 
@@ -74,7 +76,8 @@ brew install --cask brig
 
 The cask brings [hull](https://github.com/brig-sh/hull) with it. During the
 `0.1.0-rc` series the casks are maintained by hand, so if the tap lags the
-newest release, use [install.sh](docs/install.md#installsh) instead.
+newest release, use [install.sh](docs/install.md#installsh) instead: it
+installs hull and cosign too, so it leaves you with the same working host.
 
 Check what brig found on your host:
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -39,47 +39,95 @@ outright, use [install.sh](#installsh) instead. Or read `Casks/brig.rb` and
 
 ## install.sh
 
-Outcome: the `brig` and `brigd` binaries installed directly, without
-Homebrew.
+Outcome: a working install without Homebrew. `brig` and `brigd` on macOS and
+Linux, `hull` and its two runners on macOS, and `cosign` on both.
 
-Prerequisites: `curl` and `tar` on `PATH`.
+Prerequisites: `curl`, `tar`, and either `sha256sum` or `shasum` on `PATH`.
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/brig-sh/brig/main/install.sh | sh
 ```
 
 This downloads the newest release for your OS and architecture. There is no
-stable release yet, so that includes prereleases. It checks the archive
-against the published `checksums.txt` with `sha256sum` or `shasum`, then
-installs `brig` and `brigd` into `BRIG_INSTALL_DIR` or `/usr/local/bin`. It
-uses `sudo` when that directory is not writable.
+stable release yet, so that includes prereleases. Everything it fetches is
+checked against a SHA-256 before it is installed, and the destination is
+`BRIG_INSTALL_DIR` or `/usr/local/bin`. It uses `sudo` when that directory is
+not writable.
 
-CAUTION: on a host with neither `sha256sum` nor `shasum` on `PATH`, the
-checksum check is skipped and the install proceeds anyway. If you want the
-check enforced rather than skipped, install `sha256sum` or `shasum` first.
+A host with neither `sha256sum` nor `shasum` stops the install. A checksum step
+that quietly downgrades to no check is the one outcome it exists to prevent, so
+this is a refusal rather than a warning.
 
-`install.sh` does not check the cosign signature on `checksums.txt`. That
-check needs cosign, which `install.sh` does not require you to have. See
-[Verifying a downloaded release with cosign](#verifying-a-downloaded-release-with-cosign)
-below to check it yourself.
+An Intel Mac is refused before anything is written. brig itself publishes a
+`darwin/amd64` archive, but `hull` drives Virtualization.framework on Apple
+silicon and has never published an `amd64` build, so there would be no runtime
+to drive. See [support.md](support.md).
 
-Two variables change what it does:
+### What it installs on macOS
+
+`hull` comes from its own release, as the `hull-<version>-arm64.tar.gz`
+archive: the same one the Homebrew cask uses. It holds three executables, and
+all three go into the same directory, because `hull` discovers a runner next to
+its own executable:
+
+| Executable | What it is |
+| --- | --- |
+| `hull` | the CLI brig drives |
+| `vz-runner` | the Virtualization.framework backend |
+| `hvi` | the Hypervisor.framework backend |
+
+`hull.dmg` on the same release page holds the same three binaries in an app
+bundle, for dragging to Applications by hand. `install.sh` does not use it.
+
+### What it installs on both
+
+`cosign` is what verifies the kernel, initrd and guest agent every sandbox
+boots, and the container image behind an agent. Without it on `PATH` those
+checks report "no tooling", which under the default mode is not a refusal: the
+boot assets are fetched, written and booted with a printed warning. Installing
+it is what makes `HULL_VERIFY=require` and `BRIG_VERIFY=require` usable on a
+host without Homebrew.
+
+Two things to know about it. It is a 130 MB download, by far the largest thing
+here. And its macOS build is ad-hoc signed upstream, so Gatekeeper rejects it
+on its own -- unlike everything else `install.sh` places, which is Developer ID
+signed and notarized. It runs because a `curl` download carries no quarantine
+attribute. `install.sh` prints this rather than leaving you to find it.
+
+`install.sh` skips `cosign` entirely when one is already on `PATH`.
+
+Unlike the brig and hull archives, whose checksums come from the release that
+carries them, cosign is pinned in `install.sh` by version *and* by hash. Its
+own release cannot be verified without cosign: upstream publishes Sigstore
+bundles and no detached signature, so there is nothing `openssl` can check.
+Writing the hash down moves the trust root to a reviewed file in this
+repository.
+
+### Settings
 
 ```bash
 BRIG_INSTALL_DIR=~/bin BRIG_VERSION=v0.1.0-rc18 sh install.sh
 ```
 
 - `BRIG_INSTALL_DIR` overrides the destination. Unset, it installs to
-  `/usr/local/bin`.
-- `BRIG_VERSION` pins a release rather than fetching the newest one.
+  `/usr/local/bin`. Put it on your `PATH`: `hull` finds `cosign` there, and a
+  destination that is not on `PATH` leaves the boot check reporting "no
+  tooling" even though the binary is installed. `install.sh` warns when this
+  is the case.
+- `BRIG_VERSION` pins a brig release rather than fetching the newest one.
+- `HULL_VERSION` does the same for hull. The two are versioned independently.
+- `BRIG_INSTALL_HULL=0` skips hull, and leaves macOS without a runtime.
+- `BRIG_INSTALL_COSIGN=0` skips cosign, and leaves the boot chain unverified.
+
+`install.sh` does not check the cosign signature on `checksums.txt`, even when
+it has just installed cosign: the archive is already verified by hash, and the
+signature is the stronger separate claim. See
+[Verifying a downloaded release with cosign](#verifying-a-downloaded-release-with-cosign)
+below to check it yourself.
 
 The archive also carries the shell completion scripts, under `completions/`.
 `install.sh` does not install them for you. See [completions.md](completions.md)
 for how.
-
-On macOS, if `hull` is not already on `PATH`, `install.sh` prints the Homebrew
-command to install it. It does not install `hull` itself, since Homebrew is
-the maintained path for a runtime that needs signing.
 
 ## Verifying a downloaded release with cosign
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -91,10 +91,18 @@ it, in order.
   quotes a version number.
 
   This grep exists because a version quoted in a comment survives copy-paste.
-  As of `0.1.0-rc18`, `install.sh`'s own `BRIG_VERSION` example still named
+  Through `0.1.0-rc18`, `install.sh`'s own `BRIG_VERSION` example still named
   the previous release, `rc17`: the exact staleness this step is meant to
-  catch. Run the grep everywhere a version might hide, not just where you
-  expect one.
+  catch. That example now names no tag at all, which removes it from this
+  grep's work rather than relying on the grep to find it. Run the grep
+  everywhere a version might hide, not just where you expect one.
+
+- `install.sh` pins `cosign` by version **and** by SHA-256, one hash per
+  platform. That pin is deliberate -- cosign's own release cannot be verified
+  without cosign, so the hash in this repository is the trust root -- and it is
+  the one version here that no release of ours moves. Bump the version and all
+  three hashes together, from `cosign_checksums.txt` on the upstream release,
+  and never one without the others.
 
 ## Check before you walk away
 

--- a/install.sh
+++ b/install.sh
@@ -1,29 +1,105 @@
 #!/bin/sh
 # Install brig.
 #
-#   curl -fsSL https://raw.githubusercontent.com/brig-sh/brig/main/install.sh | sh
+#   curl -fsSL https://brig.sh/install | sh
 #
-# Downloads the latest release for this platform, checks it against the
-# published checksums, and installs brig and brigd. The archive also carries
-# the shell completion scripts under completions/, which this script leaves
-# for you to install (docs/completions.md). Homebrew is the better path on
-# macOS -- it also brings hull, the runtime brig needs there, and installs
-# the completions:
+# Downloads the newest release for this platform, checks it against the
+# published checksums, and installs brig and brigd. On macOS it also installs
+# hull -- the microVM runtime brig drives there, without which a first `brig
+# run` fails -- and cosign, which is what verifies the kernel, initrd and guest
+# agent every sandbox boots.
+#
+# Homebrew is still the better path on macOS. It tracks upgrades, and it
+# installs the shell completions this script leaves in the archive for you
+# (docs/completions.md):
 #
 #   brew tap brig-sh/brig && brew trust brig-sh/brig && brew install --cask brig
 #
-# Override the destination with BRIG_INSTALL_DIR, or the version with
-# BRIG_VERSION=v0.1.0-rc17.
+# Settings:
+#
+#   BRIG_INSTALL_DIR      where to install (default /usr/local/bin)
+#   BRIG_VERSION          a brig tag instead of the newest release
+#   HULL_VERSION          a hull tag instead of the newest release
+#   BRIG_INSTALL_HULL=0   skip hull, and leave macOS without a runtime
+#   BRIG_INSTALL_COSIGN=0 skip cosign, and leave the boot chain unverified
 set -eu
 
-REPO=brig-sh/brig
+BRIG_REPO=brig-sh/brig
+HULL_REPO=brig-sh/hull
 DEST="${BRIG_INSTALL_DIR:-/usr/local/bin}"
+
+# cosign is pinned by version and by hash, which the two repos above are not.
+# Their checksums are fetched from the release that carries the archive; this
+# one is written down here instead, because cosign's own release cannot be
+# verified without cosign. Upstream publishes Sigstore bundles and no detached
+# signature, so there is nothing openssl can check, and a bundle we half-read
+# would look like verification without being it. Pinning moves the trust root
+# to this file, which is reviewed, rather than to whatever the CDN served.
+#
+# Bump both the version and the hashes together. docs/releasing.md carries the
+# grep that catches a version quoted in one place and not the other.
+COSIGN_VERSION=v3.1.3
+COSIGN_SHA_DARWIN_ARM64=5cf948c2f4dfe59687bdd0b8523709067383e03982cc543475c8a7dc70e92a76
+COSIGN_SHA_LINUX_AMD64=4629c757b7618056f8ddd7e2625ae9fdd94c0372a65049520bc7d9df9efc7f71
+COSIGN_SHA_LINUX_ARM64=c5d324e091826b0d7a78eb16fef316450b4eb9aaec045611c08ba06f5e73220a
 
 say() { printf 'brig-install: %s\n' "$1" >&2; }
 die() { say "$1"; exit 1; }
 
 command -v curl > /dev/null 2>&1 || die "curl is required"
 command -v tar  > /dev/null 2>&1 || die "tar is required"
+
+# Pick the checksum tool before anything is downloaded, and stop if there is
+# none. sha256sum is absent on a stock macOS, where shasum covers it, and both
+# can be absent on a minimal Linux image -- which is a plausible place to pipe
+# an install script. Carrying on without a check is the one outcome a checksum
+# step exists to prevent, so this is a die and not a warning.
+if command -v sha256sum > /dev/null 2>&1; then
+  SHA256_TOOL=sha256sum
+elif command -v shasum > /dev/null 2>&1; then
+  SHA256_TOOL=shasum
+else
+  die "need sha256sum or shasum to check what it downloads; install either one"
+fi
+
+sha256_check() {
+  case "$SHA256_TOOL" in
+    sha256sum) sha256sum -c - ;;
+    shasum)    shasum -a 256 -c - ;;
+  esac
+}
+
+# verify <dir> <file> <checksums> checks one file against a checksums list in
+# the same directory.
+#
+# The expected line is pulled out and refused when absent, so a file the
+# release does not list cannot pass by handing an empty stream to the checksum
+# tool. "checksum ok" prints here and nowhere else, which is the only place it
+# is true.
+verify() {
+  _line=$(grep " $2\$" "$1/$3" || true)
+  [ -n "${_line}" ] || die "no checksum published for $2"
+  ( cd "$1" && printf '%s\n' "${_line}" | sha256_check > /dev/null ) \
+    || die "checksum mismatch for $2"
+  say "checksum ok: $2"
+}
+
+# newest_tag <repo> names the newest release, prereleases included. Neither
+# repo has a stable one yet, so /releases/latest answers 404 for both.
+newest_tag() {
+  curl -fsSL "https://api.github.com/repos/$1/releases" \
+    | sed -n 's/.*"tag_name": *"\([^"]*\)".*/\1/p' | head -1
+}
+
+# install_from <dir> <name> puts one executable in DEST.
+install_from() {
+  if [ -w "$DEST" ]; then
+    install -m 0755 "$1/$2" "$DEST/$2"
+  else
+    say "$DEST is not writable, using sudo"
+    sudo install -m 0755 "$1/$2" "$DEST/$2"
+  fi
+}
 
 os=$(uname -s | tr '[:upper:]' '[:lower:]')
 case "$os" in
@@ -37,60 +113,142 @@ case "$(uname -m)" in
   *) die "unsupported architecture: $(uname -m)" ;;
 esac
 
-version="${BRIG_VERSION:-}"
-if [ -z "$version" ]; then
-  # The newest release, prereleases included: there is no stable one yet.
-  version=$(curl -fsSL "https://api.github.com/repos/$REPO/releases" \
-    | sed -n 's/.*"tag_name": *"\([^"]*\)".*/\1/p' | head -1)
-  [ -n "$version" ] || die "could not work out the latest version; set BRIG_VERSION"
+# An Intel Mac is refused here rather than later. The release does publish
+# darwin/amd64 archives of brig itself, so this used to install cleanly and
+# then fail on the first run with "brig drives hull on macOS, and none was
+# there" -- which reads as a dependency the user can go and install. They
+# cannot: hull drives Virtualization.framework on Apple silicon and has never
+# published an amd64 build. Say so now, while nothing has been written.
+if [ "$os" = darwin ] && [ "$arch" = amd64 ]; then
+  die "brig needs Apple silicon on macOS: hull has no amd64 build, so there would be no runtime to drive (docs/support.md)"
 fi
-
-bare="${version#v}"
-archive="brig-${bare}-${os}-${arch}.tar.gz"
-base="https://github.com/$REPO/releases/download/$version"
 
 tmp=$(mktemp -d)
 trap 'rm -rf "$tmp"' EXIT
 
-say "downloading $archive"
-curl -fsSL -o "$tmp/$archive" "$base/$archive" \
-  || die "no build for ${os}/${arch} in $version"
-
-# Never install something we have not checked. The checksum file is signed
-# with cosign; verifying that signature needs cosign installed, which this
-# script does not require, so it is documented in the README rather than done
-# here.
-if curl -fsSL -o "$tmp/checksums.txt" "$base/checksums.txt"; then
-  if command -v sha256sum > /dev/null 2>&1; then
-    ( cd "$tmp" && grep " $archive\$" checksums.txt | sha256sum -c - > /dev/null ) \
-      || die "checksum mismatch for $archive"
-  elif command -v shasum > /dev/null 2>&1; then
-    ( cd "$tmp" && grep " $archive\$" checksums.txt | shasum -a 256 -c - > /dev/null ) \
-      || die "checksum mismatch for $archive"
-  else
-    say "no sha256 tool found, skipping the checksum check"
+install_brig() {
+  version="${BRIG_VERSION:-}"
+  if [ -z "$version" ]; then
+    version=$(newest_tag "$BRIG_REPO")
+    [ -n "$version" ] || die "could not work out the newest version; set BRIG_VERSION"
   fi
-  say "checksum ok"
-else
-  die "could not fetch checksums.txt"
-fi
 
-tar -xzf "$tmp/$archive" -C "$tmp"
+  bare="${version#v}"
+  archive="brig-${bare}-${os}-${arch}.tar.gz"
+  base="https://github.com/$BRIG_REPO/releases/download/$version"
 
-install_one() {
-  if [ -w "$DEST" ]; then
-    install -m 0755 "$tmp/$1" "$DEST/$1"
-  else
-    say "$DEST is not writable, using sudo"
-    sudo install -m 0755 "$tmp/$1" "$DEST/$1"
+  say "downloading $archive"
+  curl -fsSL -o "$tmp/$archive" "$base/$archive" \
+    || die "no build for ${os}/${arch} in $version"
+  # The checksum file is signed with cosign as well. Verifying that signature
+  # needs a cosign this script may be about to install, so the signature is
+  # documented in the README rather than checked here.
+  curl -fsSL -o "$tmp/brig-checksums.txt" "$base/checksums.txt" \
+    || die "could not fetch checksums.txt for $version"
+  verify "$tmp" "$archive" brig-checksums.txt
+
+  # Both archives carry a LICENSE and a README.md, so each unpacks into its own
+  # directory rather than over the other.
+  mkdir -p "$tmp/brig"
+  tar -xzf "$tmp/$archive" -C "$tmp/brig"
+  install_from "$tmp/brig" brig
+  install_from "$tmp/brig" brigd
+  say "installed $("$DEST/brig" version) to $DEST"
+}
+
+# hull ships one arm64 archive holding all three executables it needs: the CLI,
+# and the two runners that carry the entitlements their backends require --
+# virtualization for vz-runner, hypervisor for hvi. They go into the same
+# directory on purpose: hull discovers a runner next to its own executable, and
+# splitting them breaks that.
+#
+# The archive is what the Homebrew cask installs too. hull.dmg holds the same
+# binaries in an app bundle for people who would rather drag it to
+# Applications, which is not a thing a script should be doing.
+install_hull() {
+  hull_version="${HULL_VERSION:-}"
+  if [ -z "$hull_version" ]; then
+    hull_version=$(newest_tag "$HULL_REPO")
+    [ -n "$hull_version" ] || die "could not work out hull's newest release; set HULL_VERSION"
+  fi
+
+  hull_bare="${hull_version#v}"
+  hull_archive="hull-${hull_bare}-arm64.tar.gz"
+  hull_base="https://github.com/$HULL_REPO/releases/download/$hull_version"
+
+  say "downloading $hull_archive"
+  curl -fsSL -o "$tmp/$hull_archive" "$hull_base/$hull_archive" \
+    || die "no hull build for arm64 in $hull_version"
+  curl -fsSL -o "$tmp/hull-checksums.txt" "$hull_base/checksums.txt" \
+    || die "could not fetch hull's checksums.txt for $hull_version"
+  verify "$tmp" "$hull_archive" hull-checksums.txt
+
+  mkdir -p "$tmp/hull"
+  tar -xzf "$tmp/$hull_archive" -C "$tmp/hull"
+  install_from "$tmp/hull" hull
+  install_from "$tmp/hull" vz-runner
+  install_from "$tmp/hull" hvi
+  say "installed $("$DEST/hull" --version) to $DEST"
+}
+
+# cosign is what turns hull's boot-asset check from a printed warning into an
+# answer. Without it on PATH the check reports "no tooling", and under the
+# default mode that is not a refusal: the kernel a sandbox boots is fetched,
+# written and booted unverified. Installing it is what makes HULL_VERIFY=require
+# and BRIG_VERIFY=require usable on a host without Homebrew.
+install_cosign() {
+  if command -v cosign > /dev/null 2>&1; then
+    say "cosign is already on PATH, leaving it alone"
+    return
+  fi
+
+  case "$os/$arch" in
+    darwin/arm64) cosign_sha=$COSIGN_SHA_DARWIN_ARM64 ;;
+    linux/amd64)  cosign_sha=$COSIGN_SHA_LINUX_AMD64 ;;
+    linux/arm64)  cosign_sha=$COSIGN_SHA_LINUX_ARM64 ;;
+    *) say "no pinned cosign for $os/$arch, skipping it"; return ;;
+  esac
+
+  # Worth saying out loud: this is a 130 MB download for one subprocess, and it
+  # is the largest thing this script pulls by an order of magnitude.
+  say "downloading cosign $COSIGN_VERSION (about 130 MB)"
+  curl -fsSL -o "$tmp/cosign" \
+    "https://github.com/sigstore/cosign/releases/download/$COSIGN_VERSION/cosign-${os}-${arch}" \
+    || die "could not fetch cosign $COSIGN_VERSION for ${os}/${arch}"
+  printf '%s  cosign\n' "$cosign_sha" > "$tmp/cosign-checksums.txt"
+  verify "$tmp" cosign cosign-checksums.txt
+  install_from "$tmp" cosign
+  say "installed cosign $COSIGN_VERSION to $DEST"
+  if [ "$os" = darwin ]; then
+    # Everything else this script installs is Developer ID signed and
+    # notarized. cosign's macOS build is ad-hoc signed upstream, so Gatekeeper
+    # rejects it on its own and it runs here only because a curl download
+    # carries no quarantine attribute. Say it rather than let someone find out.
+    say "note: cosign's macOS build is ad-hoc signed upstream, unlike the rest of this install"
   fi
 }
-install_one brig
-install_one brigd
 
-say "installed $("$DEST/brig" version) to $DEST"
+install_brig
 
-if [ "$os" = darwin ] && ! command -v hull > /dev/null 2>&1; then
-  say "macOS also needs hull, the microVM runtime:"
+if [ "$os" = darwin ] && [ "${BRIG_INSTALL_HULL:-1}" != 0 ]; then
+  install_hull
+fi
+
+if [ "${BRIG_INSTALL_COSIGN:-1}" != 0 ]; then
+  install_cosign
+fi
+
+# hull finds cosign on PATH, so a DEST that is not on it leaves the boot check
+# reporting "no tooling" even though the binary is installed.
+case ":${PATH}:" in
+  *":$DEST:"*) ;;
+  *) say "$DEST is not on your PATH; add it, or hull will not find cosign there" ;;
+esac
+
+if [ "$os" = darwin ] && ! command -v hull > /dev/null 2>&1 \
+   && [ "${BRIG_INSTALL_HULL:-1}" = 0 ]; then
+  say "hull was skipped, so brig has no runtime here:"
   say "  brew tap brig-sh/brig && brew trust brig-sh/brig && brew install --cask hull"
 fi
+
+say "next: brig doctor"


### PR DESCRIPTION
<!-- Title: feat(install): Install hull and cosign, and refuse an Intel Mac -->

## Summary

`install.sh` left a macOS host that could not run anything. It installed `brig` and `brigd`, printed a Homebrew command for hull, and stopped. The first `brig run` then failed with `brig drives hull on macOS, and none was there` — which reads as a dependency the user can go and install. They could not, on an Intel Mac, and on Apple silicon they had to go find the instruction themselves.

hull already publishes exactly the artifact a script wants. `hull-<version>-arm64.tar.gz` holds `hull`, `vz-runner` and `hvi`, and it is the same archive the Homebrew cask installs. `hull.dmg` is a drag-to-Applications bundle of those same binaries, which is not something a script should be driving — so this uses the tarball, like the cask does.

The second half is cosign. Without it on `PATH`, hull's boot-asset check reports "no tooling", and under the default mode that is not a refusal: the kernel, initrd and guest agent a sandbox boots are fetched, written and booted with a printed warning. The one control over the boot chain was off by default on this install path purely because nothing pulled the binary in — the same gap `Casks/hull.rb` calls out for the cask.

Two things about cosign are stated rather than hidden, in the script's output and in the docs: it is a 130 MB download for one subprocess, and its macOS build is ad-hoc signed upstream, so Gatekeeper rejects it on its own — unlike everything else installed here, which is Developer ID signed and notarized. It runs because a `curl` download carries no quarantine attribute.

It is also pinned by version **and** by SHA-256, which the brig and hull archives are not. Their checksums come from the release that carries them; cosign's own release cannot be verified without cosign, because upstream publishes Sigstore bundles and no detached signature, so there is nothing `openssl` can check. That leaves TLS as the only thing vouching for it. Writing the hashes down moves the trust root to a reviewed file in this repository.

## Related issues

Closes #182. Closes #166.

## Changes

- `install.sh` installs hull on macOS from `hull-<version>-arm64.tar.gz`: `hull`, `vz-runner` and `hvi` into one directory, because hull discovers a runner next to its own executable. hull is versioned independently of brig, so it resolves its own newest tag; `HULL_VERSION` pins it, `BRIG_INSTALL_HULL=0` skips it.
- `install.sh` installs cosign on both platforms when there is none on `PATH`, pinned to `v3.1.3` with one hash per platform. `BRIG_INSTALL_COSIGN=0` skips it.
- An Intel Mac is refused before anything is written. brig publishes a `darwin/amd64` archive, hull never has, and hull is the only runtime brig drives on macOS. (#182)
- A missing sha256 tool now stops the install, and `checksum ok` prints only where a checksum was actually compared — it used to sit outside the `if`/`elif`/`else` above it. The expected line is also extracted and refused when absent, so a file the release does not list cannot pass by handing an empty stream to the checksum tool. (#166)
- A warning when the destination is not on `PATH`: hull finds cosign there, so a `BRIG_INSTALL_DIR` off `PATH` leaves the boot check reporting "no tooling" even though the binary is installed.
- The `BRIG_VERSION` example in the header named `rc17` while `rc18` was current. It now names no tag, taking it out of the release grep's work rather than relying on the grep to catch it (#166's last note).
- Docs: `docs/install.md` rewrites the `install.sh` section for what it now does; `README.md` stops calling cosign a manual step; `docs/releasing.md` gains the cosign pin as a thing to bump, and records that the stale `BRIG_VERSION` example is gone.

**No automated test was added, and there is no harness to add it to** — nothing in `script/` or `.github/workflows/` drives `install.sh` today. Faking it needs a stubbed GitHub releases API and stub release assets, which is a bigger piece of work than this change and worth its own PR. Verified by real end-to-end runs instead, captured below.

## Checklist

- [x] `make all` passes (vet, test, build)
- [x] `script/smoke.sh` passes
- [ ] ~~I have added or updated tests covering the change~~ — no harness drives `install.sh`; see Changes
- [x] I have run `go test ./... -race`, if the change touches concurrency, subprocesses or the daemon
- [ ] ~~I have exercised the change against a real runtime (`brig run`)~~ — install path only, touches no run, exec or credential code
- [x] I have updated the affected docs (see [docs/README.md](../docs/README.md) for the map)

## Credentials and the sandbox boundary

Neither promise is affected: no code changes, and nothing here touches `internal/wrap`, `internal/creds`, `internal/profile` or `internal/secret`.

It does move the adjacent one in the right direction. A `curl | sh` install could not previously run `HULL_VERIFY=require` or `BRIG_VERIFY=require` at all, because those refuse a host with no cosign. Now it can.

## Verification

`make all` — vet, `go test -race ./...` across all 15 packages, build:

```
go vet ./...
go test -race ./...
ok  github.com/brig-sh/brig/cmd/brig    5.372s
...
ok  github.com/brig-sh/brig/internal/wrap    11.317s
go build -ldflags '...' -o .../brig ./cmd/brig
```

`script/smoke.sh` → `PASS`. `script/check-retired-spellings.sh` → exit 0. `bash script/check-tests-kept.sh origin/main HEAD` → `every test present at 12e8700 is still here`. `shellcheck -s sh install.sh` → clean; `sh -n install.sh` → OK.

**Full install, macOS 26 / Apple silicon**, `BRIG_INSTALL_DIR` to a temp dir, with cosign hidden from `PATH`:

```
brig-install: downloading brig-0.1.0-rc18-darwin-arm64.tar.gz
brig-install: checksum ok: brig-0.1.0-rc18-darwin-arm64.tar.gz
brig-install: installed brig 0.1.0-rc18 to .../testdest4
brig-install: downloading hull-0.1.0-rc27-arm64.tar.gz
brig-install: checksum ok: hull-0.1.0-rc27-arm64.tar.gz
brig-install: installed hull version 0.1.0-rc27 to .../testdest4
brig-install: downloading cosign v3.1.3 (about 130 MB)
brig-install: checksum ok: cosign
brig-install: installed cosign v3.1.3 to .../testdest4
brig-install: note: cosign's macOS build is ad-hoc signed upstream, unlike the rest of this install
brig-install: .../testdest4 is not on your PATH; add it, or hull will not find cosign there
brig-install: next: brig doctor
```

Six executables landed; the installed cosign reports `GitVersion: v3.1.3`.

**Signatures survive `install -m 0755`** — the thing that would have made this hard. On the installed copies, not the archive:

| Executable | Authority | Entitlement | `spctl -a -t install` |
| --- | --- | --- | --- |
| `hull` | Developer ID Application (JDHGY38643) | — | accepted, Notarized Developer ID |
| `vz-runner` | Developer ID Application (JDHGY38643) | `com.apple.security.virtualization` | accepted, Notarized Developer ID |
| `hvi` | Developer ID Application (JDHGY38643) | `com.apple.security.hypervisor` | accepted, Notarized Developer ID |

`codesign --verify --strict` returns valid for all three, and each CDHash matches the copy straight out of the tarball.

**Intel Mac refusal** (`uname` stubbed to report `x86_64`/`Darwin`):

```
brig-install: brig needs Apple silicon on macOS: hull has no amd64 build, so there would be no runtime to drive (docs/support.md)
exit=1
```

Nothing was written to the destination — which is the actual complaint in #182.

**No sha256 tool** (`PATH` holding only `curl` and `tar`):

```
brig-install: need sha256sum or shasum to check what it downloads; install either one
exit=1
```

Nothing written. Under the old script this host was told `checksum ok` and got an unverified install.

**Both opt-outs** (`BRIG_INSTALL_HULL=0 BRIG_INSTALL_COSIGN=0`) → `brig` and `brigd` only.

Not verified: Linux, and an Intel Mac other than by stubbing `uname`. The Linux paths differ only in the cosign asset name and in hull being skipped.

## Follow-up, not in this PR

A change to the site that serves `brig.sh` adds a `/install` route proxying this script, pinned to a brig tag. That pin should move to the first tag carrying this change; until it does, `brig.sh/install` would serve the rc18 script, which installs neither hull nor cosign. The `curl` URL in `docs/install.md` stays on `raw.githubusercontent.com` here, and should switch to `https://brig.sh/install` once that route is live.
