### PR TITLE
docs: State the security boundary as three lists and trim the rest

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,6 +1,6 @@
 # Security policy
 
-brig exists to hold a boundary. An agent gets one directory and the credentials
+Brig exists to hold a boundary. An agent gets one directory and the credentials
 it was named, and nothing else on the host. Anything that weakens that boundary,
 or that reaches something the agent was never given, belongs here rather than in
 a public issue.
@@ -11,13 +11,13 @@ you.
 
 ## Supported versions
 
-There is no stable release yet. brig ships prereleases only, currently the
+There is no stable release yet. Brig ships prereleases only, currently the
 `0.1.0-rc` series, and the version you are on is whatever `brig version`
 prints. Fixes land on `main` and go out in the next prerelease. We do not
-backport to an earlier `rc`, so the supported version is the latest one: if you
-are reporting against an older prerelease, please check that the issue still
-reproduces on the newest before you send it, and expect the fix to arrive as a
-newer prerelease rather than a patch to the one you filed against.
+backport to an earlier `rc`, so the supported version is the latest one. If
+you are reporting against an older prerelease, check that the issue still
+reproduces on the newest before you send it. Expect the fix to arrive as a
+newer prerelease, not as a patch to the one you filed against.
 
 ## Reporting a vulnerability
 
@@ -28,15 +28,16 @@ https://github.com/brig-sh/brig/security/advisories
 
 That opens a private thread visible only to you and the maintainers, so nothing
 is disclosed while we work on a fix. Please do not open a public issue for a
-security problem, and do not send a pull request that reveals the flaw before an
+security problem. Do not send a pull request that reveals the flaw before an
 advisory exists.
 
-If you would rather use email, write to **security@brig.sh** instead. Both reach
-the same people.
+To use email instead, write to **security@brig.sh**. Both reach the same
+people.
 
-Include what you would want if you were fixing it: the version from
-`brig version`, the operating system and runtime (hull on macOS, nerdctl or
-runc on Linux), what you did, what happened, and what you expected instead. A
+Include what a fix needs: the version from `brig version`, the operating
+system, and the runtime. Name the runtime as hull on macOS, nerdctl with the
+urunc shim on Linux, or runc when `BRIG_CONTAINERD_RUNTIME=runc` is set.
+Also include what you did, what happened, and what you expected instead. A
 proof of concept helps, even a rough one.
 
 ## What to expect
@@ -54,24 +55,32 @@ back inside the response window, send a reminder to security@brig.sh.
 
 ## Scope
 
-In scope is anything that breaks a promise brig actually makes: a run that
-reaches a host credential it was not given or a file outside the workspace, a
-credential that leaks off the intended channel, the secret store handing back an
-item it should not, image verification passing something it should reject, or a
-tampered release verifying as genuine. `CONTRIBUTING.md` calls the first two the
-two promises, and `docs/security.md` is where the exact edges of all of them are
-written down.
+In scope is anything that breaks a promise Brig actually makes:
 
-Out of scope are the limitations brig already declares. `docs/security.md` lists
-them under
-[Things brig does not claim](docs/security.md#things-brig-does-not-claim): brig
-does not sandbox the agent from the network by default, does not isolate one
-sandbox from another under the default shared network (`--network isolated`
-and `--network offline` are the postures that do), does not filter terminal
-escape sequences the agent writes, and does
-not stop an agent misusing a credential it was deliberately handed. A report
-that brig does one of those is describing a known limitation, not a
+- a run that reaches a host credential it was not given, or a file outside
+  the guest home
+- a credential that leaks off the intended channel
+- the secret store handing back an item it must not
+- image verification passing something it must reject
+- a tampered release verifying as genuine
+
+`CONTRIBUTING.md` calls the first two the two promises. `docs/security.md`
+is where the exact edges of all of them are written down.
+
+Out of scope are the limitations Brig already declares. `docs/security.md`
+lists them under
+[Things brig does not claim](docs/security.md#things-brig-does-not-claim):
+
+- Brig does not sandbox the agent from the network by default
+- Brig does not isolate one sandbox from another under the default shared
+  network (`--network isolated` and `--network offline` are the postures
+  that do)
+- Brig does not filter terminal escape sequences the agent writes
+- Brig does not stop an agent misusing a credential it was deliberately
+  handed
+
+A report that Brig does one of those is describing a known limitation, not a
 vulnerability. That page is the authority on the boundary, so we point at it
 here rather than restate it, which keeps the two from drifting apart. If you
-think one of those limitations is worse than the page admits, or the page is
-wrong about where a line sits, that is worth a report.
+think one of those limitations is worse than the page admits, that is worth
+a report. The same is true if the page is wrong about where a line sits.

--- a/docs/policies.md
+++ b/docs/policies.md
@@ -1,14 +1,14 @@
 # Networking and egress policy
 
-By the end of this page you can read the three network postures a sandbox
-runs under. You can also write an egress policy, bind it to a profile or
-one session, and check where brig actually enforces it.
+A sandbox runs under one of three network postures. You can bind an
+egress policy to a profile, or to one session, on top of that.
 
-Policy enforcement needs hull's `hvi` backend, which needs macOS 15 or
-newer, and a hull newer than 0.1.0-rc21. On every other backend, including
-every Linux runtime, brig refuses a policy-bound boot rather than running it
-unenforced. A run with `--network offline` is the exception: it reaches no
-network at all, so it satisfies any egress rule and is never refused. See [Where a policy is enforced](#where-a-policy-is-enforced-and-where-it-is-not).
+An egress policy is enforced only on hull's `hvi` backend, which needs macOS
+15 or newer and a hull newer than 0.1.0-rc21. Every other runtime, including
+every Linux runtime, refuses to boot a policy it cannot enforce. The one
+exception is `--network offline`: it reaches no network at all, so it
+satisfies any egress rule and is never refused. See
+[Where a policy is enforced, and where it is not](#where-a-policy-is-enforced-and-where-it-is-not).
 
 ## Network postures
 
@@ -25,14 +25,13 @@ brig run claude --network isolated
 | --- | --- |
 | `shared` | one network for every sandbox on the host. The default |
 | `isolated` | a network of this sandbox's own |
-| `offline` | no route out. The agent runs, the workspace is mounted, nothing leaves |
+| `offline` | no route out. The agent runs, the guest home is mounted, nothing leaves |
 
-`shared` is a shared network in name, not in reach. On both macOS backends,
-sandboxes on it cannot reach each other. An ARP broadcast from one guest
-crosses to the other, but the reply does not cross back, so neither guest
-ever learns the other's address. On Linux, sandboxes on the shared network
-can reach each other. `brig info` prints the posture as one of these three
-lines:
+`shared` is a shared network in name, not in reach. Sandboxes on it cannot
+reach each other on either macOS backend, but they can reach each other on
+Linux. See the per-backend table in
+[security.md](security.md#things-brig-does-not-claim) for how that was
+measured. `brig info` prints the posture as one of these three lines:
 
 ```
 NETWORK      shared (one network for every sandbox on this host)
@@ -41,13 +40,13 @@ NETWORK      offline (no egress)
 ```
 
 `isolated` needs the `hvi` backend on macOS. `vz` and `qemu` take their
-network from vmnet, which brig does not own, so brig refuses `--network
+network from vmnet, which Brig does not own, so Brig refuses `--network
 isolated` there. On Linux, nerdctl creates a network per sandbox for
 `isolated`, so the posture works on any Linux host.
 
 Binding an egress policy to a sandbox forces the `isolated` posture, whether
 or not `--network` asked for it. See
-[Where a policy is enforced](#where-a-policy-is-enforced-and-where-it-is-not).
+[Where a policy is enforced, and where it is not](#where-a-policy-is-enforced-and-where-it-is-not).
 
 An unrecognized value refuses the run rather than picking a posture nobody
 asked for, and names where the value came from:
@@ -69,11 +68,9 @@ brig policy create locked-down   # writes ~/.config/brig/policies/locked-down.ya
 brig policy edit locked-down     # change the rules
 ```
 
-This page covers the document, the commands that manage it, and binding it
-to a profile or a session. A bound policy is enforced on the `hvi` backend,
-at the network gateway brig gives that sandbox. A run on a backend that
-cannot enforce one is refused rather than left unconstrained. See
-[Where a policy is enforced](#where-a-policy-is-enforced-and-where-it-is-not).
+See
+[Where a policy is enforced, and where it is not](#where-a-policy-is-enforced-and-where-it-is-not)
+for what a bound policy actually gets you.
 
 ## Where policies live
 
@@ -85,7 +82,7 @@ absoluteness. This follows the
 [XDG Base Directory Specification, version 0.8](https://specifications.freedesktop.org/basedir/latest/):
 an empty or relative `$XDG_CONFIG_HOME` counts as unset.
 
-The directory starts empty, and brig never writes there unless you ask it
+The directory starts empty, and Brig never writes there unless you ask it
 to. `brig policy create` and `brig policy edit` are the only commands that
 write to it.
 
@@ -119,7 +116,7 @@ egress:
 | `desc` | no | One line, shown by `brig policy ls` |
 | `egress.default` | yes | `allow` or `deny`, applied to any traffic neither list below names |
 | `egress.allow` | no | Exceptions to a `deny` default |
-| `egress.deny` | no | A host or range to refuse regardless. At the gateway that enforces the rules, `deny` takes priority over `allow` and over `default`. brig applies no priority of its own: it passes every rule through as a flag. See [Where a policy is enforced](#where-a-policy-is-enforced-and-where-it-is-not) |
+| `egress.deny` | no | A host or range to refuse regardless. At the gateway that enforces the rules, `deny` takes priority over `allow` and over `default`. Brig applies no priority of its own: it passes every rule through as a flag. See [Where a policy is enforced](#where-a-policy-is-enforced-and-where-it-is-not) |
 
 Each entry in `allow` or `deny` names exactly one of `host:` or `cidr:`. Both,
 or neither, is refused. `host:` is a domain, or a glob such as
@@ -172,7 +169,7 @@ brig: name "no" reads as false when written unquoted in YAML, not as itself; pic
 | `brig policy rm <name> [--force]` | delete it. Refuses one that is bound to anything, inline or attached, unless `--force` |
 | `brig policy attach <policy> <profile> [-n NAME]` | bind it to every run of a profile, or, with `-n`, to one session by name instead |
 | `brig policy detach <policy> <profile> [-n NAME]` | reverse an attach |
-| `brig policy check <profile> [-n NAME]` | list what is effectively bound to a run of the profile (or `-n` session), and report whether brig can enforce anything against it at all |
+| `brig policy check <profile> [-n NAME]` | list what is effectively bound to a run of the profile (or `-n` session), and report whether Brig can enforce anything against it at all |
 
 Complete command lines for all eight:
 
@@ -210,10 +207,9 @@ $ brig policy attach locked-down ubuntu
 brig: cannot attach locked-down to ubuntu: ubuntu is kind: shell, which has no agent to hook an egress rule into. Nothing was written
 ```
 
-Both `attach` and `check` print that last line, because "attached" and a
-`check` that prints a policy name both read as a rule in force everywhere.
-Where it is in force depends on the backend the run lands on. See
-[Where a policy is enforced](#where-a-policy-is-enforced-and-where-it-is-not).
+Both `attach` and `check` print that last line. "attached" and a
+`check` that prints a policy name can both read as a rule already in force.
+See [Where a policy is enforced, and where it is not](#where-a-policy-is-enforced-and-where-it-is-not).
 It goes to stderr, where this CLI puts every advisory, so stdout stays the
 command's answer. Both commands print the same constant from
 `internal/policy`, so the two cannot drift into saying different things.
@@ -245,16 +241,16 @@ no policy applies to ubuntu
 brig: cannot enforce any policy on ubuntu: ubuntu is kind: shell, which has no agent to hook an egress rule into
 ```
 
-"Whether brig can enforce it" means exactly two structural checks. Is the
-profile `kind: shell` or `kind: gui`? Nothing can ever enforce a policy
-against either. Does every bound name still resolve to a policy that
-loaded?
+"Whether Brig can enforce it" means exactly two structural checks. The
+first is whether the profile is `kind: shell` or `kind: gui`. Neither of
+those can ever enforce a policy. The second is whether every bound name
+still resolves to a policy that loaded.
 
 `check` does not resolve the current runtime, the current hypervisor, or
 the runtime's version. It cannot tell you whether the host you are on
-right now will boot the run or refuse it. That answer only appears at boot
-time, from the checks in
-[Where a policy is enforced](#where-a-policy-is-enforced-and-where-it-is-not).
+right now will boot the run or refuse it. See
+[Where a policy is enforced, and where it is not](#where-a-policy-is-enforced-and-where-it-is-not)
+for the checks that answer that.
 
 `--force` on `rm`, or on a rename, can leave a binding pointing at a name
 nothing loads under any more:
@@ -278,7 +274,7 @@ locked-down     only Anthropic's API and one internal range
 ```
 
 "not loaded" rather than "no such policy", because there are two ways to
-get there, and brig cannot always tell them apart. Either nothing declares
+get there, and Brig cannot always tell them apart. Either nothing declares
 that name, or the file that declares it did not parse. In that second case
 the file and its parse error are named separately on stderr.
 
@@ -418,13 +414,13 @@ removed /home/you/.config/brig/policies/locked-down.yaml
 
 ## Errors you are likely to meet
 
-| what brig says | what happened |
+| what Brig says | what happened |
 | --- | --- |
 | ``unknown policy "x". `brig policy ls` lists them`` | `show`, `edit` or `rm` on a name that is not there |
 | `name "x" may use only lowercase letters, digits, dot, dash and underscore, and must start with a letter or digit` | see [Naming a policy](#naming-a-policy) |
 | `name "x" reads as false when written unquoted in YAML, not as itself; pick a different name` | the name is a bare YAML boolean, null or number word. See [Naming a policy](#naming-a-policy) |
-| `<path> already exists. Edit it directly with brig policy edit x, or pass --force to replace it with a fresh starter` | `create` on a name whose file is already there |
-| `policy "x" already exists, declared in <path>. Edit it directly with brig policy edit x, or remove that file first` | `create` on a name a *different* file already declares. `--force` does not help here |
+| ``<path> already exists. Edit it directly with `brig policy edit x`, or pass --force to replace it with a fresh starter`` | `create` on a name whose file is already there |
+| ``policy "x" already exists, declared in <path>. Edit it directly with `brig policy edit x`, or remove that file first`` | `create` on a name a *different* file already declares. `--force` does not help here |
 | `a rule needs host: or cidr:` | a rule in `allow:`/`deny:` named neither |
 | `a rule takes host: or cidr:, not both …` | a rule named both |
 | `cidr "x" is not a valid CIDR: …` | a typo in a `cidr:` value, such as a missing octet |
@@ -446,7 +442,7 @@ Read from the source rather than assumed: the default egress stance is
 allow everything, with no filtering applied at all. It is not a deny-all
 default, and it is not an empty allow list either. A sandbox nobody
 attached a policy to has unrestricted egress, exactly as it did before any
-of this existed. No profile brig ships binds a policy, and `brig run
+of this existed. No profile Brig ships binds a policy, and `brig run
 <agent>` on a fresh install filters nothing. No gateway is given a rule
 until a policy is attached to that profile or that session by hand.
 
@@ -465,9 +461,9 @@ first is what you get. The second is what you ask for.
 ## Where a policy is enforced, and where it is not
 
 Exactly one backend can enforce an egress policy: hull's `hvi` backend, at
-the user-mode network gateway brig gives that sandbox. `vz` and `qemu` take
+the user-mode network gateway Brig gives that sandbox. `vz` and `qemu` take
 their network from vmnet, and every Linux runtime takes its network from
-the container network. Neither of those is something brig filters.
+the container network. Neither of those is something Brig filters.
 
 On the `hvi` backend, a boot reads every policy bound to the run and puts
 the rules on the network gateway it gives that sandbox. That gateway is the
@@ -477,7 +473,7 @@ Measured in a real guest in
 allowed name reaches, a denied name does not resolve, and an address
 dialled directly does not connect.
 
-On every backend that cannot enforce a policy, brig refuses the boot rather
+On every backend that cannot enforce a policy, Brig refuses the boot rather
 than running unenforced. `vz`, `qemu` and every Linux runtime refuse a
 filtered run outright, naming the backend that does enforce. Refusing it
 beats booting a sandbox that reports a policy and filters nothing. There is
@@ -487,13 +483,13 @@ set, regardless of who is watching.
 
 That refusal is checked before anything starts, and again on the path that
 finds the sandbox already running. A policy cannot be waved through by the
-accident of the sandbox being up already. Every runtime brig ships refuses
-a policy it cannot enforce. This is a guarantee about the runtimes brig
+accident of the sandbox being up already. Every runtime Brig ships refuses
+a policy it cannot enforce. This is a guarantee about the runtimes Brig
 ships today, not a property of the interface. A runtime that never answers
 the question is never asked, and stays unrefused.
 
 The runtime has to be new enough, too. The gateway's `--egress-*` flags
-arrived after hull 0.1.0-rc21. brig probes the binary itself, `<bin>
+arrived after hull 0.1.0-rc21. Brig probes the binary itself, `<bin>
 network-gateway --help`, rather than checking a version number. The exact
 release does not matter: a hull newer than 0.1.0-rc21 works. An older one
 is refused by name once a policy applies to the run:
@@ -507,7 +503,7 @@ brig: a policy applies to this sandbox, but hull cannot enforce one (its network
 ```
 
 This probe has a gap, worth stating plainly rather than hiding. If the
-probe command itself fails to run, brig draws no conclusion from that
+probe command itself fails to run, Brig draws no conclusion from that
 failure, and the boot proceeds anyway. The reasoning is that a runtime too
 broken to print its own help produces a clearer error later in the boot.
 But the probe cannot tell a broken binary from one that exits non-zero on
@@ -515,13 +511,13 @@ But the probe cannot tell a broken binary from one that exits non-zero on
 fails open. A policy can reach a gateway that does not take the flags,
 with no refusal from this check first.
 
-Three properties worth stating outright:
+Binding a policy has these properties:
 
 - **The rules are fixed when the sandbox boots.** They go on the gateway's
   command line and it reads them once. Editing a policy changes what the
   next boot enforces, and no environment variable overrides a running
   gateway's rules. A sandbox that is already up when the rules change does
-  not keep running under the old ones. brig detects the mismatch, stops,
+  not keep running under the old ones. Brig detects the mismatch, stops,
   removes and reboots the sandbox, and warns that any other session on it
   will be disconnected.
 - **A policy takes the network posture with it.** Rules belong to a
@@ -539,15 +535,15 @@ Three properties worth stating outright:
 
 ### What this does not do yet
 
-`attach` and `check` refuse what brig knows it cannot enforce at all (a
+`attach` and `check` refuse what Brig knows it cannot enforce at all (a
 `kind: shell`/`kind: gui` profile), and a name bound to nothing. Neither
 inspects the rules a policy contains. Neither can tell you that an `allow`
 glob matches nothing you meant. They can only tell you that the document
 parses.
 
 Deny-over-allow-over-default ordering, and the host-rule behavior below,
-are the enforcing gateway's documented behavior, not something brig
-verifies itself. brig's own merge applies no priority. It concatenates the
+are the enforcing gateway's documented behavior, not something Brig
+verifies itself. Brig's own merge applies no priority. It concatenates the
 `allow` and `deny` lists from every bound policy. Each rule reaches the
 gateway as an `--egress-allow` or `--egress-deny` flag on its command
 line.
@@ -559,7 +555,7 @@ denied name fails to resolve, and an address dialled directly fails to
 connect. It does not exercise a `deny` rule overriding an `allow` rule, and
 it does not exercise a `default: allow` policy. Treat deny-over-allow
 ordering as hull's documented gateway behavior, evidenced historically by
-that one measurement, and not as something brig's own tests confirm.
+that one measurement, and not as something Brig's own tests confirm.
 
 A `host` rule is enforced through the gateway's own resolver, so what it
 covers depends on the default. Under `default: deny`, the resolver answers

--- a/docs/security.md
+++ b/docs/security.md
@@ -1,33 +1,66 @@
-# What brig protects, and what it does not
+# What Brig protects, and what it does not
 
-The reason to run an agent in a sandbox is that the agent runs code you did
-not write, against a machine that holds everything you have. brig narrows what
-"everything" means. What the agent can reach on the host is its workspace,
-any project you name on the run line, and the credentials you gave it. No
-other host directory is mounted, and, on every profile brig ships, no host
-credential source is read on the run path. A profile of your own carrying the
-deprecated `hostCredential:` key is the exception: it reads the macOS keychain
-item it names on every run. See [secrets.md](secrets.md). What the agent can reach over the network is a separate
-question, with a much weaker answer, covered below.
+An agent runs code you did not write. You run it in a sandbox because that
+code executes against a machine that holds everything you have. Brig narrows
+what "everything" means. On the host, the agent can reach its guest home and
+the credentials you gave it. It can also reach any project you name on the
+run line. No other host directory is mounted.
 
-This page states what is isolated first, then what an agent can still do.
-Some of it is weaker than it looks, and we would rather write that down than
-let someone find out later.
+On every profile Brig ships, no host credential source is read on the run
+path. A profile of your own carrying the deprecated `hostCredential:` key is
+the exception: it reads the macOS keychain item it names on every run. See
+[secrets.md](secrets.md) for that exception. What the agent can reach over
+the network is a separate question, with a much weaker answer, covered below.
 
 If you have found a flaw in one of these boundaries, [SECURITY.md](../SECURITY.md)
 is how to report it privately. The section below on
 [things brig does not claim](#things-brig-does-not-claim) is the line between a
 vulnerability and a known limitation.
 
+## What the agent can reach
+
+The guest can access:
+
+- its guest home, read-write
+- the project you name on the run line, read-write at `/work/<name>`
+- the credentials you deliver to it
+- the internet, on the default `shared` network
+- any hostmount volume a profile declares
+
+The guest cannot access:
+
+- any other host directory
+- your keychain
+- your SSH agent
+- your secret manager
+- an environment variable a profile's `deny` list refuses
+
+Mounting a project or delivering a credential changes both lists. The agent
+can change the real files at those two mounts, not a copy of them. Anything
+it can read there it can also send over the network. A credential you deliver
+is usable by the agent for as long as it holds it. The agent can misuse it
+the same way a person holding it can.
+
+Every hostmount in a shipped profile already lives inside the guest home.
+That means no shipped hostmount exposes anything today, a property of the
+shipped profiles rather than a guarantee about a profile you write yourself.
+
+A `deny` list only ever covers an environment variable. A `files:` binding
+reaches the guest by a different channel, and the list does not see it.
+
+What "the internet" means in practice is in
+[Things brig does not claim](#things-brig-does-not-claim) below. So is
+whether the guest can reach a service bound on the host.
+
 ## The boundary
 
 The sandbox is a microVM on both. On macOS it is booted by
 [hull](https://github.com/brig-sh/hull) over Virtualization.framework, which
-`brew install --cask brig` brings along. On Linux brig drives `nerdctl` and
+`brew install --cask brig` brings along. On Linux Brig drives `nerdctl` and
 hands the container to the urunc shim (`io.containerd.urunc.v2`), which is the
-default rather than the direction, so the guest has a kernel of its own there
-too. `BRIG_CONTAINERD_RUNTIME=runc` asks for a plain container instead, which
-shares the host kernel: that is the weaker of the two, and it is something you
+default rather than the direction. That gives the guest a kernel of its own
+there too. `BRIG_CONTAINERD_RUNTIME=runc` asks for a plain container instead, which
+shares the host kernel. That is the weaker of the two, and it is something you
 have to choose rather than something you get.
 
 Which of them you got is the `ISOLATION` row of the execution envelope, printed
@@ -40,18 +73,19 @@ ISOLATION    microVM (nerdctl over containerd, io.containerd.urunc.v2)
 ISOLATION    container (docker over containerd, runc: the guest shares the host kernel)
 ```
 
-The row reports what this run resolved -- the binary in hand, the backend it
-settled on, the shim it will name -- rather than what the paragraph above
-promises. A shim brig does not recognise may well boot a VM, and brig cannot
-establish that from a name, so the row says it cannot tell instead of claiming
-the stronger boundary.
+The row reports what this run resolved: the binary in hand, the backend it
+settled on, and the shim it will name. That is not the same as what the
+paragraph above promises. A shim Brig does not recognise can still boot a
+sandbox, and Brig cannot establish the isolation that sandbox gets from a
+shim name alone. So the row says it cannot tell, instead of claiming the
+stronger boundary.
 
-Inside it, the guest has your workspace mounted as its home, read-write. Name
+Inside it, the guest has your guest home mounted as its home, read-write. Name
 a project on the run line and that project is a second host directory, also
 mounted read-write, at `/work/<name>`. The agent can change those files too.
 
 A profile's own hostmount volumes are further shares. Every one in a shipped
-profile lives inside the workspace already, so nothing extra is exposed
+profile lives inside the guest home already, so nothing extra is exposed
 today. That is a property of the shipped profiles, not a guarantee. A
 hostmount your own profile declares outside a tmpfs cover is a host path the
 guest can see.
@@ -64,18 +98,19 @@ have to be forwarded in explicitly: the guest cannot fetch them for itself.
 ## Credentials
 
 **A run on a shipped profile reads no host credential source.** Nothing on the
-`brig run`, `exec` or `shell` path reaches a keychain item brig did not write,
-a credential file outside the workspace, or a host command that produces one.
-Two host reads do happen, and no setting turns either off. brig runs `git
+`brig run`, `exec` or `shell` path reaches a keychain item Brig did not write.
+Nothing on that path reaches a credential file outside the guest home, or a
+host command that produces one. Two host reads do happen, and no setting
+turns either off. Brig runs `git
 config --get` in the directory you invoked it from, for `user.name`,
 `user.email` and `github.user`, to resolve the commit identity forwarded into
-the guest. If `github.user` comes back empty it then reads the `user:` line
+the guest. If `github.user` comes back empty, it then reads the `user:` line
 from the stanza for your git host in gh's `hosts.yml`, under `$GH_CONFIG_DIR`
-or `~/.config/gh`, to find the login that pairs with the forwarded token. That
-file usually carries gh's own OAuth token as well; brig takes the login and
+or `~/.config/gh`. That line names the login that pairs with the forwarded
+token. That file usually carries gh's own OAuth token as well. Brig takes the login and
 nothing else. `BRIG_GIT_IDENTITY=0`, `BRIG_GIT_CONFIG=0` and `BRIG_GIT_USER`
-change what brig does with the answers, not whether it asks. Your host login
-enters brig's own store once, when you type `brig secret import <profile>`,
+change what Brig does with the answers, not whether it asks. Your host login
+enters Brig's own store once, when you type `brig secret import <profile>`,
 and every run afterwards reads only that store:
 
 ```bash
@@ -83,104 +118,104 @@ brig run claude-code               # log in inside the sandbox, or:
 brig secret import claude-code     # carry the host login in, once
 ```
 
-That is a change from earlier releases, which read Claude Code's own keychain
-item on every invocation as a fallback. The profile key that did it,
-`hostCredential:`, is deprecated and has left the shipped profiles; brig
+The profile key that read Claude Code's own keychain item on every invocation,
+`hostCredential:`, is deprecated and has left the shipped profiles. Brig
 removes the field in the next release. `BRIG_CREDENTIALS_CMD`, which pointed
 that read at a host command of your own, is already gone: a run that sets it
 fails, naming `brig secret import <profile> <name> --from-command '<command>'`.
 
-Until the field goes too, the sentence above is about the profiles brig ships.
+Until the field goes too, the sentence above is about the profiles Brig ships.
 A profile of your own still carrying `hostCredential:` keeps the old
-behaviour, because that is what deprecating rather than deleting the key
-means: every run reads the host item it names, and raises the approval dialog
-that comes with it.
+behaviour. That is what deprecating rather than deleting the key means: every
+run reads the host item it names. It also raises the approval dialog that
+comes with it.
 `brig run` warns when it finds one. Moving it to `secrets:` with `sources:` is
 what makes the promise above true for your profile too.
 
 A credential reaches the guest by one of two channels, and the profile picks
 per secret. `files:` writes it into the guest at the path the agent already
-reads; `env:` binds it as an environment variable, for credentials whose
-consumer offers no file interface. For an `env.<name>` binding -- or the
-deprecated `forward:` spelling of one -- brig still reads the named variable
-from its own environment, so whatever populates that environment remains a
+reads. `env:` binds it as an environment variable, for credentials whose
+consumer offers no file interface. For an `env.<name>` binding, or the
+deprecated `forward:` spelling of one, Brig still reads the named variable
+from its own environment. Whatever populates that environment remains a
 usable backend for those.
 
 On Linux the store is a Secret Service keyring on your session bus,
 gnome-keyring or KWallet ([secrets.md](secrets.md#linux)). A host with no
-keyring has no store, and a profile whose secrets are *optional* degrades
-there rather than failing: the run boots and the agent asks for a login,
-which is what `claude-code` does. A **required** secret does fail outright,
+keyring has no store. A profile whose secrets are *optional* degrades there
+rather than failing: the run boots and the agent asks for a login. That is
+what `claude-code` does. A **required** secret does fail outright,
 because there is nowhere on that host to read it from.
 
 Values are re-read on every exec, so a rotated credential is picked up without
-restarting the sandbox. Nothing is written into the workspace.
+restarting the sandbox. Nothing is written into the guest home from the host
+for this.
 
 ### What file delivery buys, and what it costs
 
-A credential delivered as a file stays out of `/proc/<pid>/environ`, is not
-inherited by processes the agent spawns, and can be rewritten under a running
-agent -- so a rotated secret can reach a live session, which no environment
-variable can. The bytes land on a memory-backed mount covering the agent's
-whole config directory, verified to be `tmpfs` with no swap before anything is
-written, so there is no path from the credential to your disk to check.
+A credential delivered as a file stays out of `/proc/<pid>/environ` and is not
+inherited by processes the agent spawns. It can also be rewritten under a
+running agent, so a rotated secret can reach a live session, which no
+environment variable can. The bytes land on a memory-backed mount covering
+the agent's whole config directory, verified to be `tmpfs` with no swap
+before anything is written. So there is no path from the credential to your
+disk to check.
 
-Four costs, and none of them is small enough to leave implied.
+Weigh these costs before you rely on file delivery. None of them is small
+enough to leave implied.
 
-- **brig stores and hands over a refresh token.** There is no way to give
+- **Brig stores and hands over a refresh token.** There is no way to give
   Claude Code a working `.credentials.json` without `refreshToken` and
-  `refreshTokenExpiresAt` -- a file carrying only an access token is *worse*
+  `refreshTokenExpiresAt`. A file carrying only an access token is *worse*
   than an environment variable, because the agent attempts a refresh, fails,
   and prompts. So a compromised agent inside the sandbox can mint access
   tokens indefinitely, and keeps doing so after the host's own token has
   expired. The compensating argument is real and belongs beside it: the guest
   refreshes for itself, so a long session stops breaking every few hours. It
   is a trade, taken deliberately.
-- **brig's copy is less protected than the item it came from.** The host's
-  Claude item is ACL-scoped to the application that wrote it, which is why it
-  raises a dialog the first time something else reads it. The copy brig writes
-  carries the **default ACL**, so anything that can run `/usr/bin/security` as
-  you reads it back with no dialog at all. Narrowing the ACL does not fix this
-  -- any process can invoke `security` -- so the only real mitigation is
-  keeping the stored copy low-value, and a refresh token is not low-value.
-  When you are not using it, delete it: `brig secret delete claude-credentials`.
+- **Brig's copy is less protected than the item it came from.** The host's
+  Claude item is ACL-scoped to the application that wrote it. That is why it
+  raises a dialog the first time something else reads it. The copy Brig
+  writes carries the default ACL, the same one every secret in
+  [the secret store](#the-secret-store) carries. The same consequence
+  applies: keeping the stored copy low-value is the only real mitigation, and
+  a refresh token is not low-value. When you are not using it, delete it:
+  `brig secret delete claude-credentials`.
 - **The denylist stays env-scoped.** A `files:` binding bypasses the deny check
-  entirely, and no name check could fix that: a profile could deliver a metered
-  API key inside a `settings.json` and nothing would see it. That is defensible
-  rather than a hole, because `deny` exists to catch **accident** -- an ambient
+  entirely, and no name check can fix that. A profile can deliver a metered
+  API key inside a `settings.json`, and nothing sees it. That is defensible
+  rather than a hole. `deny` exists to catch **accident**, an ambient
   variable swept into the guest because it happened to be in your shell. A file
   binding takes an explicit stored secret and an explicit binding written by
-  the profile author; nobody file-binds an `ANTHROPIC_API_KEY` by mistake. The
+  the profile author. Nobody file-binds an `ANTHROPIC_API_KEY` by mistake. The
   two names on `claude-code`'s denylist are env-shaped by the agent's own
   design, so the guard still covers the channel the risk uses.
 - **The stored copy does not rotate.** A credential renewed on the host does
-  not update brig's copy, and one *revoked* on the host stays valid in brig's
-  store until you re-import or delete it. brig warns before boot when the
-  stored copy has expired, and names the command that refreshes it; it cannot
+  not update Brig's copy. One *revoked* on the host stays valid in Brig's
+  store until you re-import or delete it. Brig warns before boot when the
+  stored copy has expired, and names the command that refreshes it. It cannot
   see a revocation at all.
 
 A `0600` file is also still readable by anything running as the agent's uid
-inside the sandbox. Files narrow the exposure; they do not draw a boundary.
+inside the sandbox. Files narrow the exposure. They do not draw a boundary.
 See [what is still exposed](#what-is-still-exposed) below.
 
-Three rules apply, though the second only to a value read from the ambient
-environment:
+Brig applies these rules when it resolves a secret:
 
 - Unset or empty is skipped, so it cannot shadow a value baked into the image.
 - A `scheme://` value read from the environment is refused as an unresolved
   secret-manager reference. direnv and friends leave those in the environment
-  readily, and forwarded verbatim it yields "Invalid username or token" in
+  readily. Forwarded verbatim, it yields "Invalid username or token" in
   the guest, which looks exactly like a broken sandbox. A `value:` literal or
-  a value from brig's own secret store skips this check: it was put there on
-  purpose rather than left behind by a tool that never got to resolve it, so
-  refusing it would reject a perfectly good credential for merely looking
-  like one it is not. `BRIG_ALLOW_REFS=1` forwards an ambient reference
-  anyway.
+  a value from Brig's own secret store skips this check. Brig put it there
+  on purpose, not left behind by a tool that never resolved it. Refusing it
+  rejects a perfectly good credential for merely looking like one it is not.
+  `BRIG_ALLOW_REFS=1` forwards an ambient reference anyway.
 - A variable on the profile's `deny` list is refused, with the reason.
 
 `brig info <agent>` reports the guest's environment, by name, and fails the
-same way a run would if a declared secret cannot be resolved. It never
-prints a value: a secret-sourced variable comes back annotated, e.g.
+same way a run does if a declared secret cannot be resolved. It never
+prints a value: a secret-sourced variable comes back annotated, for example
 `GH_TOKEN(secret)`, never with the value itself. A credential delivered as a
 file is not an environment variable and does not appear in that list at all.
 
@@ -188,19 +223,19 @@ file is not an environment variable and does not appear in that list at all.
 
 The credential file is the part that does not. It lands on a `tmpfs` mount
 covering `~/.claude`, checked to be `tmpfs` with no swap before anything is
-written, so `~/.claude/.credentials.json` and the temp file the agent renames
-onto it never touch your disk. `brig stop` takes that mount with the VM,
+written. So `~/.claude/.credentials.json` and the temp file the agent
+renames onto it never touch your disk. `brig stop` takes that mount with the sandbox,
 which is why an in-sandbox login on this profile does not outlive a stop.
 
 The rest of `~/.claude` is not on that mount. Seven paths under it are
-hostmounted, so they live in the workspace on host disk and persist across
+hostmounted, so they live in the guest home on host disk and persist across
 boots:
 
 - `settings.json` and `CLAUDE.md`, your permission allowlist and your
   user-level memory, written by hand or by the agent on your instruction.
 - `sessions`, `projects` and `history.jsonl`, which are the conversation.
 - `plugins` and `skills`, which are also where `--skills` copies your own, so
-  leaving either off would make that flag do nothing.
+  leaving either off makes that flag do nothing.
 
 Anything else under `~/.claude` is ephemeral, including anything a future
 Claude Code version starts writing there. This list is the `volumes:` block of
@@ -214,20 +249,20 @@ variable *name* appears on its command line. So a forwarded credential is not
 readable in `ps` by other processes on the host.
 
 `BRIG_ENV_ARGV=1` puts them back on the command line for a runtime build that
-does not accept a bare `--env KEY`, and gives up the guarantee -- for a value
-read from the environment. A value brig resolved on your behalf is exempt from
-the hatch and stays off the command line regardless -- one bound from its own
-secret store, and the host credential too, however that was obtained --
-because the host durably logs every exec's argv, and an opt-in debugging
-escape hatch has no business turning that log into a credential leak.
+does not accept a bare `--env KEY`. That gives up the guarantee for a value
+read from the environment. A value Brig resolved on your behalf is exempt
+from the hatch. It stays off the command line regardless: one bound from its
+own secret store, and the host credential too, however that was obtained.
+The host durably logs every exec's argv. An opt-in debugging escape hatch has
+no business turning that log into a credential leak.
 
 ### What is still exposed
 
 The credential is readable inside the sandbox by anything running alongside
 the agent. That is inherent: the sandbox cannot use a credential it cannot
 see. Docker's sandboxes avoid it by rewriting auth headers in a host-side
-proxy, which works for proxied HTTP and not for `git push`, a vendor CLI's own
-token refresh, or an MCP server holding its own connection.
+proxy. That works for proxied HTTP, but not for `git push`, a vendor CLI's
+own token refresh, or an MCP server holding its own connection.
 
 Our answer is a narrow blast radius rather than a sentinel value. Prefer a
 fine-grained `GH_TOKEN` scoped to the repositories you want reachable, over a
@@ -235,13 +270,13 @@ classic PAT carrying your whole account.
 
 ## The secret store
 
-`brig secret` is the one place brig stores something rather than reading it,
+`brig secret` is the one place Brig stores something rather than reading it,
 and after the switchover above it is the **only** store a run reads. A profile
 names what it wants out of it under `secrets:`, and `brig secret import` is how
 a host login gets in.
 
-Prefer that over composing a value into brig's environment, for one concrete
-reason: a value brig resolved on your behalf is exempt from the
+Prefer that over composing a value into Brig's environment, for one concrete
+reason. A value Brig resolved on your behalf is exempt from the
 `BRIG_ENV_ARGV` escape hatch above, and an ambient one is not. The two paths
 end at the same variable in the same guest. Only one of them stays off the
 command line the host logs no matter what anyone sets later.
@@ -262,156 +297,140 @@ brig secret ls
 What that means for the things this document is about:
 
 - **The value never appears in argv.** The whole `add-generic-password`
-  command, base64 value and all, goes to `security -i` down a pipe, so brig's
+  command, base64 value and all, goes to `security -i` down a pipe. Brig's
   own command line is `security -i` and nothing else. This is the same
-  guarantee the forwarding path makes above, for the same reason.
-
-  Confirming it by watching `ps` during a create does not work, which is worth
-  saying because an empty result looks the same as a mistyped `grep`: the write
-  lives a few milliseconds and a sampling loop will not catch it. Pin it in the
-  process table instead, by running `security` the way brig does and then
-  holding it open. `security -i` executes each line as it arrives and blocks
-  for the next, so a fifo nothing closes leaves the process sitting there with
-  the write already done:
-
-  ```bash
-  mkfifo /tmp/probe
-  security -i < /tmp/probe &
-  exec 3>/tmp/probe                          # a writer, but never an EOF
-  printf 'add-generic-password -s sh.brig.probe -a probe -w %s\n' \
-    "$(printf %s hunter2 | base64)" >&3      # the real command, down the pipe
-  ps -Ao args | grep -x '[s]ecurity -i'      # the whole argv, command and all
-  ps -Ao args | grep '[a]dd-generic-password'  # no process is carrying it
-  security find-generic-password -s sh.brig.probe -a probe -w  # yet it stored
-  exec 3>&-; kill %1
-  security delete-generic-password -s sh.brig.probe -a probe
-  rm /tmp/probe
-  ```
-
-  The read-back is what makes this a test rather than a tautology: the item is
-  really in the keychain, so the command really was carried, and it was still
-  never an argument.
-- **The item's ACL is the default one**, which is what makes brig's own
-  secrets read back without a keychain dialog: `security` created them, so
-  `security` is trusted to read them. The consequence is the part worth being
-  clear about -- **anything that can run `/usr/bin/security` as you can read
-  them back too**. That is the same boundary as your own shell, and it is
-  weaker than a per-application ACL would be. brig does not ask for the
-  broad `-A`, but it does not narrow the default either.
+  guarantee the forwarding path makes above, for the same reason. `security -i`
+  reads one command per line and blocks for the next. So the write is on the
+  process table only for as long as the pipe stays open. Reproduce it by
+  running `security -i` against a fifo, holding the fifo open with an idle
+  writer. Send the real `add-generic-password` line down it, then read
+  `ps -Ao args` while it sits there. The argv shows `security -i` and nothing
+  more. `security find-generic-password` afterwards confirms the value
+  really was stored. Closing the fifo and deleting the probe item cleans up.
+- **The item's ACL is the default one.** `security` created these items, so
+  `security` is trusted to read them back, with no keychain dialog. The
+  consequence is the part worth being clear about: **anything that can run
+  `/usr/bin/security` as you can read them back too.** That is the same
+  boundary as your own shell, and it is weaker than a per-application ACL.
+  Brig does not ask for the broad `-A`, but it does not narrow the
+  default either. This is the same fact [file delivery](#what-file-delivery-buys-and-what-it-costs)
+  states for the Claude credential copy specifically.
 - **Values are base64-encoded.** `security -i` reads one command per line, so a
-  raw newline in a value would end the command early -- and everything after it
-  would be read as a *second command*. Encoding removes that, and with it the
-  need to quote anything: base64 spells everything in letters, digits, `+`, `/`
+  raw newline in a value ends the command early. Everything after it
+  reads as a *second command*. Encoding removes that, and with it the
+  need to quote anything. base64 spells everything in letters, digits, `+`, `/`
   and `=`, so no `"` and no `\` ever reaches the line. It also makes the NUL
   byte and the non-UTF8 byte ordinary, which is what lets an SSH key or a
   binary value round-trip at all. The visible cost is that Keychain Access, and
   `security find-generic-password -w` by hand, show base64 rather than the
-  secret. It is encoding, not encryption, and protects nothing on its own --
-  the keychain does that.
-- **A value has a size ceiling, and brig refuses rather than stores short.**
-  That 4096-byte line is the budget for the *whole* command, so a longer name
-  leaves fewer bytes for the value it names -- about 3KB of raw value in
-  practice. Every API key and SSH key fits; a 4096-bit RSA private key does
-  not. brig checks the length up front and reads back what it wrote, because
-  `security` answers a line it cannot fit by shortening it and reporting
-  success. See [secrets.md](secrets.md#the-size-limit) for the numbers.
+  secret. It is encoding, not encryption, and protects nothing on its own.
+  The keychain does that.
+- **A value has a size ceiling, and Brig refuses rather than stores short.**
+  That 4096-byte line is the budget for the *whole* command. A longer name
+  leaves fewer bytes for the value it names, about 3KB of raw value in
+  practice. Every API key and SSH key fits. A 4096-bit RSA private key does
+  not. Brig checks the length up front and reads back what it wrote. Rather
+  than fail outright, `security` answers a line it cannot fit by shortening
+  it and reporting success. See [secrets.md](secrets.md#the-size-limit) for
+  the numbers.
 - **`brig secret ls` never decrypts.** It reads attributes only, which is why
   listing raises no access prompt and why it can show names and dates but
   never values. Worth being exact about what it reads, though:
-  `security dump-keychain` takes no service filter -- its options are
-  `[-adhir] [keychain...]` and nothing else -- and brig names no keychain
+  `security dump-keychain` takes no service filter. Its options are
+  `[-adhir] [keychain...]` and nothing else, and Brig names no keychain
   either, so the dump covers the whole keychain *search list*. On a stock Mac
   that is your login keychain **and the System keychain**, which is a wider
-  net than the login keychain alone; `security list-keychains` shows yours.
+  net than the login keychain alone. `security list-keychains` shows yours.
   `ls` enumerates the attributes of every item in all of them and discards the
-  ones that are not brig's. Nothing is decrypted and nothing leaves the
-  process, but names and dates belonging to other applications, and to the
-  system, do pass through brig on their way to being thrown away.
-- **brig writes only under its own service, which contains brig rather than
+  ones that are not Brig's. Nothing is decrypted and nothing leaves the
+  process. Names and dates belonging to other applications, and to the
+  system, do pass through Brig on their way to being thrown away.
+- **Brig writes only under its own service, which contains Brig rather than
   vouching for what it finds.** Every command that creates, changes or removes
-  an item carries `-s sh.brig.secret`, so brig cannot reach outside that
-  namespace. The converse does not follow, and it would be the more
-  comfortable thing to claim: the service name is a label, not an authenticity
+  an item carries `-s sh.brig.secret`, so Brig cannot reach outside that
+  namespace. The converse does not follow, though it is the more
+  comfortable thing to claim. The service name is a label, not an authenticity
   check, and nothing stops another process running as you from adding an item
-  under it -- which brig would then read, update and delete as its own. What
-  brig does instead is degrade honestly. `read` says plainly when a value is
-  not in brig's encoding, and `ls` skips a name outside brig's grammar, so an
-  item brig did not write is either reported or passed over rather than
-  presented as yours. An item belonging to another application -- Claude Code's
-  own, say -- is read by `brig secret import` and never written, and that read
+  under it. Brig then reads, updates and deletes that item as its own. What
+  Brig does instead is degrade honestly. `read` says plainly when a value is
+  not in Brig's encoding. `ls` skips a name outside Brig's grammar, so an
+  item Brig did not write is either reported or passed over rather than
+  presented as yours. An item belonging to another application, Claude Code's
+  own, say, is read by `brig secret import` and never written. That read
   *does* raise a dialog, for exactly the ACL reason above: `security` did not
   create it. A run never performs that read at all, which is the point of the
-  import verb: the dialog appears when you asked for it, once, and never again
-  on the boot path.
+  import verb. The dialog appears when you asked for it, once, and never
+  again on the boot path.
 
 On Linux the store is a Secret Service keyring, and a host without one has no
-store: `brig secret` says which half is missing rather than falling back to a
-file, which would be a downgrade nothing told you about.
+store. `brig secret` says which half is missing, rather than falling back to
+a file, which is a downgrade nothing told you about.
 
 ## Writing into the workspace
 
-The workspace is the guest's home, mounted read-write, so its contents are the
-sandbox's to choose. brig also writes into it from the host on every
-invocation: the stale-share marker, the onboarding seed, the trust key, the
-guest git files, the skills copied in by `--skills`. Put those two facts
-together and you have the one place where the sandbox gets to influence what
-happens on the host, so it is worth naming precisely.
+The guest home is mounted read-write, so its contents are the
+sandbox's to choose. Brig also writes into it from the host on every
+invocation. Those writes are the stale-share marker, the onboarding seed,
+the trust key, the guest git files, and the skills copied in by `--skills`.
+Put those two facts together and you have the one place where the sandbox
+gets to influence what happens on the host. That is worth naming precisely.
 
-brig runs as you and outside the sandbox. A guest that plants a symlink where
-brig writes next has aimed brig at a host path the guest itself can never
-reach -- your `~/.ssh`, your shell profile -- and brig would follow it,
-because to brig it is just a path inside the workspace. Nothing about the
-microVM boundary stops this: the write is on the host side of it.
+Brig runs as you and outside the sandbox. A guest can plant a symlink where
+Brig writes next. That aims Brig at a host path the guest itself can never
+reach, your `~/.ssh` or your shell profile. Brig follows it anyway, because
+to Brig it is just a path inside the guest home. Nothing about the microVM
+boundary stops this: the write is on the host side of it.
 
-So every host-side read and write brig makes inside the workspace goes through
-an `os.Root` opened on the workspace. It resolves each path itself, refuses an
+So every host-side read and write Brig makes inside the guest home goes
+through an `os.Root` opened on it. It resolves each path itself, refuses an
 absolute symlink outright, and will not let a relative one climb past the
-root. A symlink that escapes the workspace this way is refused everywhere,
+root. A symlink that escapes the guest home this way is refused everywhere,
 on a read or a write. There is no window between the check and the open for
 the guest to swap the file in.
 
-A symlink that stays *inside* the workspace is a different story, and reading
-and writing do not treat it alike. Where brig writes a state file, the
-symlink is refused even though it does not escape. brig writes only regular
+A symlink that stays *inside* the guest home is a different story, and reading
+and writing do not treat it alike. Where Brig writes a state file, the
+symlink is refused even though it does not escape. Brig writes only regular
 files there, so a link where a state file belongs was put there rather than
 left there.
 
-Where brig reads a file, an internal symlink is followed instead. A
-`.gitconfig` symlinked to your own dotfiles, inside the workspace, has to
+Where Brig reads a file, an internal symlink is followed instead. A
+`.gitconfig` symlinked to your own dotfiles, inside the guest home, has to
 keep working. The refusal it replaced used to claim such a link "leads out
-of" the workspace, which was never true for one that stays inside.
+of" the guest home, which was never true for one that stays inside.
 
-Either way, brig decides from what it actually opened, not from a check made
+Either way, Brig decides from what it actually opened, not from a check made
 beforehand. A fifo, socket, device or directory where a regular file belongs
 is refused there. That closes the window where the guest renames one file
 type over another between the two.
 
-The one escape a root cannot see is a symlink *at* the workspace or on the
-way to it, since resolving that still leaves every path below it honestly
-"inside the root". That is checked separately, before anything is created,
+The one escape a root cannot see is a symlink *at* the guest home or on the
+way to it. Resolving that still leaves every path below it honestly "inside
+the root". That is checked separately, before anything is created,
 and the check has a shape worth knowing. The guest writes as you, so it can
-swap an entry only inside a directory you can write. The path to the
-workspace is split where the first such directory appears. Above it, every
-entry sits where the guest cannot reach, and that part is opened by name,
-following the links the system or an administrator put there (`/tmp` and
-`/var` on macOS are links). From there down, brig descends one component at a
-time against the directory it already holds, refuses every symlink, and
-confirms after each step that what it opened is what it looked at. The
-workspace itself is always in the descended part, so a link there is refused
-wherever it sits.
+swap an entry only inside a directory you can write. The path to the guest
+home is split where the first such directory appears. Above it, every entry
+sits where the guest cannot reach, and that part is opened by name. It
+follows the links the system or an administrator put there (`/tmp` and
+`/var` on macOS are links). From there down, Brig descends one component at
+a time against the directory it already holds, and refuses every symlink.
+It confirms after each step that what it opened is what it looked at. The
+guest home itself is always in the descended part, so a link there is
+refused wherever it sits.
 
 Whether you can write a directory is what the kernel says, asked through
 `access(2)`, plus ownership: a directory you own you can always `chmod`. So a
 group membership past the first sixteen and an ACL both count, on both
 platforms. A link above the split whose target passes through a directory
-you can write, a root-owned `/data` pointing into your home, say, is refused
-like any other link the guest could reach; name the real directory instead.
+you can write is refused like any other link the guest can reach. A
+root-owned `/data` pointing into your home is one example. Name the real
+directory instead.
 
-Running brig as root, ownership tells it nothing, because the guest's writes
-are root's too. It then trusts only what nobody but root could have written,
-which keeps the system's own links usable and protects nothing: a sandbox run
-as root can reach a nested workspace's parents like anything else, and this
-is not the control for that.
+Running Brig as root, ownership tells it nothing, because the guest's writes
+are root's too. It then trusts only files that only root was able to write.
+That keeps the system's own links usable, but protects nothing: a sandbox
+run as root can reach a nested guest home's parents like anything else.
+This is not the control for that.
 
 What this looks like when it fires is a failed run, before anything is
 written, naming the link and where it points:
@@ -424,22 +443,22 @@ files inside the workspace. The workspace is mounted read-write as the
 sandbox's home, so that link was put there from inside the sandbox, to have
 brig -- which runs as you, on the host -- reach a file the sandbox cannot.
 Nothing was written; inspect /Users/alex/brig/claude-code/.claude.json and
-remove it before running brig again
+remove it before running brig again: a symlink in the workspace leads out of it
 ```
 
-Read it as what it says. brig does not create the links it writes through, so
-one in the way is either something you put there deliberately, or the sandbox
-reaching for the host. Neither is a case for retrying: remove the link, or
-point the workspace somewhere else.
+Read it as what it says. Brig does not create the links it writes through.
+One in the way is either something you put there deliberately, or the
+sandbox reaching for the host. Neither is a case for retrying: remove the link, or
+point the guest home somewhere else.
 
 `--home` pointed at a symlink is refused for the same reason, with the
 same kind of message, and is fixed by naming the real directory.
 
 ## Guest images
 
-An image is code that will run with your credentials, so brig checks where it
-came from before booting it. The check is cosign's keyless verification, and
-the question it asks is not "was this signed?" but "was this built by that
+An image is code that will run with your credentials, so Brig checks where it
+came from before booting it. The check is cosign's keyless verification. The
+question it asks is not "was this signed?" but "was this built by that
 workflow, in that repo?":
 
 ```bash
@@ -450,15 +469,14 @@ cosign verify \
   ghcr.io/brig-sh/claude-code-stock:latest
 ```
 
-That works anonymously -- the images are public, and the signature lives in
+That works anonymously: the images are public, and the signature lives in
 Sigstore's transparency log, not behind a registry login. `:latest` is a
-multi-arch index; the per-architecture tags (`:arm64`, `:amd64`) and the
+multi-arch index. The per-architecture tags (`:arm64`, `:amd64`) and the
 immutable `:<arch>-<sha>` pins are signed the same way and verify with the
 same command.
 
-
-The identity is anchored on the repository and the workflow file, so a
-signature from anywhere else fails -- including one from another workflow in
+The identity is anchored on the repository and the workflow file. A
+signature from anywhere else fails, including one from another workflow in
 the same repository.
 
 `BRIG_VERIFY` has three modes: `off`, `warn` and `require`. `warn` is the
@@ -474,12 +492,12 @@ What `warn` does with the answer:
 | image under `ghcr.io/brig-sh/`, signature verifies | one line saying so, boots |
 | image published by somebody else | warning, boots |
 | cosign not installed | warning, boots |
-| image under `ghcr.io/brig-sh/`, signature fails | stops and asks `[y/N]`; refuses when there is no terminal |
+| image under `ghcr.io/brig-sh/`, signature fails | stops and asks `[y/N]`. Refuses when there is no terminal |
 
 The asymmetry is deliberate. Bring-your-own images are a supported way to use
-brig, so refusing to boot one would make the feature useless, and "could not
+Brig, so refusing to boot one makes the feature useless. "Unable to
 check" is not the same as "failed". The one case with no innocent reading is
-an image sitting under our registry whose signature does not verify, and that
+an image sitting under our registry whose signature does not verify. That
 is the case that stops.
 
 A typo in `BRIG_VERIFY` refuses the run, naming the three values, rather than
@@ -491,53 +509,57 @@ at your own registry and workflow if you publish signed images yourself.
 ### The digest, not the tag
 
 A tag is a name, and a name can resolve to different bytes in the registry and
-in your local store. The provenance claim is about the bytes that run, so brig
+in your local store. The provenance claim is about the bytes that run. Brig
 resolves the reference to the digest the registry serves before the check,
-verifies that digest, and boots it. The object cosign checked is the object that
-runs, and the success line names the digest rather than the tag it came from. A
-local store holding a different digest under the tag is treated as the
-signature-failure row above: it stops, and a yes boots the verified digest
-rather than the copy on disk. A registry that cannot be reached stops in the
-same way, because one of our images could not be checked, and a network
-failure must not be what turns the default mode into "unchecked";
+verifies that digest, and boots it. The object cosign checked is the object
+that runs, and the success line names the digest rather than the tag it came
+from. A local store holding a different digest under the tag is treated as
+the signature-failure row above: it stops. A yes boots the verified
+digest rather than the copy on disk. A registry that cannot be reached stops
+in the same way. One of our images was not checked, and a
+network failure must not be what turns the default mode into "unchecked".
 `BRIG_VERIFY=require` refuses outright. Every cosign call is bounded, so an
 outage fails in seconds rather than hanging the boot.
 
-All of this is for images under `ghcr.io/brig-sh/`. An image brig did not
-publish carries no signature of ours to check, so brig makes no cosign call for
-it at all: it boots by tag, as it always has, with the one line saying whose
-image it is. Resolving a digest for it would cost a registry round trip on every
-boot and buy a pin brig cannot vouch for.
+All of this is for images under `ghcr.io/brig-sh/`. An image Brig did not
+publish carries no signature of ours to check, so Brig makes no cosign call for
+it at all. It boots by tag, as it always has, with one line saying whose
+image it is. Resolving a digest for it costs a registry round trip on
+every boot and buys a pin Brig cannot vouch for.
 
-This holds wherever the runtime's store answers a digest: containerd on Linux,
-and hull from 0.1.0-rc23 on macOS. brig asks the hull it is driving rather than
-assuming, because the one on PATH may be older than brig. An older hull cannot
-find a digest reference in its store, so a pinned boot there would re-pull on
-every run and fail outright under `BRIG_PULL=never` with the bytes on disk.
-brig therefore verifies and boots the tag on such a hull, prints one line
-saying so, and the gap remains there until you upgrade: under the default
-`missing` pull policy cosign checks the tag in the registry, not necessarily
-the copy hull already holds, and `BRIG_PULL=always` is the workaround. brig
-does not name a digest on a boot that did not pin one.
+This holds wherever the runtime's store answers a digest: containerd on
+Linux, and hull from 0.1.0-rc23 on macOS. Brig asks the hull it is driving
+rather than assuming, because the one on PATH can be older than Brig. An
+older hull cannot find a digest reference in its store, so a pinned boot
+there re-pulls on every run. It fails outright under `BRIG_PULL=never`
+with the bytes on disk. Brig therefore verifies and boots the tag on such a
+hull, prints one line saying so, and the gap remains there until you upgrade.
+Under the default `missing` pull policy, cosign checks the tag in the
+registry, not necessarily the copy hull already holds. `BRIG_PULL=always`
+is the workaround. Brig does not name a digest on a boot that did not pin
+one.
 
 Two things are still narrower on macOS than on Linux. An image pulled under an
-older hull has no index digest on record, and a multi-arch tag resolves to its
-index digest, so the first pinned boot of such an image after upgrading hull
-misses the cache and pulls once; under `BRIG_PULL=never` it fails until the
-image is pulled again. And hull does not yet expose the digest its store holds
-for a reference, so the report that the local copy differs from what the
-registry serves is Linux-only for now. The boot is pinned either way.
+older hull has no index digest on record, and a multi-arch tag resolves to
+its index digest. The first pinned boot of such an image after upgrading
+hull misses the cache and pulls once. Under `BRIG_PULL=never` it fails until
+the image is pulled again. The second gap is that hull does not yet expose
+the digest its store holds for a reference. The report that the local copy
+differs from what the registry serves is Linux-only for now. The boot is
+pinned either way.
 
 `claude-desktop` points at a `ghcr.io/nofireai/` image, and `ubuntu` at
-`docker.io/library/ubuntu`. brig has no signing policy for either registry, so
+`docker.io/library/ubuntu`. Brig has no signing policy for either registry, so
 both warn on every boot until those images move.
 
 ### The kernel, not only the image
 
-Six of the eight shipped profiles boot a kernel and an initrd brig downloads,
+Six of the eight shipped profiles boot a kernel and an initrd Brig downloads,
 rather than one baked into the image. They are `claude-code`, `codex`,
 `gemini`, `grok`, `opencode` and `ubuntu`. `cursor` and `claude-desktop` boot
-their own image and skip everything below.
+their own image and skip everything below. `cursor` has no published image
+today: `brig agent ls` marks it `(no published image)`, so a run of it fails
+before any of this applies.
 
 That bundle is checked too, under the same `BRIG_VERIFY` setting, but as a
 second and separately-rooted check. Its trust root is its own: registry
@@ -548,19 +570,18 @@ that fails stops the boot outright, in every mode except `off`. There is no
 a bad kernel signature worth asking about.
 
 One thing the check does not buy: nothing is pinned from the result. The
-check verifies a registry reference, not the
-bytes that boot. What actually starts the guest is whatever kernel and
-initrd sit in `BRIG_BOOT_ASSETS`, or failing that the runtime's own asset
-directory, or the platform default. Only existence and being non-empty are
-checked there. brig does not bind the kernel on disk to the artifact it just
-verified. `BRIG_VERIFY_REGISTRY`, `BRIG_VERIFY_IDENTITY` and
-`BRIG_VERIFY_ISSUER` repoint the image's trust policy only: the kernel's
-identity is fixed.
+check verifies a registry reference, not the bytes that boot. What actually
+starts the guest is whatever kernel and initrd sit in `BRIG_BOOT_ASSETS`, or
+failing that the runtime's own asset directory, or the platform default.
+Only existence and being non-empty are checked there. Brig does not bind the
+kernel on disk to the artifact it just verified. `BRIG_VERIFY_REGISTRY`,
+`BRIG_VERIFY_IDENTITY` and `BRIG_VERIFY_ISSUER` repoint the image's trust
+policy only: the kernel's identity is fixed.
 
-## brig's own binaries
+## Brig's own binaries
 
 Releases are signed with keyless cosign as well. There is no key to
-distribute and none for us to lose: the certificate is short-lived, bound to
+distribute and none for us to lose. The certificate is short-lived, bound to
 the release workflow's OIDC identity, and recorded in a public transparency
 log.
 
@@ -596,85 +617,41 @@ by having built it.
 
 ## Telemetry
 
-brig is local-first and asks you to create no account, and a reader who takes
-that at face value will not expect a network call to a collector. There is
-one, on macOS, so here is what it is.
+Telemetry must not cross the boundary this page describes. The runtime Brig
+drives sends usage events to NOFire AI, on macOS only: nothing is sent on
+Linux. `brig telemetry off` (or `DO_NOT_TRACK=1`) turns it off everywhere
+it does run. See [docs/telemetry.md](telemetry.md) for how to check the
+current state, and for the field-by-field list of what an event carries.
+That list is
+[hull's stated commitment](https://github.com/brig-sh/hull/blob/main/docs/telemetry.md),
+not something this repository verifies: it excludes host paths, repository
+names, command arguments and agent prompts. It also excludes secret names
+and values, image references, network destinations and file metadata.
 
-The runtime brig drives reports usage events over OTLP to an OpenTelemetry
-collector run by NOFire AI, with no third-party analytics service in the path.
-brig tags those events with its own name, because brig is what you installed
-and hull is an implementation detail of it. On Linux the backend is `nerdctl`,
-which has no telemetry of any kind, and nothing is sent.
-
-The switch is `brig telemetry off`, which records the answer where the runtime
-keeps it, so it holds for every later invocation whether brig is the caller or
-not. `DO_NOT_TRACK=1` or `HULL_TELEMETRY_DISABLED=1` in the environment does
-the same for one shell without writing anything down, and beats a recorded
-yes. `brig telemetry status` reports which of those is currently deciding.
-
-**Nothing is sent before you have answered.** The runtime defaults telemetry
-on when it cannot put the question to anyone, and brig's boot invocation gives
-it no terminal, so left alone a fresh install would report its first boot
-before anyone had been asked. brig suppresses counting for every operation
-that runs without a terminal: the boot and the stop until an answer is on
-file, and the plumbing always. The one invocation that does inherit your
-terminal -- the exec that hands the sandbox to the agent -- is left able to
-ask, which is where the question appears. A default is not consent, but
-neither is a prompt nobody can ever see.
-
-An event carries a fixed envelope -- schema version, event type, product name
-and version, OS version, CPU architecture, an install identifier generated
-locally, a timestamp, a checksum -- plus, depending on the event: the brig
-subcommand and whether it succeeded, with failures reduced to coarse classes
-and never the error text; the hypervisor backend and whether the boot worked;
-how long a sandbox lived; sampled RSS and CPU of the VM process while a
-command is attached; and a panic type with a path-trimmed stack trace when
-something crashes. The install identifier is a random value in
-`~/.hull/telemetry.json`; deleting the file rotates it. Crash reports queue in
-`~/.hull/crashes/` and can be read or deleted before they are uploaded. IP
-addresses are dropped at ingestion, raw events are kept for a year, and
-widening what is collected re-asks the question rather than proceeding on the
-old answer. Field by field, that is
-[hull's telemetry documentation](https://github.com/brig-sh/hull/blob/main/docs/telemetry.md).
-
-These are never collected, and this is a commitment about what brig will send
-rather than a note about what it happens to send today:
-
-- workspace paths, and host paths generally
-- repository names, branches or remotes
-- command arguments, brig's own and the agent's
-- agent prompts, and anything the agent read or wrote
-- secret names, secret values, and which credentials a run forwarded
-- image names and registry references
-- network destinations the guest reached
-- file metadata: names, sizes, timestamps, counts
-
-The list is the one that matters for this page, because each entry is
-something the sandbox boundary above exists to keep private. A workspace path
-names the project; an image reference names what you are building; a forwarded
-credential name says which vendor you have an account with. Telemetry that
-carried any of them would leak across the boundary the rest of this document
-describes, out of a channel the user did not think was there. If you find one
-of them in a payload, that is a bug and
-[SECURITY.md](../SECURITY.md) is how to report it.
-
+Four more hull behaviors matter for checking that commitment yourself.
 `HULL_TELEMETRY_DEBUG=1` prints payloads to stderr instead of sending them,
-which is how to check any of this for yourself rather than taking our word for
-it.
+so you can read what an event actually carries. The install identifier is a
+random value hull stores in `~/.hull/telemetry.json`. Deleting the file
+rotates that identifier. Crash reports queue in `~/.hull/crashes/`, and you
+can read or delete one there before it is uploaded. That commitment also
+drops IP addresses at ingestion and keeps raw events for a year.
+
+If you find one of those excluded items in a payload, that is a bug and
+[SECURITY.md](../SECURITY.md) is how to report it.
 
 ## Things brig does not claim
 
 It does not sandbox the agent from the network by default, on any backend. A
-sandbox nobody attached a policy to has unrestricted egress, which is what
-every sandbox had before policies existed and what `brig run <agent>` gets on a
-fresh install. `--network offline` is the one posture with no route out at
+sandbox nobody attached a policy to has unrestricted egress. That is what
+every sandbox had before policies existed, and what `brig run <agent>` gets on
+a fresh install. `--network offline` is the one posture with no route out at
 all, on every backend.
 
 Attach one and that changes, on `hvi`: the rules are enforced at the network
-gateway brig gives that sandbox. Every runtime brig ships refuses to boot a
+gateway Brig gives that sandbox. Every runtime Brig ships refuses to boot a
 policy it cannot enforce, rather than booting it unconstrained (see
 [docs/policies.md](policies.md)). That refusal is each adapter's own choice,
-not a guarantee brig imposes on every runtime it will ever drive. The
+not a guarantee Brig imposes on every runtime it will ever drive. The
 one exception is `--network offline`: a policy-carrying sandbox with no route
 out satisfies every rule set, so it is not refused on any backend. Short of
 that, on `vz`, on `qemu` and on Linux there is no policy to be had at all.
@@ -682,16 +659,16 @@ Outbound traffic there is whatever the runtime allows.
 
 It does not say whether the guest can reach services bound on the host
 itself. That covers a dev server, a local model, an MCP server, a metadata
-endpoint. brig adds nothing to narrow that. What the guest's network reaches
+endpoint. Brig adds nothing to narrow that. What the guest's network reaches
 is the runtime's default, and whether that includes the host is unmeasured
 on every backend. The one control that exists is an egress policy on `hvi`,
 with `default: deny` and no `cidr` allow for the host's own ranges. There is
 no equivalent on `vz`, `qemu` or Linux.
 
 It does not promise that one sandbox cannot reach another under the default
-`shared` network. What happens there depends on the backend: brig asks the
+`shared` network. What happens there depends on the backend. Brig asks the
 runtime for its shared network, and what the runtime does with that request
-is the runtime's own behaviour, not brig's. The measurements are in
+is the runtime's own behaviour, not Brig's. The measurements are in
 [docs/manual-tests/sandbox-reachability.md](manual-tests/sandbox-reachability.md).
 
 | backend | can one sandbox reach another? |
@@ -703,51 +680,51 @@ is the runtime's own behaviour, not brig's. The measurements are in
 So on Linux, two agents you gave *different* credentials sit on one broadcast
 domain, each able to reach whatever the other is listening on. That is a real
 hole in the narrow-blast-radius argument above: there the radius is narrow per
-workspace and per token, not per sandbox. If it matters that two agents cannot
-reach each other, run them on separate hosts, or on macOS.
+guest home and per token, not per sandbox. If it matters that two agents
+cannot reach each other, run them on separate hosts, or on macOS.
 
 On macOS the separation under the *shared* network is real, but it is a
-property of the backend rather than something brig asks for. brig asks for a
-shared network and gets guests that cannot address each other. No test in brig
-would notice if a runtime change removed it. Treat it as a property that holds,
-not as a guarantee brig makes.
+property of the backend rather than something Brig asks for. Brig asks for a
+shared network and gets guests that cannot address each other. No test in Brig
+notices if a runtime change removes it. Treat it as a property that holds,
+not as a guarantee Brig makes.
 
 `--network isolated` is the guarantee. It gives the sandbox a network of its
-own -- its own CNI network on Linux, its own gateway process on a `/30` of its
-own on `hvi` -- so no other sandbox is on it whatever the backend would have
-done with a shared one. A sandbox carrying an egress policy is isolated whether
-or not it asked to be, because the rules live on that gateway and cover
-everything behind it.
+own. On Linux that is its own CNI network. On `hvi` it is its own gateway
+process on a `/30` of its own. No other sandbox is on it, no matter what the
+backend does with a shared one. A sandbox carrying an egress policy is
+isolated whether or not it asked to be. The rules live on that gateway and
+cover everything behind it.
 
-Two things about that posture. It is **refused** on `vz` and on `qemu`, where
-brig owns no network to give: a run asking for it there is stopped and told
-which backend implements it, rather than booted onto the shared network under a
-row claiming otherwise. And it is about reachability, not resources -- an
+That posture is **refused** on `vz` and on `qemu`, where
+Brig owns no network to give. A run asking for it there is stopped and told
+which backend implements it. It is not booted onto the shared network under a
+row claiming otherwise. The guarantee is about reachability, not resources. An
 isolated sandbox is one process and one network more than a shared one, which
 is what `brig rm --all` prunes.
 
 It does not filter what the agent writes to your terminal. `brig` hands the
-tty over with `syscall.Exec` and is gone before the agent produces a byte,
-which is what buys correct `^C` handling and a truthful exit status -- and it
-means every byte the agent emits reaches your terminal emulator unexamined.
+tty over with `syscall.Exec` and is gone before the agent produces a byte.
+That buys correct `^C` handling and a truthful exit status. Every byte the
+agent emits reaches your terminal emulator unexamined.
 The one exception is `--json`: there `brig` stays alive as the agent's parent
 so it can print one status line after the agent exits. The tty is still the
-agent's, `brig` reads nothing the agent prints and writes nothing to it, and
+agent's. `brig` reads nothing the agent prints and writes nothing to it, and
 the exit status is still the agent's own. What changes is only that `brig` is
 present for the run rather than gone.
-That is a real surface: OSC 52 writes to, and reads from, the system
-clipboard; DCS sequences are forwarded verbatim by `tmux` and `screen` to the
-*outer* terminal; and a cursor-position query makes the terminal type its
+That is a real surface. OSC 52 writes to, and reads from, the system
+clipboard. DCS sequences are forwarded verbatim by `tmux` and `screen` to the
+*outer* terminal. A cursor-position query makes the terminal type its
 reply onto your shell's standard input. An agent that has read a hostile
 README can do any of those. `hull exec` and `hull logs` do filter, because
 hull stays in the middle of that stream. `brig run` deliberately does not
 stay. `brig logs` does: it reads a log back rather than driving a terminal, so
-it filters control sequences by default, and `--raw` turns that off and hands
+it filters control sequences by default. `--raw` turns that off and hands
 you the bytes with the surface above intact. If this matters for your threat
-model, run brig inside a terminal you are willing to lose, or through
+model, run Brig inside a terminal you are willing to lose, or through
 `hull exec`.
 
-It does not protect the workspace from the agent. Everything in there is
+It does not protect the guest home from the agent. Everything in there is
 writable by design, since that is the work.
 
 It does not stop an agent from spending your money. The `deny` list keeps a
@@ -760,7 +737,7 @@ Everything above narrows what an agent can reach. None of it removes the need
 to trust four things, and it is worth naming them in one place.
 
 **The guest image, and whoever publishes it.** An image under
-`ghcr.io/brig-sh/` is checked against a specific build workflow. An image brig
+`ghcr.io/brig-sh/` is checked against a specific build workflow. An image Brig
 did not publish boots on a warning under the default mode, and
 `BRIG_VERIFY=off` turns the check off for either kind. Either way, the image
 is code that runs with your credentials.
@@ -771,11 +748,11 @@ does not cover. A profile is only as careful as whoever wrote it.
 
 **hull or nerdctl.** The kernel boundary, the shared-network separation on
 macOS, and every device and namespace decision belong to the runtime, not to
-brig. brig reports what it resolved. It neither hardens nor weakens what the
+Brig. Brig reports what it resolved. It neither hardens nor weakens what the
 runtime does.
 
-**brig itself.** brig runs as you, on the host, outside the sandbox. A
+**Brig itself.** Brig runs as you, on the host, outside the sandbox. A
 resolved credential sits in its process memory as plaintext for the run's
-lifetime. brig clears that memory on the way out. That is defence in depth,
+lifetime. Brig clears that memory on the way out. That is defence in depth,
 not a control. A process already holding your credentials in memory is not
 something this page claims to protect against.


### PR DESCRIPTION
## Summary

security.md opens with what the guest can access, cannot access, and what changes when you mount a project or deliver a credential. Every existing guarantee, default, limitation and hedge is kept as classified.

## Changes

- docs/security.md: new opening lists; telemetry detail moved to telemetry.md; argv probe shortened; duplicate ACL and hostmount statements collapsed; cursor has no published image
- docs/policies.md: enforcement rule stated once, pointed at elsewhere; ARP mechanism replaced by a link
- SECURITY.md: names the default Linux shim
- Three quoted messages now match the code byte for byte

## Checklist

- [x] `make all` passes (vet, test, build)
- [x] `script/smoke.sh` passes
- ~~I have added or updated tests covering the change~~ docs only
- ~~I have run `go test ./... -race`~~ docs only
- ~~I have exercised the change against a real runtime~~ docs only
- [x] I have updated the affected docs