### PR TITLE
docs: Rewrite the README as a front door

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,37 +13,34 @@
   <a href="LICENSE"><img alt="License: Apache 2.0" src="https://img.shields.io/badge/license-Apache--2.0-blue.svg"></a>
 </p>
 
-**brig runs a coding agent inside a microVM on your own machine.** The agent
-gets a guest home of its own, plus the one project directory you name on the
-command line. Your other files stay where they are: brig mounts nothing else,
-and it reads no credential out of your keychain, your SSH agent or your secret
-manager to hand to the agent.
+**Brig runs a coding agent inside a microVM on your own machine.**
 
-That matters when you want to let an agent work unattended. The blast radius of
-a bad edit or a bad command is the project you handed it, and you can throw the
-sandbox away and start again.
+An agent working unattended can only damage what you handed it. Point it at one
+project, and a bad edit or a bad command reaches no further than that project.
+When you are done, throw the sandbox away and start clean.
 
 ## How it works
 
-One command resolves a session on the host and boots it:
+One command starts a sandbox and runs the agent in it:
 
 ```bash
 brig run claude ~/code/demo
 ```
 
-- **The session** is `claude`, the default session of the `claude-code` agent.
-  `claude@refactor` is a second, independent session of the same agent, with
-  its own sandbox and its own guest home. Every verb takes this ref.
-- **The guest home** is a host directory, `~/brig/claude-code`, mounted as the
-  agent's home. The agent's settings and history live there and survive
-  restarts.
-- **The project** is the directory you named. It is mounted read-write at
-  `/work/demo`, and the agent starts there. Name no project and brig remounts
-  whatever that session ran with last. `--no-project` mounts none.
-- **The sandbox** is a microVM: `hull` on macOS, `nerdctl` with containerd and
-  the `urunc` shim on Linux.
-- **Credentials** are not carried in by default. The sandbox boots with none,
-  so the agent asks you to log in exactly as it does on a new machine.
+A session is `<agent>` or `<agent>@<label>`, the ref every command takes.
+`claude` and `claude@refactor` are two independent sessions of the same
+agent, each with its own sandbox. The guest home is the host directory
+holding a session's settings and history. `claude` resolves to the
+`claude-code` agent, so its guest home is `~/brig/claude-code`, and
+`claude@refactor`'s is the sibling `~/brig/claude-code-refactor`, not a
+directory inside it.
+
+Name a project on the run line, and Brig mounts it read-write at
+`/work/<name>`, where the agent starts. Credentials reach the guest only
+when you deliver them: the sandbox boots with none, and the agent asks you
+to log in. What the guest does not get: every other host directory, your
+keychain, and your SSH agent. [docs/sessions.md](docs/sessions.md) is the
+full model.
 
 ## Requirements
 
@@ -51,87 +48,50 @@ brig run claude ~/code/demo
 | --- | --- |
 | Mac, Apple silicon, macOS 15 or newer | Yes |
 | Mac, Apple silicon, macOS 14 | Yes, with `BRIG_HYPERVISOR=vz` |
-| Intel Mac | No, brig needs Apple silicon |
-| Linux, x86-64 or arm64 | Yes, with nerdctl and containerd |
+| Intel Mac | No |
+| Linux, x86-64 or arm64 | Yes, with `nerdctl`, containerd and the `urunc` shim |
 
-Six of the eight built-in profiles ask for hull's `hvi` backend, which needs
-macOS 15. On macOS 14 brig refuses the run and names `BRIG_HYPERVISOR=vz` as
-the way past it. macOS 26 is what the project tests on.
+macOS 15 is the floor: six of the eight built-in profiles need the `hvi`
+backend. See [docs/install.md#platform-support](docs/install.md#platform-support)
+for the rest.
 
-`cosign` is optional. Without it brig cannot check a guest image signature and
-says so on every boot. Both install paths bring it: the cask depends on it, and
-`install.sh` installs it when there is none on `PATH`. Full instructions,
-including Linux and building from source, are in
-[docs/install.md](docs/install.md).
-
-## Quickstart
-
-Install on macOS with Homebrew:
+## Install
 
 ```bash
 brew tap brig-sh/brig
-brew trust brig-sh/brig       # brew refuses untrusted third-party taps
+brew trust brig-sh/brig
 brew install --cask brig
 ```
 
-The cask brings [hull](https://github.com/brig-sh/hull) with it. During the
-`0.1.0-rc` series the casks are maintained by hand, so if the tap lags the
-newest release, use [install.sh](docs/install.md#installsh) instead: it
-installs hull and cosign too, so it leaves you with the same working host.
+The cask brings [hull](https://github.com/brig-sh/hull) and `cosign` with
+it. For `install.sh`, Linux, or a source build, see [docs/install.md](docs/install.md).
 
-Check what brig found on your host:
+## First run
 
 ```bash
 brig doctor
 ```
 
-Each line names one fact: the host, the hypervisor, the runtime, the boot
-assets, cosign, the profiles, the secret store and brigd. A `!!` line prints
-the fix beside it. `--` means brig looked and found nothing to report, which is
-not a failure.
-
-Run an agent on a throwaway project:
+Each line is a check. A `!!` line prints its fix beside it.
 
 ```bash
-mkdir -p ~/code/demo && cd ~/code/demo
+mkdir -p ~/code/demo
 brig run claude ~/code/demo
 ```
 
-The first run pulls the guest image once, so it is the slow one. Claude Code
-then prompts you to log in, because the sandbox holds no credential. That login
-happens inside the guest. On `claude-code` it lands on a tmpfs, so `brig stop`
-takes it with the VM and the next run asks again. To carry in the login you
-already have on this Mac, see [docs/authentication.md](docs/authentication.md).
-
-You know it worked when the agent's prompt appears and `pwd` inside it prints
-`/work/demo`. Leave the agent and the sandbox keeps running, so the next
-`brig run claude` is immediate.
-
-Stop it when you are done:
+Brig prints `brig: image and boot assets verified`, Claude Code asks you to log
+in inside the sandbox, and `pwd` inside the agent prints `/work/demo`. The
+first run pulls the guest image and the boot assets, so it is slow.
+[docs/authentication.md](docs/authentication.md) covers the login and how
+to carry one in from the host.
 
 ```bash
-brig stop claude    # stop the sandbox and keep its name
+brig stop claude    # stop the sandbox, keep its name
 brig rm claude      # stop it and remove it
 ```
 
-Neither touches `~/brig/claude-code` or `~/code/demo`. Your project and the
-agent's saved state stay on the host.
-
-## Common workflows
-
-```bash
-brig ls                          # every sandbox, with its ref and workspace
-brig run claude                  # reopen the session on the project it last used
-brig run claude@refactor ~/code/demo   # a second session, its own sandbox and home
-brig sh claude                   # a login shell inside the sandbox
-brig sh claude ls /work          # one command inside it
-brig info claude                 # the boundary a run uses, before booting
-brig logs claude --follow        # stream the sandbox's log
-```
-
-`brig info` is the one to reach for when a run does not do what you expected.
-It prints the session, the image, the workspace, the verification mode, the
-network and the credentials by name, and it boots nothing.
+Neither touches `~/brig/claude-code` or `~/code/demo`.
+[docs/quickstart.md](docs/quickstart.md) walks through all of this, explained.
 
 ## The boundary
 
@@ -139,30 +99,20 @@ network and the credentials by name, and it boots nothing.
   <img alt="brig sandbox architecture. brig run resolves the session on the host. hull drives a microVM on macOS, urunc over KVM on Linux. Both give the guest the same contract: a guest home, a project mount, per-exec credentials, and an image whose signature brig checks" src="assets/architecture.svg" width="900">
 </p>
 
-What the sandbox keeps out: every host directory except the guest home and the
-project you name, your keychain, your SSH agent, and the API-key environment
-variables each profile refuses to forward.
-
-What it does not keep out. An agent can change anything in the project you
-mounted, because that mount is read-write and those are your real files. It can
-read any credential you chose to deliver into the guest. On the default
-`shared` network it can reach the internet, so anything it can read it can also
-send. Egress filtering exists, and brig enforces it only on hull's `hvi`
-backend. On any other backend a policy-bound run is refused rather than run
-unenforced.
-
-Image verification defaults to `warn`, which reports an unverifiable image and
-boots anyway. Set `BRIG_VERIFY=require` to refuse one instead.
-
-[docs/security.md](docs/security.md) states the boundary and its limits in
-full, and [docs/non-goals.md](docs/non-goals.md) says what brig does not try to
-be.
+The project mount is read-write, and those are your real files: the agent
+can change anything under it. On the default `shared` network the agent
+reaches the internet, so anything it can read it can also send. Brig
+enforces egress policy only on hull's `hvi` backend, and refuses a
+policy-bound run on any other backend rather than run it unenforced. Image
+verification defaults to `warn`, which reports an unverifiable image and
+boots it anyway. Set `BRIG_VERIFY=require` to refuse one instead.
+[docs/security.md](docs/security.md) has the full picture.
 
 ## Documentation
 
 | If you want to | Read |
 | --- | --- |
-| Install brig on any supported host | [docs/install.md](docs/install.md) |
+| Install Brig on any supported host | [docs/install.md](docs/install.md) |
 | Get a first agent running, step by step | [docs/quickstart.md](docs/quickstart.md) |
 | Understand homes, projects and sessions | [docs/sessions.md](docs/sessions.md) |
 | Log an agent in, or give it Git access | [docs/authentication.md](docs/authentication.md), [docs/secrets.md](docs/secrets.md) |
@@ -170,27 +120,28 @@ be.
 | Run your own agent or your own image | [docs/profiles.md](docs/profiles.md), [docs/guest-image.md](docs/guest-image.md) |
 | Restrict what the guest can reach | [docs/policies.md](docs/policies.md) |
 | Understand the isolation, and its limits | [docs/security.md](docs/security.md) |
+| Know what Brig counts, and turn it off | [docs/telemetry.md](docs/telemetry.md) |
 | Fix something that went wrong | [docs/troubleshooting.md](docs/troubleshooting.md) |
 | Move off a retired command spelling | [docs/migration.md](docs/migration.md) |
 | Know what is stable and what is not | [docs/stability.md](docs/stability.md) |
 
 The full index is [docs/README.md](docs/README.md).
 
-## Contributing and support
+## Project status
 
-[CONTRIBUTING.md](CONTRIBUTING.md) covers the build, the tests and the review
-norms. [AI_POLICY.md](AI_POLICY.md) says how AI-assisted contributions are
-handled. Report a vulnerability through [SECURITY.md](SECURITY.md), not a
-public issue. For anything else, [docs/support.md](docs/support.md) says where
-to ask.
+Brig is a prerelease, in the `0.1.0-rc` series. `brig version` prints yours,
+and [docs/stability.md](docs/stability.md) says what you can script against
+today. [docs/support.md](docs/support.md) says where to ask a question or
+file a bug, and [SECURITY.md](SECURITY.md) is where to report a
+vulnerability instead of a public issue. [CONTRIBUTING.md](CONTRIBUTING.md)
+covers the build, the tests and the review norms, and
+[AI_POLICY.md](AI_POLICY.md) says how AI-assisted contributions are
+handled. Brig ships under the Apache License 2.0. See [LICENSE](LICENSE).
 
-brig counts a small number of events and reports what it counts. Run
-`brig telemetry status` to see the current setting, and `brig telemetry off` to
-turn the counting off.
-
-## License
-
-Apache License 2.0. See [LICENSE](LICENSE).
+Brig itself counts nothing. On macOS the hull runtime it drives counts a
+few events, and on Linux nothing is sent. `brig telemetry status` shows the
+current setting, and `brig telemetry off` turns it off.
+[docs/telemetry.md](docs/telemetry.md) has the field-by-field detail.
 
 <p align="center">
   <picture>

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,21 +1,34 @@
-# brig documentation
+# Brig documentation
 
-Start with [the README](../README.md) for what brig is and a first run. This
-index is the map of everything else.
+Start with [the README](../README.md) for what Brig is and a first run. This
+index is the map of everything else, in the order a new reader needs it.
 
-## Get started
-
-| Page | What it gives you |
-| --- | --- |
-| [install.md](install.md) | Every way to install brig, per platform, and how to verify a download |
-| [quickstart.md](quickstart.md) | One agent running on a throwaway project, start to finish |
-| [support.md](support.md) | Where to ask a question or file a bug |
-
-## Use brig
+## Understand
 
 | Page | What it gives you |
 | --- | --- |
 | [sessions.md](sessions.md) | Guest homes, projects, named sessions, and what survives which command |
+| [security.md](security.md) | What the sandbox isolates, and what an agent can still do |
+| [non-goals.md](non-goals.md) | What Brig does not try to be |
+| [runtimes.md](runtimes.md) | The macOS backends, the Linux runtimes, and how one is chosen |
+| [brigd.md](brigd.md) | What the daemon is for |
+
+## Install
+
+| Page | What it gives you |
+| --- | --- |
+| [install.md](install.md) | Every way to install Brig, per platform, and how to verify a download |
+
+## First run
+
+| Page | What it gives you |
+| --- | --- |
+| [quickstart.md](quickstart.md) | One agent running on a throwaway project, start to finish |
+
+## Everyday tasks
+
+| Page | What it gives you |
+| --- | --- |
 | [authentication.md](authentication.md) | Getting an agent logged in, and Git access inside the guest |
 | [secrets.md](secrets.md) | The secret store, profile secret fields, and `brig secret import` |
 | [policies.md](policies.md) | Networking modes and egress policy |
@@ -23,29 +36,21 @@ index is the map of everything else.
 | [guest-image.md](guest-image.md) | The contract an image must meet to boot as a guest |
 | [completions.md](completions.md) | Shell completion for bash, zsh and fish |
 
-## Look something up
+## Reference
 
 | Page | What it gives you |
 | --- | --- |
 | [cli.md](cli.md) | Every verb and flag, the environment variables, the JSON output and the exit codes |
 | [migration.md](migration.md) | Every retired spelling and its replacement |
 | [stability.md](stability.md) | What you can script against, and what is expected to move |
-| [telemetry.md](telemetry.md) | What brig counts, and how to turn it off |
+| [telemetry.md](telemetry.md) | What Brig counts, and how to turn it off |
 
-## Understand the design
-
-| Page | What it gives you |
-| --- | --- |
-| [security.md](security.md) | What the sandbox isolates, and what an agent can still do |
-| [non-goals.md](non-goals.md) | What brig does not try to be |
-| [runtimes.md](runtimes.md) | The macOS backends, the Linux runtimes, and how one is chosen |
-| [brigd.md](brigd.md) | What the daemon is for |
-
-## Fix something
+## Fix
 
 | Page | What it gives you |
 | --- | --- |
 | [troubleshooting.md](troubleshooting.md) | Organized by the error you saw, with the command that confirms the fix |
+| [support.md](support.md) | Where to ask a question or file a bug |
 
 ## Contribute
 
@@ -57,16 +62,5 @@ index is the map of everything else.
 | [releasing.md](releasing.md) | Cutting a release. Maintainers only |
 | [../assets/README.md](../assets/README.md) | The logo and diagram assets, and how to use them |
 
-## Historical records
-
 [manual-tests/](manual-tests/) holds dated engineering records from specific
-changes. They evidence what was measured on the day they were written. They are
-not current validation, and each one says so in its own header.
-
-| Record | What it measured |
-| --- | --- |
-| [manual-tests/egress-policy.md](manual-tests/egress-policy.md) | Egress rules against a live gateway |
-| [manual-tests/runtime-stdin.md](manual-tests/runtime-stdin.md) | Standard input through the runtime |
-| [manual-tests/sandbox-reachability.md](manual-tests/sandbox-reachability.md) | What a guest can reach from inside the sandbox |
-| [manual-tests/secret-files.md](manual-tests/secret-files.md) | File-delivered secrets and their tmpfs backing |
-| [manual-tests/secret-provenance.md](manual-tests/secret-provenance.md) | Where an imported secret came from |
+changes, each one historical evidence rather than current validation.

--- a/docs/stability.md
+++ b/docs/stability.md
@@ -1,12 +1,12 @@
 # What is stable, and what is not
 
-brig is a prerelease. Every published version so far is a `0.1.0-rc` tag, and
+Brig is a prerelease. Every published version so far is a `0.1.0-rc` tag, and
 the grammar is still settling. This page says which parts you can write a
 script against today and which parts are expected to move.
 
 ## Not stable yet
 
-Nothing in brig carries a compatibility guarantee before 1.0. The command
+Nothing in Brig carries a compatibility guarantee before 1.0. The command
 grammar was renamed once already, during the 0.1 series, and
 [docs/migration.md](migration.md) is the record of that change.
 
@@ -14,7 +14,7 @@ Treat the following as subject to change without a deprecation cycle:
 
 - Profile file fields other than those the current `brig agent export` header
   documents.
-- The layout of `~/.brig`, brig's state directory, and its session index.
+- The layout of `~/.brig`, Brig's state directory, and its session index.
 - The wording of any human-readable output. Parse `--json`, not prose.
 - Anything marked "example profile" in `brig agent ls`.
 
@@ -37,15 +37,10 @@ removal in 0.3. `brig run` is never removed.
 
 ## The deprecation window
 
-A spelling brig retires keeps working for at least one release after the notice
-appears. The notice goes to stderr, so it does not corrupt piped output:
-
-```
-brig: `brig profiles` is now `brig agent ls`
-```
-
-The current window closes at 0.3, which removes the spellings listed in
-[docs/migration.md](migration.md).
+A retired spelling keeps working for at least one release after Brig prints
+its notice, and the current window closes at 0.3.
+[docs/migration.md](migration.md) has the notice example and the full mapping
+of retired spellings.
 
 ## Reporting a break
 

--- a/docs/support.md
+++ b/docs/support.md
@@ -15,12 +15,12 @@ Open an issue and pick the bug report template. Include:
 - The output of `brig version`.
 - The output of `brig doctor`.
 
-`brig doctor` reports the host, the hypervisor, the runtime, the boot assets,
-cosign, the profiles, the secret store and brigd, one line per fact.
+`brig doctor` prints one line per check: host, virtual, runtime, boot,
+verify, profiles, secrets, brigd and image.
 [../CONTRIBUTING.md#issues](../CONTRIBUTING.md#issues) lists what else helps:
 logs, your environment, and the steps to reproduce.
 
-If brig or its runtime will not install or start, check whether your platform
+If Brig or its runtime will not install or start, check whether your platform
 is supported first: [install.md](install.md#platform-support) has the full
 matrix.
 


### PR DESCRIPTION
## Summary

The README was a second manual. It now states what Brig does, the boundary, the support matrix, the Homebrew install, one first run, the main safety limitation and a task index, and links the page that owns each subject.

## Changes

- README.md: 200 to 151 lines, first runnable command in the first section
- docs/README.md: map ordered understand, install, first run, tasks, reference, fix, contribute
- docs/support.md: doctor line list matches the nine lines the command prints
- docs/stability.md: deprecation window points at migration.md instead of repeating it
- Fixed: Linux row omitted the urunc shim; telemetry was attributed to Brig instead of hull

## Checklist

- [x] `make all` passes (vet, test, build)
- [x] `script/smoke.sh` passes
- ~~I have added or updated tests covering the change~~ docs only
- ~~I have run `go test ./... -race`~~ docs only
- ~~I have exercised the change against a real runtime~~ docs only
- [x] I have updated the affected docs