### PR TITLE
docs: Tighten the sessions, runtimes, brigd and non-goals pages

### DIFF
--- a/docs/brigd.md
+++ b/docs/brigd.md
@@ -10,10 +10,10 @@ It is deliberately small, and optional. The CLI has no client for it: every
 absent that is not a problem, never `!!`:
 
 ```
---  brigd     not running (no socket at /Users/pmoust/.brig/brigd.sock)
+--  brigd     not running (no socket at ~/.brig/brigd.sock)
 ```
 
-Run it when something else wants one socket to ask brig through. That is a
+Run it when something else wants one socket to ask Brig through. That is a
 second tool driving several sandboxes from one process, or a client that
 wants boots on one sandbox serialized across several callers. Most people
 never run it.
@@ -97,14 +97,10 @@ each answer to its question. Absent in, absent out:
 
 ### Exit code
 
-Beside `error`, a response carries `code`: the stable exit status `brig`
-returns to a script, the same set and the same causes. A script driving
-brigd branches the way one driving brig does. `0` is success. On failure it
-is one of `1` general, `2` usage (an unknown op, an unknown protocol
-version), or `3` no such profile or sandbox. The rest are `4` a runtime that
-is missing or broken, `5` a boot verification refused, and `6` a credential
-that was not resolved. The full table is at
-[docs/cli.md#exit-codes](cli.md#exit-codes).
+Beside `error`, a response carries `code`. brigd uses the same codes and
+the same causes as `brig` itself, listed at
+[docs/cli.md#exit-codes](cli.md#exit-codes). A script driving brigd
+branches the way one driving `brig` does.
 
 ```json
 {"v":1,"op":"ensure","agent":"no-such-profile"}
@@ -128,9 +124,9 @@ this is a floor, not a nicety.
 
 `running` is re-read from the runtime on every report, rather than taken from
 the inventory. A sandbox stopped by something else is still reported as
-stopped. When the runtime cannot be asked at all -- its binary is gone, a
-permission error, containerd is down -- the session carries `runningError`
-instead. `running` says nothing:
+stopped. Sometimes the runtime cannot be asked at all: its binary is gone,
+a permission error came back, or containerd is down. Then the session
+carries `runningError` instead, and `running` says nothing:
 
 ```json
 {"agent":"claude-code","sandbox":"brig-claude-code","workspace":"/Users/me/brig/claude-code",
@@ -143,7 +139,7 @@ reach never made.
 
 Anything the run says about itself comes back with it, as `warnings`, one
 line each. Examples: a credential that was not forwarded and why, a secret
-about to expire, an image the check did not confirm. The CLI prints these on
+about to expire, an image that did not verify. The CLI prints these on
 the terminal of the person who typed the command. The daemon has no such
 terminal, so they travel to the client that asked, not to brigd's own
 terminal, wherever that is.
@@ -190,8 +186,8 @@ credentials, verifies the image and checks the share, then boots only if
 needed. Work on one sandbox is serialised, so two clients asking for the same
 one at the same moment get one boot rather than two.
 
-The daemon never asks a question. The image check stops to ask when an image
-claiming to be ours fails verification. There is nobody at brigd's terminal
+The daemon never asks a question. Image verification stops to ask when an
+image claiming to be ours fails to verify. There is nobody at brigd's terminal
 to answer: the client is somewhere else, and the sandbox's lock stays held
 across the wait. So a request that needs a prompt is refused
 instead, with the reason and the setting that overrides it in `error`. Setting
@@ -202,9 +198,9 @@ profile carrying `runtimeBin` drives the same binary through the daemon as it
 does through the CLI. A profile naming a binary that is not there fails that
 request and no other.
 
-`status` re-reads liveness from the runtime instead of trusting the inventory.
-A sandbox can be stopped by anything, including a `brig stop` that never went
-through the daemon.
+`status` re-reads liveness from the runtime instead of trusting the
+inventory. A sandbox can be stopped by anything, including a `brig stop`
+that never went through the daemon.
 
 The inventory lives in memory. Restarting brigd forgets which sandboxes it
 started, though the sandboxes themselves keep running and `brig ls` still
@@ -226,7 +222,8 @@ ls`, which reads the runtime directly, shows them throughout.
 ## Stability
 
 The protocol is versioned so a client can tell what it is talking to. It is
-**internal until brig 0.3**: within a version a field can be added, but none
+**internal until Brig 0.3**: within a version a field can be added, but none
 is renamed or removed. A client that ignores unknown fields keeps working. A
-change that breaks such a client becomes a new version (`v: 2`). That is the
-same rule `brig --json` output follows.
+change that breaks such a client becomes a new version (`v: 2`), the same
+rule [docs/cli.md#--json-output](cli.md#--json-output) sets for `--json`
+output.

--- a/docs/non-goals.md
+++ b/docs/non-goals.md
@@ -1,215 +1,234 @@
-# What brig will not do
+# What Brig will not do
 
-brig's shape comes from what it refuses. It delegates every mechanical
-operation to a runtime it does not own, keeps its dependencies to three, needs no
-account, and adds only the things the layer underneath has no concept of. None
-of that was written down as a boundary, so every proposal to cross one arrived
-as a fresh argument with no prior answer. This page is the prior answer.
+Brig's shape comes from what it refuses. Brig delegates every mechanical
+operation to a runtime it does not own. It keeps its dependencies to
+three, needs no account, and adds only the things the layer underneath
+has no concept of. None of that was written down as a boundary, so every
+proposal to cross one arrived as a fresh argument with no prior answer.
+This page is the prior answer.
 
-Each item below is a decision for the next twelve months, so through August
-2027, and each carries the change in circumstances that would reopen it. A
-non-goal with no reopening condition is a grudge rather than a decision, so if
-you think a trigger here has been met, say which one in an issue and the
-discussion starts from there instead of from first principles.
+Each item below is a decision for the next twelve months, through August
+2027. Each one names the change in circumstances that reopens it. A
+non-goal with no reopening condition is a grudge, not a decision. If you
+think a trigger here has been met, say which one in an issue. The
+discussion then starts from there instead of from first principles.
 
-This is not a list of things that would be bad software. Most of them are good
-software somewhere else.
+This is not a list of bad software. Most of these items are good software
+somewhere else.
 
 ## A container runtime, or a VMM
 
-brig boots nothing itself. `hull` boots the microVM on macOS, `nerdctl` over
-containerd does it on Linux, and brig's own work begins after the sandbox is
-running. Owning the boot path would mean owning Virtualization.framework, a
-kernel command line, an image store, a snapshotter and the vulnerability
-surface of all of it, in a tool whose reason to exist is that it handles your
-credentials carefully with three direct dependencies. The four things brig adds on
-top, in the README's "How it works", are the four a runtime has no concept of.
-Everything else in the boot path already works.
+Brig boots nothing itself. See [runtimes.md](runtimes.md) for what does,
+and for the boundary between what Brig decides and what the runtime
+decides.
 
-**Reopens when** a runtime brig can drive refuses upstream to expose something
-the workspace or credential promise needs, and there is no way to get it by
-shelling out. Even then the first move is a patch to that runtime, not a
+Owning the boot path means owning Virtualization.framework, a kernel
+command line, an image store, a snapshotter, and the vulnerability
+surface of all of it. Brig's reason to exist is that it handles your
+credentials carefully, with three direct dependencies. The four things
+Brig adds on top, in the README's "How it works," are the four a runtime
+has no concept of. Everything else in the boot path already works.
+
+**Reopens when** a runtime Brig can drive refuses upstream to expose
+something the guest home or credential promise needs. Shelling out cannot
+get it either. Even then the first move is a patch to that runtime, not a
 runtime of our own.
 
 ## A policy engine with its own rules language
 
-There is a line here, and it is worth being exact about where it falls. A
-profile field the runtime enforces is fine: `network: offline` translated into
-the runtime's own flag is data, brig's job ends at the translation, and the
-guarantee is the runtime's to make. An egress policy is the same shape one
-step up: a document of `allow` and `deny` rules handed to the gateway that
-enforces them, and refused where nothing can ([policies.md](policies.md)).
-The README still lists sbx's `--publish` as "not yet" rather than never, and
-a missing field of that kind is in scope. What is out of scope is a language:
-conditions, matchers, precedence rules and an evaluator that lives in brig. A
-decision brig evaluates is one people will believe is enforced, when in fact
-enforcement sits one layer down and brig can only ask for it.
+There is a line here, worth being exact about. A profile field the
+runtime enforces is fine: `network: offline` translated into the
+runtime's own flag is data. Brig's job ends at the translation, and the
+guarantee is the runtime's to make. An egress policy is the same shape
+one step up: a document of `allow` and `deny` rules handed to the gateway
+that enforces them. It is refused where nothing can enforce it
+([policies.md](policies.md)). A missing field of that kind is in scope.
+What is out of scope is a language: conditions, matchers, precedence
+rules, and an evaluator that lives in Brig. A decision Brig evaluates is
+one people will believe is enforced. In fact, enforcement sits one
+layer down, and Brig can only ask for it.
 
-**Reopens when** profile settings genuinely need to combine conditionally in a
-way plain fields cannot express, *and* every condition in the language has an
-enforcement point in the runtime underneath it. A rule with no enforcement
-point stays out however much it is wanted.
+**Reopens when** profile settings need to combine conditionally in a way
+plain fields cannot express. Every condition in the language must also
+have an enforcement point in the runtime underneath it. A rule with no
+enforcement point stays out, no matter how much it is wanted.
 
 ## A host-side proxy that terminates TLS
 
-Docker's sandboxes keep credentials out of the guest by rewriting auth headers
-in a host-side proxy. brig forwards the credential instead, and
-`docs/security.md` says plainly what that costs. The reason is that a proxy
-only covers proxied HTTP: it does nothing for `git push`, for a vendor CLI
-refreshing its own token, or for an MCP server holding its own connection, and
-those are the operations an agent actually performs. The second reason is that
-the proxy is not free on the host side either. A process that terminates TLS
-for the guest holds every credential in cleartext, on the host, for the life of
-the sandbox, and needs a CA the guest is made to trust. That is a new and
-attractive target in exchange for narrowing an exposure brig already answers a
-different way, with a narrow blast radius: one workspace, one fine-grained
-token.
+Docker's sandboxes keep credentials out of the guest by rewriting auth
+headers in a host-side proxy. Brig forwards the credential instead.
+`docs/security.md` says plainly what that costs. The reason is that a
+proxy only covers proxied HTTP. It does nothing for `git push`, for a
+vendor CLI refreshing its own token, or for an MCP server holding its own
+connection. Those are the operations an agent actually performs.
 
-**Reopens when** the agents people run under brig have a credential surface
-that is entirely HTTP a proxy can see, or a runtime offers a credential broker
-with a per-request hook so the plaintext lives somewhere other than a brig
-process.
+The proxy is not free on the host side either. A process that terminates
+TLS for the guest holds every credential in cleartext, on the host, for
+the life of the sandbox. It also needs a CA the guest is made to trust.
+That is a new and attractive target. In exchange, it narrows an exposure
+Brig already answers a different way, with a narrow blast radius: one
+guest home, one fine-grained token.
+
+**Reopens when** the agents people run under Brig have a credential
+surface that is entirely HTTP a proxy can see. It also reopens when a
+runtime offers a credential broker with a per-request hook, so the
+plaintext lives somewhere other than a Brig process.
 
 ## Remote or Kubernetes operation
 
-brig runs on the machine in front of you, and three of its properties depend on
-that. The workspace is a live host directory, not a copy, which is why there is
-no `cp` verb. Credentials are resolved from your own keychain per invocation.
-On the two profiles that declare a tmpfs, `claude-code` and `claude-desktop`,
-an in-sandbox login lives in guest memory and dies with `brig stop`. On the
-rest it is already on the persisted workspace, like everything else there.
-Point brig at a remote host and the workspace becomes a synchronisation
-problem, and the credential path becomes a transport with its own threat
-model. A login that was meant to stay in memory is now sitting on a machine
-you are not in front of. Kubernetes adds a controller, a custom resource, an
-image pull secret story and a scheduler on top of all that. The remote story that works today is
-the boring one: `ssh` to the host and run brig there.
+Brig runs on the machine in front of you, and three of its properties
+depend on that. The guest home is a live host directory, not a copy,
+which is why there is no `cp` verb. Credentials are resolved from your
+own keychain per invocation. On the two profiles that declare a tmpfs,
+`claude-code` and `claude-desktop`, an in-sandbox login lives in guest
+memory and dies with `brig stop`. On the rest it is already on the
+persisted guest home, like everything else there.
 
-**Reopens when** running the agent on a different machine from the one you edit
-on becomes the common case rather than an occasional one, and a design exists
-that keeps the credential on the operator's machine rather than copying it to
-the remote host.
+Point Brig at a remote host, and the guest home becomes a synchronisation
+problem. The credential path also becomes a transport with its own
+threat model. A login that was meant to stay in memory now sits on a machine
+you are not in front of. Kubernetes adds a controller, a custom resource,
+an image pull secret story, and a scheduler on top of all that. The
+remote story that works today is the boring one: `ssh` to the host and
+run Brig there.
+
+**Reopens when** running the agent on a different machine from the one
+you edit on becomes the common case rather than an occasional one. It
+also needs a design that keeps the credential on the operator's machine,
+rather than copying it to the remote host.
 
 ## A hosted control plane, or any account
 
 There is nothing to sign in to, and that is a feature with a price we are
 willing to pay. Every piece of state is on your disk: profiles in
-`~/.config/brig`, secrets in your login keychain, workspaces in `~/brig`,
-sessions in `brigd`'s inventory. Nothing registers, nothing phones home,
-nothing we run can be down while you are trying to boot a sandbox. An account
-would also widen the security page: brig's threat model would have to include
-our servers, our operators and our outages, and today it does not have to
-mention them at all.
+`~/.config/brig`, secrets in your login keychain, guest homes in `~/brig`,
+sessions in `brigd`'s inventory. Nothing registers, and nothing phones
+home. Nothing we run can be down while you are trying to boot a sandbox.
+An account also widens the security page. Brig's threat model then has
+to include our servers, our operators and our outages, none of which it
+has to mention today.
 
-**Reopens when** a feature people want turns out to be impossible without a
-shared service, and even then it ships as a separate opt-in service rather than
-as a requirement. brig without an account keeps doing everything it does today,
-permanently. That part is not up for review in twelve months or in sixty.
+**Reopens when** a feature people want turns out to be impossible without
+a shared service. Even then it ships as a separate opt-in service rather
+than as a requirement. Brig without an account keeps doing everything it
+does today, permanently. That part is not up for review in twelve months
+or in sixty.
 
 ## SDKs in several languages
 
-A library per language is a release train per language, a dependency set per
-language, and a chance per language to drift behind the CLI, all to wrap a
-process the caller could have spawned. The short dependency list in
-`CONTRIBUTING.md` exists for the tool itself, and the same reasoning applies to
-what we ask users to link into their programs. The commitment instead is a CLI
-disciplined enough not to need wrapping: stable verbs and exit codes, human
-output on stdout, diagnostics on stderr, and a `--json` mode wherever a program
-is the reader rather than a person. Today that mode covers the read verbs --
+A library per language is a release train per language, a dependency set
+per language, and a chance per language to drift behind the CLI. All of
+that to wrap a process the caller can spawn directly. The short
+dependency list in `CONTRIBUTING.md` exists for the tool itself. The same
+reasoning applies to what we ask users to link into their own programs.
+
+The commitment instead is a CLI disciplined enough not to need wrapping.
+It gives stable verbs, exit codes, and human output on stdout with
+diagnostics on stderr. A `--json` mode covers it wherever a program is
+the reader rather than a person. Today that mode covers the read verbs:
 `ls`, `info`, `agent ls`, `agent show`, `agent export`, `agent new`,
-`policy show`, `secret ls` and `doctor` -- and `run` and `sh`, which under
-`--json` report the agent's exit status on one line (`env`, the deprecated
-spelling of `info`, takes it too). More verbs get it as callers need them,
-and asking for one is a small issue rather than an argument. For lifecycle control there is
-already an interface with no library attached: `brigd` speaks line-delimited
-JSON over a unix socket and is documented in [brigd.md](brigd.md).
+`policy show`, `secret ls` and `doctor`. It also covers `run` and `sh`,
+which under `--json` report the agent's exit status on one line. `env`,
+the deprecated spelling of `info`, takes it too. More verbs get it as
+callers need them, and asking for one is a small issue rather than an
+argument. For
+lifecycle control there is already an interface with no library
+attached: `brigd` speaks line-delimited JSON over a unix socket and is
+documented in [brigd.md](brigd.md).
 
 **Reopens when** callers are reimplementing the same non-trivial logic in
-several languages against brig's output, and the cause is something a `--json`
-mode cannot fix, such as a protocol that needs a handshake a shell caller
-cannot perform.
+several languages against Brig's output, and the cause is something a
+`--json` mode cannot fix. An example is a protocol that needs a
+handshake a shell caller cannot perform.
 
 ## A dashboard or a TUI ahead of the CLI
 
 The refusal is in the last three words. `brig ls`, `brig info` and
-`brig agent ls` are how you see what exists, what would be forwarded and what
-each profile refuses, and while any of that is missing from the CLI, adding a
-screen that displays it is building the second floor first. A live interface
-also has to stay in the middle of something, and brig deliberately does not:
-`brig sh` replaces itself with the runtime so `^C` and the exit status are
-the agent's own, which `docs/security.md` explains and accepts the cost of.
+`brig agent ls` are how you see what exists, what will be forwarded, and
+what each profile refuses. While any of that is missing from the CLI,
+adding a screen that displays it is building the second floor first. A
+live interface also has to stay in the middle of something, and Brig
+deliberately does not. `brig sh` replaces itself with the runtime, so
+`^C` and the exit status are the agent's own, a cost
+[docs/security.md](security.md) explains and accepts.
 
-**Reopens when** the CLI covers the whole surface and someone shows a task that
-is genuinely hard to read as text, such as watching several sandboxes at once.
-Such a thing should then be a client of `brigd`'s protocol, so that nothing
-becomes reachable only through a screen.
+**Reopens when** the CLI covers the whole surface and someone shows a
+task that is genuinely hard to read as text. An example is watching
+several sandboxes at once. Such a thing must then be a client of
+`brigd`'s protocol, so that nothing becomes reachable only through a
+screen.
 
 ## Nested containers, or a Docker daemon inside the guest
 
 This one is refused for want of demand rather than on principle. Running
-containers inside the guest needs either nested virtualization or a privileged
-guest, plus a second image store living on host disk inside the workspace, and
-it complicates the model the whole tool is built around: a small, named set
-of host directories is what the agent can reach. That is a real cost, and
-nobody has yet shown it is worth paying.
+containers inside the guest needs either nested virtualization or a
+privileged guest. It also needs a second image store living on host
+disk inside the guest home. That complicates the model the whole tool
+is built around: a small, named set of host directories is what the
+agent can reach. That is a real cost, and nobody has yet shown it is
+worth paying.
 
-**Reopens when** people report the workflows that need it, concretely: a repo
-whose tests bring up containers, a compose file the agent is meant to run. Once
-those exist and a runtime under brig supports them without a privileged guest,
-this becomes an ordinary feature discussion rather than a non-goal.
+**Reopens when** people report the workflows that need it, concretely.
+Examples are a repo whose tests bring up containers, or a compose file
+the agent is meant to run. Once those exist, and a runtime under Brig
+supports them without a privileged guest, this becomes an ordinary
+feature discussion rather than a non-goal.
 
 ## GPU scheduling
 
-Passing a device into a microVM is specific to each hypervisor and each driver,
-and dividing a small number of devices between sandboxes means brig arbitrating
-a resource it does not own, which is the exact category of work it delegates.
-It is also aimed at the wrong place: the agents brig runs are CLIs that call a
-model over the network, so the accelerator that matters is not in your machine.
+Passing a device into a microVM is specific to each hypervisor and each
+driver. Dividing a small number of devices between sandboxes means Brig
+arbitrating a resource it does not own. That is the exact category of
+work it delegates. It is also aimed at the wrong place. The agents Brig
+runs are CLIs that call a model over the network, so the accelerator that
+matters is not in your machine.
 
-**Reopens when** an agent people run under brig does local inference as its
-normal mode. Even then the answer is a profile field naming a device, handed to
-the runtime the way `mem` and `cpus` are. Scheduling across sandboxes stays
-out.
+**Reopens when** an agent people run under Brig does local inference as
+its normal mode. Even then the answer is a profile field naming a device,
+handed to the runtime the way `mem` and `cpus` are. Scheduling across
+sandboxes stays out.
 
 ## Windows
 
-The guest is Linux either way. This is about the host, and a Windows host is
-three new things at once: a runtime path brig does not drive today, a secret
-backend with no relationship to the keychain behaviour `docs/security.md`
-documents in detail, and a filesystem whose case and symlink semantics differ
-from the ones the workspace safety code was written and tested against. That
-code refuses a planted symlink through an `os.Root`, and it is one of the two
-promises, so it does not get ported on the assumption it still holds. The route
-that exists is to run brig on Linux, including a Linux environment hosted on a
+The guest is Linux either way. This is about the host. A Windows host is
+three new things at once. It has a runtime path Brig does not drive
+today. It has a secret backend with no relationship to the keychain
+behaviour `docs/security.md` documents in detail. And it has a filesystem
+whose case and symlink semantics differ from the ones the guest home
+safety code was written and tested against. That code refuses a planted
+symlink through an `os.Root`. It is one of the two promises, so it does
+not get ported on the assumption it still holds. The route that exists is
+to run Brig on Linux. That includes a Linux environment hosted on a
 Windows machine, where the microVM path needs nested virtualization to be
 available.
 
-**Reopens when** there is a Windows-native runtime brig can drive, and someone
-willing to own the secret backend and the workspace path tests on that
-platform, not once but as they change.
+**Reopens when** there is a Windows-native runtime Brig can drive. It
+also needs someone willing to own the secret backend and the guest home
+path tests on that platform, not once but as they change.
 
 ## A plugin system
 
-Loading third-party code into the process that resolves your credentials is
-the thing the short dependency list exists to prevent, and a plugin API also
-turns internal interfaces into a contract we then cannot change. brig is
-already extensible three ways that do not require it. Profiles are data, so
-any Linux CLI in an OCI image runs under brig with a YAML file and no code at
-all. Secrets come from any backend you like, since anything that can put a
-value into brig's store or its environment is a usable source. And `brigd`
-speaks a documented protocol to whatever wants to drive sessions. Where brig
-does use outside code it does so as a subprocess with a defined interface:
-`cosign`, `oras`, `security`.
+Loading third-party code into the process that resolves your credentials
+is the thing the short dependency list exists to prevent. A plugin API
+also turns internal interfaces into a contract we then cannot change.
+Brig is already extensible three ways that do not require it. Profiles
+are data, so any Linux CLI in an OCI image runs under Brig with a YAML
+file and no code at all. Secrets come from any backend you like, since
+anything that can put a value into Brig's store or its environment is a
+usable source. And `brigd` speaks a documented protocol to whatever wants
+to drive sessions. Where Brig does use outside code, it does so as a
+subprocess with a defined interface: `cosign`, `oras`, `security`.
 
-**Reopens when** a kind of extension appears that is none of those three and
-keeps being asked for. The answer then is another subprocess with a defined
-protocol, in the shape of `cosign` and `oras`, rather than code loaded into
-brig's address space.
+**Reopens when** a kind of extension appears that is none of those three
+and keeps being asked for. The answer then is another subprocess with a
+defined protocol, in the shape of `cosign` and `oras`, rather than code
+loaded into Brig's address space.
 
 ## Proposing one of these anyway
 
 Open an issue with the `enhancement` label, name the item, and say which
 trigger you think has been met and what changed. That is a much shorter
-conversation than the general case, which is the point of writing the list
-down. If an item here turns out to be wrong rather than merely early, that is
-worth an issue too: this page is a decision, and decisions get revisited.
+conversation than the general case, which is the point of writing the
+list down. If an item here turns out to be wrong rather than merely
+early, that is worth an issue too. This page is a decision, and decisions
+get revisited.

--- a/docs/runtimes.md
+++ b/docs/runtimes.md
@@ -1,61 +1,65 @@
-# The runtimes brig drives
+# The runtimes Brig drives
 
-brig boots nothing itself. It decides what a sandbox should be and then asks
-another program to make one: `hull` on macOS, `nerdctl` over containerd on
-Linux. Those programs are separate projects with their own repositories,
-releases and licences, and installing brig means installing them too.
+Brig delegates booting to a runtime, `hull` on macOS or `nerdctl` on
+Linux, instead of booting a sandbox itself. See
+[non-goals.md](non-goals.md#a-container-runtime-or-a-vmm) for why.
 
-This page says what each one is, what it is licensed under, what brig asks of
-it, and exactly which commands brig runs against it. If you are deciding
-whether to adopt this stack, the short answer is that on macOS you are taking
-brig and hull, and on Linux you are taking brig plus three projects it does
-not own.
+This page calls `hull` and `nerdctl` runtimes. Under hull, `vz`, `hvi`
+and `qemu` are hypervisor backends, shortened to backend after this first
+use.
+
+If you adopt this stack, on macOS you take on Brig and hull. On Linux
+you take on Brig, plus three projects it does not own: nerdctl,
+containerd and urunc.
 
 ## What you are installing
 
-Licences were read from each repository's `LICENSE` file on 2026-08-26.
+Licences were read from each repository's `LICENSE` file on 2026-08-26,
+and not checked again since. Treat this table as a starting point, not a
+live guarantee.
 
 | component | what it does | where it comes from | licence |
 | --- | --- | --- | --- |
-| `brig`, `brigd` | resolves the profile, the workspace and the credentials, then drives the runtime | this repository | Apache-2.0 |
+| `brig`, `brigd` | resolves the profile, the guest home and the credentials, then drives the runtime | this repository | Apache-2.0 |
 | `hull` | CLI that pulls an OCI image and boots it as a microVM on Apple Silicon | [brig-sh/hull](https://github.com/brig-sh/hull) | Apache-2.0 |
 | `vz-runner` | Swift helper hull launches for its `vz` backend, which is what talks to Virtualization.framework | same repository as hull, installed beside it | Apache-2.0 |
-| `hvi` | separate VM monitor for hull's `hvi` backend, which talks to Hypervisor.framework directly | [brig-sh/hvi-vmm](https://github.com/brig-sh/hvi-vmm), a git submodule of hull, installed beside hull | Apache-2.0 |
-| `nerdctl` | Docker-compatible CLI for containerd, the binary brig drives on Linux | [containerd/nerdctl](https://github.com/containerd/nerdctl) | Apache-2.0 |
+| `hvi` | separate microVM monitor for hull's `hvi` backend, which talks to Hypervisor.framework directly | [brig-sh/hvi-vmm](https://github.com/brig-sh/hvi-vmm), a git submodule of hull, installed beside hull | Apache-2.0 |
+| `nerdctl` | Docker-compatible CLI for containerd, the binary Brig drives on Linux | [containerd/nerdctl](https://github.com/containerd/nerdctl) | Apache-2.0 |
 | `containerd` | daemon underneath nerdctl: it holds the image store and hands each container to a shim | [containerd/containerd](https://github.com/containerd/containerd) | Apache-2.0 |
 | `urunc` | the containerd shim `io.containerd.urunc.v2`, which boots the container as a microVM instead of a process | [urunc-dev/urunc](https://github.com/urunc-dev/urunc) | Apache-2.0 |
-| `cosign` | checks the signature on a guest image before it boots. Optional, and the check degrades to a warning without it | [sigstore/cosign](https://github.com/sigstore/cosign) | Apache-2.0 |
+| `cosign` | verifies the signature on a guest image before it boots. Optional, and verification degrades to a warning without it | [sigstore/cosign](https://github.com/sigstore/cosign) | Apache-2.0 |
 | `oras` | pulls the boot bundle on Linux for a `genericBoot` profile. Optional otherwise | [oras-project/oras](https://github.com/oras-project/oras) | Apache-2.0 |
-| boot bundle | the kernel, `container-initrd` and the in-guest agent that let brig exec into an image built as an ordinary container. Published as an OCI artifact at `ghcr.io/nofireai/hull-assets`, one tag per guest platform | fetched by hull on macOS, by oras on Linux | unconfirmed: signed with keyless cosign, but the repository that builds it is not public and states no licence |
+| boot bundle | the kernel, `container-initrd` and the in-guest agent that let Brig exec into an image built as an ordinary container. Published as an OCI artifact at `ghcr.io/nofireai/hull-assets`, one tag per guest platform | fetched by hull on macOS, by oras on Linux | unconfirmed: signed with keyless cosign, but the repository that builds it is not public and states no licence |
 
-hull is published by the same organisation as brig and exists because brig
-needed it, but it is a usable runtime on its own and its command surface is
-not brig-shaped. nerdctl, containerd and urunc predate brig, are used far
-outside it, and brig is an ordinary caller of all three: it passes flags any
-other caller could pass.
+hull is published by the same organisation as Brig and exists because
+Brig needed it. It is a usable runtime on its own, and its command
+surface is not `brig`-shaped. nerdctl, containerd and urunc predate Brig
+and are used far outside it. Brig is an ordinary caller of all three: it
+passes flags any other caller can pass.
 
 ## The three macOS backends
 
 hull accepts three values for its `--hypervisor` flag: `vz`, `hvi` and
-`qemu`. brig passes through whichever one the profile names, or
+`qemu`. Brig passes through whichever one the profile names, or
 `BRIG_HYPERVISOR` when that is set.
 
-`vz` talks to Virtualization.framework through the `vz-runner` helper. It is
-what brig falls back to when neither the profile nor `BRIG_HYPERVISOR` names a
-backend. brig always passes `--hypervisor` explicitly, so hull's own default
-never decides it. It is also the only
+`vz` talks to Virtualization.framework through the `vz-runner` helper. It
+is what Brig falls back to when neither the profile nor
+`BRIG_HYPERVISOR` names a backend. Brig always passes `--hypervisor`
+explicitly, so hull's own default never decides it. It is also the only
 backend that can show a graphical console, so a `kind: gui` profile is
 refused on `hvi` and `qemu`.
 
-`hvi` talks to Hypervisor.framework directly, through the `hvi` VM monitor.
-It is the only backend that runs a network gateway of its own. An attached
-egress policy and `--network isolated` both refuse to run on anything else.
+`hvi` talks to Hypervisor.framework directly, through the `hvi` microVM
+monitor. It is the only backend that runs a network gateway of its own.
+An attached egress policy and `--network isolated` both refuse to run on
+anything else.
 Six of the eight shipped profiles set `hypervisor: hvi`, so most runs use
 `hvi` rather than the `vz` fallback.
 
 `qemu` is a third value hull accepts. Which framework it uses, if any, and
 what it needs on the host are questions for hull's own documentation.
-Nothing in brig's source answers them.
+Nothing in Brig's source answers them.
 
 `brig doctor`'s `Hypervisor.framework available` line is not a report on any
 of these three backends. It is the pass string of one `kern.hv_support`
@@ -64,10 +68,10 @@ never gates the exit status.
 
 ## Where the boundary sits
 
-brig decides, and the runtime never sees the reasoning:
+Brig decides, and the runtime never sees the reasoning:
 
 - which image, and whether its signature verified (`internal/verify`)
-- which host directory is the workspace, and that it is the guest's home
+- which host directory is the guest home
 - which credentials are resolved, which are denied for billing safety, and
   which are handed in by name rather than by value
 - the sandbox name, memory, CPU count, network mode, pull policy, root
@@ -75,17 +79,17 @@ brig decides, and the runtime never sees the reasoning:
 - on macOS, the kernel and initrd paths for an image that carries no kernel,
   and the gateway address each sandbox takes
 
-The runtime decides everything mechanical: how the image is pulled and stored,
-how the VM is configured and booted, how a command gets into the guest, and
-what a stopped instance means.
+The runtime decides everything mechanical: how the image is pulled and
+stored, and how the sandbox is configured and booted. It also decides
+how a command gets into the guest, and what a stopped instance means.
 
-Nothing is linked in. brig has three direct Go dependencies -- `sigs.k8s.io/yaml`
-for the profiles, `golang.org/x/sys` for the terminal and process calls, and
-`github.com/godbus/dbus/v5` for the Linux secret store -- and every interaction
-below is a subprocess, which is the same rule that applies to `cosign` and
-`oras`.
+Nothing is linked in. Brig has three direct Go dependencies:
+`sigs.k8s.io/yaml` for the profiles, `golang.org/x/sys` for the terminal
+and process calls, and `github.com/godbus/dbus/v5` for the Linux secret
+store. Every interaction below is a subprocess, the same rule that
+applies to `cosign` and `oras`.
 
-## Every command brig runs
+## Every command Brig runs
 
 Taken from the source. On macOS, from `internal/runtime/hull.go` unless another
 file is named:
@@ -119,27 +123,30 @@ hull network-gateway --socket <path> --qemu-socket <path>.qemu
      [--egress-allow <rule>]... [--egress-deny <rule>]...   # carrying a policy
 ```
 
-`hull --version` is the one version brig reads, and it reads it for one
-decision: a hull from 0.1.0-rc23 boots a digest reference from its own store,
-so brig pins the image it verified; an older one boots the tag, and brig says
-so. An unreadable answer counts as pinning. `network-gateway --help` is read
-for one word, `--egress-default`, before a sandbox carrying a policy is
-booted: a gateway that does not take the flag would drop the rules on the
-floor, so brig refuses the run instead.
+`hull --version` is the one version Brig reads, and it reads it for one
+decision. A hull from 0.1.0-rc23 boots a digest reference from its own
+store, so Brig pins the image it verified. An older one boots the tag,
+and Brig says so. An unreadable answer counts as pinning.
+`network-gateway --help` is read for one word, `--egress-default`,
+before a sandbox carrying a policy is booted. A gateway that does not
+take the flag drops the rules on the floor, so Brig refuses the run
+instead.
 
-brig picks that subnet from 198.18.0.0/15, the range RFC 2544 reserves for
-network benchmarking: it is never routed on the public internet and almost
-nothing claims it, so a sandbox network is unlikely to collide with something
-the workspace needs to reach. The alternatives are all crowded -- 10.0.0.0/8 by
-corporate VPNs and cloud VPCs, 172.16.0.0/12 by Docker, 192.168.0.0/16 by home
-routers and by vmnet on macOS, and 100.64.0.0/10 by Tailscale. The sibling
-198.19.0.0/16 is left alone because OrbStack uses it.
+Brig picks that subnet from 198.18.0.0/15, the range RFC 2544 reserves
+for network benchmarking. It is never routed on the public internet and
+almost nothing claims it. A sandbox network is unlikely to collide
+with something you need to reach. The alternatives are all
+crowded: 10.0.0.0/8 by corporate VPNs and cloud VPCs, and 172.16.0.0/12
+by Docker. Home routers and vmnet on macOS use 192.168.0.0/16, and
+Tailscale uses 100.64.0.0/10. The sibling 198.19.0.0/16 is left alone
+because OrbStack uses it.
 
-`hull exec` is the whole exec path: the reachability probe, the captured read,
-the credential written over stdin and the terminal handover all build the same
-argv (`execArgs`), and the handover replaces the brig process with hull so the
-guest gets a real terminal. `hull logs <name>` is what `brig logs <ref>` runs,
-and it is also named in brig's error output when a sandbox will not come up.
+`hull exec` is the whole exec path. The reachability probe, the captured
+read, the credential written over stdin, and the terminal handover all
+build the same argv (`execArgs`). The handover replaces the Brig process
+with hull, so the guest gets a real terminal. `hull logs <name>` is what
+`brig logs <ref>` runs, and it is also named in Brig's error output when
+a sandbox will not come up.
 
 On Linux, from `internal/runtime/nerdctl.go`:
 
@@ -179,50 +186,50 @@ cosign verify --certificate-identity-regexp <identity>
 ```
 
 Every runtime command carries `HULL_TELEMETRY_PRODUCT=brig` and
-`HULL_TELEMETRY_SUPPRESS=1` in its environment, with the suppression lifted
-only for the operations a user asked for, so one brig command counts once.
+`HULL_TELEMETRY_SUPPRESS=1` in its environment. Brig lifts the suppression
+only for the operations a user asked for, so one Brig command counts once.
 `DO_NOT_TRACK` and `HULL_TELEMETRY_DISABLED` pass through untouched and win.
 
 Forwarded values travel in that same environment and only the bare variable
 name goes in argv, so nothing readable in `ps` carries a secret. `BRIG_ENV_ARGV=1`
 puts ordinary values back on the command line for a runtime build that cannot
-take a bare `--env NAME`, and a value brig resolved on your behalf stays off
+take a bare `--env NAME`. A value Brig resolved on your behalf stays off
 the command line even then.
 
-## How brig finds the runtime
+## How Brig finds the runtime
 
 `internal/runtime/runtime.go`, in order:
 
-1. `BRIG_RUNTIME` names the backend, `hull` or `nerdctl`. Anything else is
+1. `BRIG_RUNTIME` names the runtime, `hull` or `nerdctl`. Anything else is
    refused by name. Unset, it is `hull` on macOS and `nerdctl` everywhere else.
-2. `BRIG_RUNTIME_BIN` is the executable to run. A path is taken as it stands
-   and a bare name is looked up on PATH, and either way one that is missing or
+2. `BRIG_RUNTIME_BIN` is the executable to run. A path is taken as it stands,
+   and a bare name is looked up on PATH. Either way, one that is missing or
    not executable is reported against the variable before anything runs.
 3. A profile's `runtimeBin` does the same thing without a variable per shell,
    and loses to `BRIG_RUNTIME_BIN`. A leading `~` is expanded, and a path that
    is missing or not executable is reported against the profile that named it.
-4. Otherwise PATH: `hull` for the hull backend, and `nerdctl` then `docker` for
-   the other one.
+4. Otherwise PATH: `hull` for the hull runtime, and `nerdctl` then `docker`
+   for the other one.
 
-What brig asks the runtime about itself is short. It asks hull where its boot
-assets live (`hull assets dir`), because they sit under hull's own store and a
-path compiled into brig would drift silently; it asks either runtime which
-sandboxes exist and what state they are in (`ps`); and it asks hull two
-capability questions, `hull --version` for digest pinning and
-`network-gateway --help` for policy enforcement, both described above.
-`brig info <ref>` prints what it settled on, as
+What Brig asks the runtime about itself is short. It asks hull where its
+boot assets live (`hull assets dir`). They sit under hull's own
+store, and a path compiled into Brig can drift out of date silently. It asks either
+runtime which sandboxes exist and what state they are in (`ps`). And it
+asks hull two capability questions, `hull --version` for digest pinning
+and `network-gateway --help` for policy enforcement, both described
+above. `brig info <ref>` prints what it settled on, as
 `runtime hull (/opt/homebrew/bin/hull)`, and `brig doctor` reports the
 runtime's version beside the rest of the host.
 
-Neither answer gates the run outright, and that is deliberate: brig degrades
+Neither answer gates the run outright, and that is deliberate: Brig degrades
 one feature at a time rather than refusing an old build. A hull without
-`assets dir` falls back to `~/.hull/assets`, a runtime without `ps -a` falls
+`assets dir` falls back to `~/.hull/assets`. A runtime without `ps -a` falls
 back to the plain listing, and a hull that cannot pin a digest boots the tag
 and says so. The one refusal is a policy on a gateway that cannot enforce it.
-A hull too old for a flag brig passes fails at that flag, with hull's own
+A hull too old for a flag Brig passes fails at that flag, with hull's own
 message.
 
-## What brig requires of each
+## What Brig requires of each
 
 **hull** has to accept the verbs and flags listed above, and three things
 beyond them:
@@ -230,34 +237,35 @@ beyond them:
 - a bare `--env NAME`, taking the value from its own environment. Without it
   the only way to forward a credential is `BRIG_ENV_ARGV=1`, which puts values
   where `ps` can read them.
-- `exec -u root`, which is how brig mounts a tmpfs inside a running sandbox.
+- `exec -u root`, which is how Brig mounts a tmpfs inside a running sandbox.
   Container runtimes get their tmpfs at create time instead
   (`internal/wrap/secretfiles.go`).
 - `network-gateway`, for the `hvi` backend. That backend has no egress of its
-  own, so brig starts one shared gateway and joins every sandbox to it, and
-  hands out the addresses on that network itself. Guests on one gateway share a
-  broadcast domain but cannot address each other: the gateway carries an ARP
-  broadcast between them and does not carry the unicast reply, so neither
-  learns the other's MAC address. See
+  own, so Brig starts one shared gateway and joins every sandbox to it. Brig
+  also hands out the addresses on that network itself. Guests on one gateway
+  share a broadcast domain, but cannot address each other. The gateway
+  carries an ARP broadcast between them and does not carry the unicast
+  reply, so neither learns the other's MAC address. See
   [security.md](security.md#things-brig-does-not-claim) for what that means per
   backend, which is not the same answer on Linux.
 
 Six of the eight shipped profiles ask for `hvi` and set `genericBoot: true`
-(`internal/profile/specs`), so the default macOS path needs the `hvi` binary
+(`internal/profile/specs`). The default macOS path needs the `hvi` binary
 beside hull, a working gateway, and the boot bundle. `BRIG_HYPERVISOR=vz` moves
 to the other backend, and the graphical profile is refused anywhere but `vz`,
 which is the backend with a console.
 
-**nerdctl** has to carry `--annotation` through to the shim, take `--runtime`,
-and honour `-v`, `--tmpfs` and a bare `-e NAME`. `docker` is accepted in its
-place and works for an image that carries its own kernel; a `genericBoot`
-profile is refused on docker rather than attempted, because docker does not
-pass annotations to the runtime and the sandbox would boot without a kernel and
-fail somewhere far from the cause.
+**nerdctl** has to carry `--annotation` through to the shim, take
+`--runtime`, and honour `-v`, `--tmpfs` and a bare `-e NAME`. `docker` is
+accepted in its place and works for an image that carries its own
+kernel. docker does not pass annotations to the runtime, so a
+`genericBoot` profile is refused on it rather than attempted. Without
+the annotations, the sandbox boots with no kernel and fails somewhere
+far from the cause.
 
 **urunc** has to read `com.urunc.unikernel.bootKernel` and
 `com.urunc.unikernel.bootInitrd` from the container's OCI spec and boot the
-image with them. That pair is the entire contract between brig and urunc, and
+image with them. That pair is the entire contract between Brig and urunc, and
 it is the same pair hull takes on its command line.
 
 **containerd** has to be running with the urunc shim installed.
@@ -268,20 +276,20 @@ costs.
 
 ### Versions and pins
 
-brig's source pins no version of hull, nerdctl, containerd or urunc, and
-verifies no digest of any of them. The pin lives on the install path: the hull
-cask in `brig-sh/homebrew-brig` names one release tarball and its sha256, and
-brig's cask depends on that cask, so `brew install --cask brig` gets the exact
-build the tap names. When this page was written that was hull 0.1.0-rc21, and
-hull had newer tags: both casks are hand-written for the prerelease series, so
-read `Casks/hull.rb` for what an install will actually give you.
+Brig's source pins no version of hull, nerdctl, containerd or urunc, and
+verifies no digest of any of them. The pin lives on the install path: the
+hull cask in `brig-sh/homebrew-brig` names one release tarball and its
+sha256. Brig's cask depends on that cask, so `brew install --cask
+brig` gets the exact build the tap names. Both casks are hand-written
+for the prerelease series, so read `Casks/hull.rb` for what an install
+will actually give you.
 
-The boot bundle is the other thing with a digest attached. hull verifies its
-signature with cosign against the publishing workflow before writing it, and
-records the digest it verified; brig delegates the whole fetch to hull on macOS
-for exactly that reason. On Linux the same bundle arrives through `oras` with
-no such check, and `BRIG_BOOT_ASSETS_REF` is how you pin a version or point at a
-mirror.
+The boot bundle is the other thing with a digest attached. hull verifies
+its signature with cosign against the publishing workflow before writing
+it, and records the digest it verified. Brig delegates the whole fetch
+to hull on macOS for exactly that reason. On Linux the same bundle
+arrives through `oras` with no such verification, and
+`BRIG_BOOT_ASSETS_REF` is how you pin a version or point at a mirror.
 
 ## Swapping one out
 
@@ -292,64 +300,68 @@ Cheap swaps, no code:
 - docker instead of nerdctl: it is already in the PATH search, with the
   `genericBoot` limitation above.
 - a different containerd shim: `BRIG_CONTAINERD_RUNTIME`. Anything that reads
-  the two boot annotations replaces urunc without brig noticing. The envelope's
-  `ISOLATION` row names the shim you put there, and calls the boundary unknown
+  the two boot annotations replaces urunc without Brig noticing. The envelope's
+  `ISOLATION` row names the shim you put there. It calls the boundary unknown
   rather than a microVM for any shim other than urunc's own that it cannot
   place.
 - a different hypervisor backend under hull: `BRIG_HYPERVISOR`, or
   `hypervisor:` in a profile.
 
 Replacing hull or nerdctl entirely is a code change, not a setting.
-`BRIG_RUNTIME` accepts those two words and nothing else, so a third backend
-means implementing the `Runtime` interface in `internal/runtime/runtime.go`
-(kind, binary, running, list, run, probe, output, feed, replace, stop, remove,
-logs hint) and adding a case to `DetectFor`. The interface is the whole of what
-brig needs from a runtime, which is the useful part of the answer: if hull
-stopped tomorrow, what would have to be rebuilt is a program that boots an OCI
-image as a VM and can exec into it, not anything about workspaces, credentials
-or profiles. Those live above the seam and are written once for both operating
-systems.
+`BRIG_RUNTIME` accepts those two words and nothing else. A third
+runtime means implementing the `Runtime` interface in
+`internal/runtime/runtime.go`, and adding a case to `DetectFor`. That
+interface lists kind, binary, running, list, run, probe, output, feed,
+replace, stop, remove, and logs hint. It is the whole of what Brig needs
+from a runtime, which is the useful part of the answer. If hull stopped
+tomorrow, what needs rebuilding is a program that boots an OCI image as
+a microVM and can exec into it. Nothing about guest homes, credentials
+or profiles needs to change. Those live above the seam and are written
+once for both operating systems.
 
-### What is shared, and what is brig's alone
+### What is shared, and what is Brig's alone
 
 Shared with other projects: containerd, nerdctl and urunc, none of which know
-brig exists. cosign and oras likewise.
+Brig exists. cosign and oras likewise.
 
-Shared between brig and hull: the boot bundle, the on-disk layout it lands in,
+Shared between Brig and hull: the boot bundle, the on-disk layout it lands in,
 and the two annotation names. A machine that has run either runtime has already
 seeded the other.
 
 hull, `vz-runner` and `hvi` exist for this stack, though hull is a general
-microVM runtime and does not depend on brig.
+microVM runtime and does not depend on Brig.
 
-brig's alone: profiles, the secret store and its provenance records, the
-credential forwarding rules, the billing denylist, the workspace-as-home
-contract, image verification policy and `brigd`.
+Brig's alone: profiles, the secret store and its provenance records, the
+credential forwarding rules, and the billing denylist. Also alone: the
+guest home contract, image verification policy and `brigd`.
 
 ## Building hull from source on macOS
 
-A from-source hull cannot boot a VM unless it is signed with an Apple identity.
-This is the requirement that surprises people, so it is worth being exact about
-it.
+Skip this section unless you are working on hull itself.
 
-The backends do not talk to the hypervisor themselves. `vz-runner` does, and it
-needs the `com.apple.security.virtualization` entitlement; `hvi` talks to
-Hypervisor.framework instead and needs `com.apple.security.hypervisor`. macOS
-honours an entitlement only on a binary signed with a real Apple identity, an
-Apple Development or Developer ID Application certificate. An ad-hoc signature
-(`codesign --sign -`) gets the entitlement honoured only with AMFI disabled,
-which means disabling SIP and setting a boot argument. Copying an entitled
-binary strips its signature, so it has to be re-signed after every build and
-every copy.
+A from-source hull cannot boot a microVM unless it is signed with an
+Apple identity. This is the requirement that surprises people, so it is
+worth being exact about it.
+
+The backends do not talk to the hypervisor themselves. `vz-runner` does,
+and it needs the `com.apple.security.virtualization` entitlement. `hvi`
+talks to Hypervisor.framework instead and needs
+`com.apple.security.hypervisor`. macOS honours an entitlement only on a
+binary signed with a real Apple identity, an Apple Development or
+Developer ID Application certificate. An ad-hoc signature
+(`codesign --sign -`) gets the entitlement honoured only with AMFI
+disabled, which means disabling SIP and setting a boot argument. Copying
+an entitled binary strips its signature, so it has to be re-signed after
+every build and every copy.
 
 hull's `make macos` builds and signs all three binaries when given a
-`CODESIGN_IDENTITY`, and its README documents the entitlement plists. Since the
-shipped brig profiles ask for the `hvi` backend, a from-source build needs the
-`hvi` binary signed too, not only `vz-runner`.
+`CODESIGN_IDENTITY`, and its README documents the entitlement plists.
+Since the shipped Brig profiles ask for the `hvi` backend, a from-source
+build needs the `hvi` binary signed too, not only `vz-runner`.
 
 The released hull is signed, notarized and stapled, so
-`brew install --cask brig` gives you a runtime that boots without any of this.
-That is the path to prefer unless you are working on hull itself.
+`brew install --cask brig` gives you a runtime that boots without any of
+this.
 
-Building brig from source needs none of it. brig holds no entitlement and
+Building Brig from source needs none of it. Brig holds no entitlement and
 drives whatever hull it finds.

--- a/docs/sessions.md
+++ b/docs/sessions.md
@@ -1,23 +1,26 @@
 # Sessions, homes and projects
 
-A `brig run` or `brig sh` line names a session: an agent, optionally a
-label, and optionally a project. This page explains what each of those
-words means, what brig keeps separate per session, and what survives which
-command. [quickstart.md](quickstart.md) is the walkthrough. This page is
-the reference underneath it.
+[quickstart.md](quickstart.md) is the walkthrough. This page is the
+reference underneath it.
 
 ## The ref
 
-Every verb takes a ref, `<agent>` or `<agent>@<label>`. An empty label
-means the agent's default session, so `claude` and `claude@refactor` are
-two independent sessions of one agent. Each gets its own guest home and
-its own sandbox.
+Every ref is `<agent>` or `<agent>@<label>`. An empty label means the
+agent's default session, so `claude` and `claude@refactor` are two
+independent sessions of one agent. Each gets its own guest home and its own
+sandbox.
 
 `claude` and `desktop` are aliases, resolved to the built-in agents
-`claude-code` and `claude-desktop`. Those are the only two aliases brig
+`claude-code` and `claude-desktop`. Those are the only two aliases Brig
 resolves. A real agent always wins over an alias. If you create a profile
 of your own literally named `claude`, it takes the word outright. The
 built-in `claude-code` is then reachable only by its full name.
+
+A label always picks the guest home and the sandbox name, for every agent.
+Reaching the agent itself as a display name is narrower. Brig passes the
+label to the agent only when the resolved profile is literally
+`claude-code`. It does that only on `brig run`, never on `brig sh`. No
+other profile, not even `claude-desktop`, receives it this way.
 
 ## The guest home
 
@@ -34,9 +37,9 @@ inside it. The guest home is host-backed. It is an ordinary directory on
 your disk, and it survives every command this page covers, until you
 remove it by hand.
 
-`brig info` and `brig ls` both call this directory `WORKSPACE` in their own
-output. This page calls it the guest home everywhere else. They are the
-same thing under two names, one brig's internal label and one this page's.
+`brig ls` and `brig info` both print this directory as `WORKSPACE`, and the
+`BRIG_WORKSPACE` environment variable names it too. Both are the CLI's
+labels for the guest home, the term this page uses everywhere else.
 
 ## The project
 
@@ -46,14 +49,14 @@ Name a directory on the run line:
 brig run claude ~/code/demo
 ```
 
-brig mounts `~/code/demo` read-write at `/work/demo`, and the agent starts
-there. Name no project, and brig remounts whatever this session last ran
+Brig mounts `~/code/demo` read-write at `/work/demo`, and the agent starts
+there. Name no project, and Brig remounts whatever this session last ran
 with, read back from its session index. `--no-project` mounts none.
 `--no-project` is refused alongside a project named on the same line, and
 refused on every verb but `run`.
 
 Run the same session against a different project than it last used, and
-brig recreates the sandbox. It warns you, stops the running sandbox,
+Brig recreates the sandbox. It warns you, stops the running sandbox,
 removes it, and starts a new one with the new project mounted. A mount
 cannot be attached to a live guest. The same recreate happens the first
 time you name a project on a session that had none, and when
@@ -69,32 +72,32 @@ restart warning.
 
 Four things can hold state for a session. They are the guest home on host
 disk, a memory-backed mount inside the guest, the sandbox itself, and what
-brig recorded about the session. Only two of the eight built-in agents,
+Brig recorded about the session. Only two of the eight built-in agents,
 `claude-code` and `claude-desktop`, declare a memory-backed mount at all.
 For the other six, `codex`, `cursor`, `gemini`, `grok`, `opencode` and
 `ubuntu`, the whole guest home is the host-backed share above. An in-guest
 login for those agents lands on host disk and survives every stop.
 
-| Event | Guest home | Memory-backed mount (`claude-code`, `claude-desktop`) | The sandbox | What brig recorded |
+| Event | Guest home | Memory-backed mount (`claude-code`, `claude-desktop`) | The sandbox | What Brig recorded |
 | --- | --- | --- | --- | --- |
 | The agent exits | kept | kept, the sandbox is still up | still running | unchanged |
-| `brig stop` | kept | gone with the VM | stopped, still named in `brig ls` | kept |
+| `brig stop` | kept | gone with the sandbox | stopped, still named in `brig ls` | kept |
 | `brig rm` | kept | gone | removed | dropped |
 | `brig rm --all` | kept, every session | gone | every sandbox removed | dropped, every session |
 | A host reboot | kept, an ordinary host directory | gone, guest memory cannot survive a reboot | the runtime's own business, not established here | kept as host files |
 
-`brig stop` keeps the sandbox's name, its row in `brig ls`, and what brig
+`brig stop` keeps the sandbox's name, its row in `brig ls`, and what Brig
 recorded about the session. `brig rm` drops the last of those too. Neither
 touches the guest home.
 
 A host reboot cannot take your work: the guest home is a host directory,
-and what brig recorded is host files. It does take everything inside the
+and what Brig recorded is host files. It does take everything inside the
 sandbox, including a `claude-code` login that had landed on memory.
 Whether the sandbox itself is still listed afterward is the runtime's own
 business. If it has gone, the next `brig ls` forgets it, and the next run
 boots a new one.
 
-brig keeps its own bookkeeping, the session index among it, under
+Brig keeps its own bookkeeping, the session index among it, under
 `~/.brig`. That layout is not a stable interface: do not build a script
 against its files directly.
 
@@ -103,12 +106,9 @@ against its files directly.
 A label is turned into a slug: lowercased, and every character outside
 `[A-Za-z0-9._-]` replaced with a dash. Runs of dashes are collapsed, and
 leading and trailing dots and dashes are trimmed. Nothing is shortened.
-Lowercasing matters because macOS filesystems are case-insensitive.
-Without it, `Foo` and `foo` name two different sandboxes that collide on
-one directory.
 
 The `<agent>@<label>` form is strict. If a label is not already its own
-slug, brig refuses it and names the slug it maps to, instead of rewriting
+slug, Brig refuses it and names the slug it maps to, instead of rewriting
 it for you. It also refuses more than one `@`, a ref naming no agent, a
 trailing `@` with no label, and a label with no usable characters. A
 label that names another agent's own default session is refused too.
@@ -117,14 +117,6 @@ The retiring `--name` flag is the lenient spelling. It sanitizes the name
 itself and warns which directory it actually used, so `--name "Refactor
 Sprint"` becomes `refactor-sprint` with a warning, not a refusal. Only the
 `@` form insists you already typed the slug.
-
-## The label and the agent's own display name
-
-A label always picks the guest home and the sandbox name, for every
-agent. Reaching the agent itself as a display name is narrower. brig
-passes the label to the agent only when the resolved profile is literally
-`claude-code`, and only on `brig run`, never on `brig sh`. No other
-profile, not even `claude-desktop`, receives it this way.
 
 ## Printing the ref
 


### PR DESCRIPTION
## Summary

Same facts, fewer words, one term per concept.

## Changes

- docs/sessions.md: label design rationale removed, rule and refusal kept
- docs/runtimes.md: runtime versus hypervisor backend stated once; stale hull rc21 number dropped; from-source section flagged as hull-only
- docs/brigd.md: exit codes link cli.md instead of repeating the table
- docs/non-goals.md: reference to a removed README table deleted

## Checklist

- [x] `make all` passes (vet, test, build)
- [x] `script/smoke.sh` passes
- ~~I have added or updated tests covering the change~~ docs only
- ~~I have run `go test ./... -race`~~ docs only
- ~~I have exercised the change against a real runtime~~ docs only
- [x] I have updated the affected docs