### PR TITLE
ci: Add a DCO sign-off check

### DIFF
--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -1,0 +1,96 @@
+name: DCO
+
+# Every commit in a pull request carries a Signed-off-by trailer, which is how
+# a contributor certifies the Developer Certificate of Origin
+# (https://developercertificate.org/).
+# CONTRIBUTING.md has asked for `git commit -s` from the start; nothing checked
+# it, and commits without the trailer have already reached main.
+#
+# Its own workflow rather than a job in ci.yml: a ruleset requires the context
+# "<workflow> / <job>", so the required check keeps its name when ci.yml is
+# reorganised, and this runs on ubuntu in seconds rather than queueing behind
+# the other lanes.
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  sign-off:
+    name: DCO sign-off
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      # Full history: the check walks every commit the pull request adds, not
+      # only its head.
+      - name: Check out the full history
+        uses: actions/checkout@v5
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+
+      # Per commit rather than the range in one call, so a failure names the
+      # commit to fix. Violations become annotations and a run summary, so a
+      # contributor sees which one without opening the log.
+      - name: Check every commit is signed off
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+
+          # Commits written by a tool, not by a person who can certify
+          # anything: the release bot that opens the cask pull request on a
+          # stable tag, and the dependency bots. Requiring the trailer of one
+          # would only mean a human forging it on the bot's behalf.
+          is_exempt() {
+            case "$1" in
+              bot@goreleaser.com | *'[bot]'*) return 0 ;;
+              *) return 1 ;;
+            esac
+          }
+
+          failed=0
+          echo "## DCO sign-off" >> "$GITHUB_STEP_SUMMARY"
+
+          for sha in $(git rev-list --reverse --no-merges \
+                        "${BASE_SHA}..${HEAD_SHA}"); do
+            short=$(git log -1 --format=%h "$sha")
+            subject=$(git log -1 --format=%s "$sha")
+            author=$(git log -1 --format=%ae "$sha")
+
+            if is_exempt "$author"; then
+              echo "- \`${short}\` ${subject} -- exempt (${author})" \
+                >> "$GITHUB_STEP_SUMMARY"
+              continue
+            fi
+
+            # The trailer on its own line, carrying a name and an address,
+            # which is what `git commit -s` writes. A bare "Signed-off-by: me"
+            # certifies nobody.
+            if git log -1 --format=%B "$sha" \
+               | grep -qiE '^[[:space:]]*Signed-off-by:[[:space:]]*[^<]+<[^>]+>[[:space:]]*$'; then
+              echo "- \`${short}\` ${subject}" >> "$GITHUB_STEP_SUMMARY"
+              continue
+            fi
+
+            failed=1
+            echo "::error::${short} ${subject}: no Signed-off-by trailer"
+            echo "- \`${short}\` ${subject} **MISSING Signed-off-by**" \
+              >> "$GITHUB_STEP_SUMMARY"
+          done
+
+          if [ "$failed" = 1 ]; then
+            {
+              echo
+              echo "Sign off the commits and force-push:"
+              echo
+              echo "    git rebase --signoff ${BASE_SHA}"
+              echo "    git push --force-with-lease"
+              echo
+              echo "\`git commit -s\` does it for new commits."
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 1
+          fi


### PR DESCRIPTION
## Summary

CONTRIBUTING.md has asked for `git commit -s` from the start and nothing
enforced it. Commits without the trailer have already reached `main` here, and
eight of them landed in a single hull pull request, where every neighbouring
commit on `main` carries one.

This adds a workflow that walks the commits a pull request adds and fails on
any that lacks a `Signed-off-by` trailer, naming each one as an annotation and
in the run summary, with the `git rebase --signoff <base>` line that fixes it.

Presence is all it asks. hvi-vmm has enforced the same rule through commitlint
for a while, and carries nine commits whose sign-off address differs from the
author's -- so checking the two against each other would reject work that is
already the house style.

Commits written by a tool are exempt. GoReleaser opens the cask pull request
on every stable tag and cannot certify anything; asking it for the trailer
would only mean a human forging one on its behalf.

It is its own workflow rather than a job in `ci.yml`, because a ruleset
requires the context `<workflow> / <job>`: keeping it separate means the
required check keeps its name when `ci.yml` is reorganised, and it runs on
ubuntu in seconds rather than queueing behind the other lanes.

Verified before opening: `actionlint` and `shellcheck` are clean, and the
script was run against real history -- it fails the eight unsigned commits in
hull, passes the signed ones beside them, exempts a GoReleaser-authored and a
dependabot-authored commit, fails an unsigned human commit in the same range,
and passes an empty range.

**This check cannot block a merge on its own.** This repository's `main`
ruleset has no required status checks, so the workflow is advisory until the
context `DCO sign-off` is added to it -- which can only be done once this is
on `main`. Happy to follow up with that, or leave it to you.

## Related issues

None.

## Changes

- `.github/workflows/dco.yml`: a `pull_request` workflow whose single job
  checks every non-merge commit in the pull request's range for a
  `Signed-off-by` trailer, exempting tool-authored commits.

## Checklist

- ~~`make all` passes (vet, test, build)~~ -- no Go code changed
- ~~`script/smoke.sh` passes~~ -- no Go code changed
- ~~I have added or updated tests covering the change~~ -- the workflow is the
  test; it was exercised against real history as described above
- ~~I have run `go test ./... -race`, if the change touches concurrency,
  subprocesses or the daemon~~
- ~~I have exercised the change against a real runtime (`brig run <agent>`), if
  it touches the run, exec or credential path~~
- [x] I have updated the affected docs (see [docs/README.md](../docs/README.md)
  for the map) -- CONTRIBUTING.md already documents the sign-off requirement;
  this only starts enforcing it
