### PR TITLE
fix(secret): say when a profile has nothing to import

### DIFF
--- a/cmd/brig/secretimport.go
+++ b/cmd/brig/secretimport.go
@@ -92,6 +92,21 @@ func importSecrets(out io.Writer, args []string) error {
 	if err != nil {
 		return err
 	}
+	// Nothing to fill means nothing to read and nothing to store, so say so
+	// and stop before the store is opened: on a host with no keyring, opening
+	// it is what would turn a guaranteed no-op into a failure. A count of zero
+	// reads like an import that found nothing, which is a different thing
+	// from a profile with nothing to find. selectForImport has already made
+	// the named form an error, so this is the unnamed form only.
+	if len(selected) == 0 {
+		if len(p.Secrets) == 0 {
+			fmt.Fprintf(out, "%s declares no secrets, so there is nothing to import\n", p.Name)
+			return nil
+		}
+		fmt.Fprintf(out, "%s declares no secret brig can read from your host\n", p.Name)
+		reportHandCreated(out, p)
+		return nil
+	}
 
 	store, err := openStore()
 	if err != nil {
@@ -124,16 +139,22 @@ func importSecrets(out io.Writer, args []string) error {
 	// failure, or `brig secret import x && brig run x` breaks. Only listed
 	// without [name...], because a named one is an error rather than a note.
 	if len(o.names) == 0 {
-		for _, d := range p.Secrets {
-			if !d.Importable() {
-				fmt.Fprintf(out, "  %s: no source on your host, so it is one you supply: "+
-					"brig secret create %s\n", d.Name, d.Name)
-			}
-		}
+		reportHandCreated(out, p)
 	}
 	reportOtherProfiles(out, p, selected)
 
 	return importFailure(failures, len(selected))
+}
+
+// reportHandCreated lists the secrets no importer covers, each with the
+// command that supplies it.
+func reportHandCreated(out io.Writer, p profile.Profile) {
+	for _, d := range p.Secrets {
+		if !d.Importable() {
+			fmt.Fprintf(out, "  %s: no source on your host, so it is one you supply: "+
+				"brig secret create %s\n", d.Name, d.Name)
+		}
+	}
 }
 
 // importOne fills one secret, in the order the rules require: read, extract,

--- a/cmd/brig/secretimport_test.go
+++ b/cmd/brig/secretimport_test.go
@@ -633,3 +633,85 @@ func TestProfileImportPointsAtTheSecretVerb(t *testing.T) {
 		t.Errorf("the error does not name the verb they meant: %v", err)
 	}
 }
+
+// noSecrets registers a profile that declares no secrets at all, which is
+// the state six of the eight shipped profiles are in.
+func noSecrets(t *testing.T) {
+	t.Helper()
+	t.Setenv("BRIG_PROFILE_DIR", writeProfile(t, `
+name: bare
+image: ghcr.io/brig-sh/bare:latest
+guestHome: /home/bare
+binary: bare
+mem: 1024
+cpus: 1
+`))
+	if err := profile.Load(profile.Dir()); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// A profile with no secrets has nothing this verb can ever do. The unnamed
+// form says so, the way the named form already does, instead of reporting a
+// count of zero that reads like an import that found nothing (#178).
+func TestImportSaysWhenAProfileDeclaresNoSecrets(t *testing.T) {
+	noSecrets(t)
+	newAnnotating(t)
+	useHost(t, nil)
+
+	for _, args := range [][]string{{"bare"}, {"bare", "--dry-run"}} {
+		var out bytes.Buffer
+		if err := importSecrets(&out, args); err != nil {
+			t.Fatalf("%v: a no-op import failed: %v", args, err)
+		}
+		got := out.String()
+		if !strings.Contains(got, "bare declares no secrets, so there is nothing to import") {
+			t.Errorf("%v: the output does not say the profile declares no secrets:\n%s", args, got)
+		}
+		if strings.Contains(got, "importing 0") || strings.Contains(got, "reading your host") {
+			t.Errorf("%v: the output still reports a count or a read:\n%s", args, got)
+		}
+	}
+}
+
+// Nothing to import means nothing to store, so the store is not opened. On a
+// host with no keyring, opening it is what turns a guaranteed no-op into a
+// failure (#178).
+func TestImportWithNothingToDoDoesNotOpenTheStore(t *testing.T) {
+	old := openStore
+	openStore = func() (secret.Store, error) { return nil, secret.ErrUnsupported }
+	t.Cleanup(func() { openStore = old })
+	useHost(t, nil)
+
+	noSecrets(t)
+	if err := importSecrets(&bytes.Buffer{}, []string{"bare"}); err != nil {
+		t.Errorf("a profile with no secrets opened the store: %v", err)
+	}
+
+	// Secrets declared, none an importer covers: the notes still print, and
+	// the store is still not needed.
+	t.Setenv("BRIG_PROFILE_DIR", writeProfile(t, `
+name: handmade
+image: ghcr.io/brig-sh/handmade:latest
+guestHome: /home/handmade
+binary: handmade
+mem: 1024
+cpus: 1
+secrets:
+  - name: handmade-token
+    required: false
+`))
+	if err := profile.Load(profile.Dir()); err != nil {
+		t.Fatal(err)
+	}
+	var out bytes.Buffer
+	if err := importSecrets(&out, []string{"handmade"}); err != nil {
+		t.Errorf("a profile with only hand-created secrets opened the store: %v", err)
+	}
+	if !strings.Contains(out.String(), "brig secret create handmade-token") {
+		t.Errorf("the hand-created secret was not reported:\n%s", out.String())
+	}
+	if strings.Contains(out.String(), "importing 0") {
+		t.Errorf("the output still reports a count of zero:\n%s", out.String())
+	}
+}

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -73,10 +73,9 @@ declares a source for `gh-token`. That one takes a value you supply by hand
 
 The other six shipped profiles declare no `secrets:` at all: `codex`,
 `cursor`, `gemini`, `grok`, `opencode`, `ubuntu`. There is nothing on your
-host for `import` to read. On a host with a working secret store, the
-command still succeeds: it prints `<profile>: importing 0 secrets` and exits
-0. On a host with no keyring it fails instead, even though there is nothing
-to import.
+host for `import` to read. The command prints
+`<profile> declares no secrets, so there is nothing to import` and exits 0,
+on any host, without opening the secret store.
 
 **If a long `claude-code` session stops authenticating.** Brig re-delivers the
 stored `claude-credentials` document on every command that reaches the


### PR DESCRIPTION
## Summary

`brig secret import codex` printed `codex: importing 0 secrets` and exited 0. Six of eight shipped profiles declare no secrets, so this was the normal output for most agents. It also opened the secret store before checking whether there was anything to store, so on a host with no keyring the no-op failed with `no secret store on this platform`.

Now the unnamed form returns before the store opens when nothing was selected. A profile with no secrets prints the sentence the named form already used. A profile whose secrets all lack a source keeps its per-secret notes and drops the count.

## Related issues

Fixes #178

## Changes

- `cmd/brig/secretimport.go`: early return when nothing is selected; hand-created notes moved into `reportHandCreated`
- `cmd/brig/secretimport_test.go`: two tests, one for the message on both forms including `--dry-run`, one that the store is not opened
- `docs/authentication.md`: quotes the new message, drops the no-keyring failure

## Checklist

- [x] `make all` passes (vet, test, build)
- [x] `script/smoke.sh` passes
- [x] I have added or updated tests covering the change
- ~~I have run `go test ./... -race`~~ no concurrency, subprocess or daemon change
- ~~I have exercised the change against a real runtime~~ import path only, no boot
- [x] I have updated the affected docs

## Credentials and the sandbox boundary

Touches the import path in `cmd/brig` only. No change to what a run reads or forwards. The store is opened later than before, never for a different set of names.